### PR TITLE
fix: address v3.1.0 PR feedback + add research docs

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -162,14 +162,16 @@ fi
 SESSION_END_MARKER="$PLANNING_DIR/.session-end-marker.json"
 STALE_SESSION_MSG=""
 if [ -f "$SESSION_END_MARKER" ]; then
-  STALE_SESSION_MSG=$(HOOK_MARKER="$SESSION_END_MARKER" bun -e "
-    try {
-      const marker = JSON.parse(await Bun.file(process.env.HOOK_MARKER).text());
-      if (marker.cleanup_pending) {
-        process.stdout.write('Stale session detected (ended: ' + (marker.ended_at || 'unknown') + '). MuninnDB cleanup will run during cognitive pre-flight.');
-      }
-    } catch { /* no marker or parse error */ }
-  " 2>/dev/null || echo "")
+  if command -v bun &>/dev/null; then
+    STALE_SESSION_MSG=$(HOOK_MARKER="$SESSION_END_MARKER" bun -e "
+      try {
+        const marker = JSON.parse(await Bun.file(process.env.HOOK_MARKER).text());
+        if (marker.cleanup_pending) {
+          process.stdout.write('Stale session detected (ended: ' + (marker.ended_at || 'unknown') + '). MuninnDB cleanup will run during cognitive pre-flight.');
+        }
+      } catch { /* no marker or parse error */ }
+    " 2>/dev/null || echo "")
+  fi
   # Remove marker after reading (cleanup will be handled by lu-cognition)
   rm -f "$SESSION_END_MARKER"
 fi
@@ -347,20 +349,23 @@ fi
 
 # Step 9: Output summary if anything was created
 if [ -n "$CREATED" ]; then
-  HOOK_CREATED="$CREATED" HOOK_NOTES_MSG="$NOTES_MSG" bun -e "
+  HOOK_CREATED="$CREATED" HOOK_NOTES_MSG="$NOTES_MSG" HOOK_STALE_MSG="$STALE_SESSION_MSG" bun -e "
     const created = process.env.HOOK_CREATED.trim();
     const notesSuffix = process.env.HOOK_NOTES_MSG || '';
+    const staleSuffix = process.env.HOOK_STALE_MSG ? ' ' + process.env.HOOK_STALE_MSG : '';
     const files = created.split(' ').filter(Boolean);
-    const msg = '[Luca] Initialized .planning/ directory. Created: ' + files.join(', ') + notesSuffix;
+    const msg = '[Luca] Initialized .planning/ directory. Created: ' + files.join(', ') + notesSuffix + staleSuffix;
     const isClaude = !!process.env.CLAUDE_PROJECT_DIR;
     const output = isClaude
       ? { systemMessage: msg }
       : { followup_message: msg };
     process.stdout.write(JSON.stringify(output));
   "
-elif [ -n "$NOTES_MSG" ]; then
-  HOOK_NOTES_MSG="$NOTES_MSG" bun -e "
-    const msg = '[Luca]' + process.env.HOOK_NOTES_MSG;
+elif [ -n "$NOTES_MSG" ] || [ -n "$STALE_SESSION_MSG" ]; then
+  HOOK_NOTES_MSG="$NOTES_MSG" HOOK_STALE_MSG="$STALE_SESSION_MSG" bun -e "
+    const notesSuffix = process.env.HOOK_NOTES_MSG || '';
+    const staleSuffix = process.env.HOOK_STALE_MSG ? ' ' + process.env.HOOK_STALE_MSG : '';
+    const msg = '[Luca]' + notesSuffix + staleSuffix;
     const isClaude = !!process.env.CLAUDE_PROJECT_DIR;
     const output = isClaude
       ? { systemMessage: msg }

--- a/.cursor/hooks/session-start.sh
+++ b/.cursor/hooks/session-start.sh
@@ -162,14 +162,16 @@ fi
 SESSION_END_MARKER="$PLANNING_DIR/.session-end-marker.json"
 STALE_SESSION_MSG=""
 if [ -f "$SESSION_END_MARKER" ]; then
-  STALE_SESSION_MSG=$(HOOK_MARKER="$SESSION_END_MARKER" bun -e "
-    try {
-      const marker = JSON.parse(await Bun.file(process.env.HOOK_MARKER).text());
-      if (marker.cleanup_pending) {
-        process.stdout.write('Stale session detected (ended: ' + (marker.ended_at || 'unknown') + '). MuninnDB cleanup will run during cognitive pre-flight.');
-      }
-    } catch { /* no marker or parse error */ }
-  " 2>/dev/null || echo "")
+  if command -v bun &>/dev/null; then
+    STALE_SESSION_MSG=$(HOOK_MARKER="$SESSION_END_MARKER" bun -e "
+      try {
+        const marker = JSON.parse(await Bun.file(process.env.HOOK_MARKER).text());
+        if (marker.cleanup_pending) {
+          process.stdout.write('Stale session detected (ended: ' + (marker.ended_at || 'unknown') + '). MuninnDB cleanup will run during cognitive pre-flight.');
+        }
+      } catch { /* no marker or parse error */ }
+    " 2>/dev/null || echo "")
+  fi
   # Remove marker after reading (cleanup will be handled by lu-cognition)
   rm -f "$SESSION_END_MARKER"
 fi
@@ -347,20 +349,23 @@ fi
 
 # Step 9: Output summary if anything was created
 if [ -n "$CREATED" ]; then
-  HOOK_CREATED="$CREATED" HOOK_NOTES_MSG="$NOTES_MSG" bun -e "
+  HOOK_CREATED="$CREATED" HOOK_NOTES_MSG="$NOTES_MSG" HOOK_STALE_MSG="$STALE_SESSION_MSG" bun -e "
     const created = process.env.HOOK_CREATED.trim();
     const notesSuffix = process.env.HOOK_NOTES_MSG || '';
+    const staleSuffix = process.env.HOOK_STALE_MSG ? ' ' + process.env.HOOK_STALE_MSG : '';
     const files = created.split(' ').filter(Boolean);
-    const msg = '[Luca] Initialized .planning/ directory. Created: ' + files.join(', ') + notesSuffix;
+    const msg = '[Luca] Initialized .planning/ directory. Created: ' + files.join(', ') + notesSuffix + staleSuffix;
     const isClaude = !!process.env.CLAUDE_PROJECT_DIR;
     const output = isClaude
       ? { systemMessage: msg }
       : { followup_message: msg };
     process.stdout.write(JSON.stringify(output));
   "
-elif [ -n "$NOTES_MSG" ]; then
-  HOOK_NOTES_MSG="$NOTES_MSG" bun -e "
-    const msg = '[Luca]' + process.env.HOOK_NOTES_MSG;
+elif [ -n "$NOTES_MSG" ] || [ -n "$STALE_SESSION_MSG" ]; then
+  HOOK_NOTES_MSG="$NOTES_MSG" HOOK_STALE_MSG="$STALE_SESSION_MSG" bun -e "
+    const notesSuffix = process.env.HOOK_NOTES_MSG || '';
+    const staleSuffix = process.env.HOOK_STALE_MSG ? ' ' + process.env.HOOK_STALE_MSG : '';
+    const msg = '[Luca]' + notesSuffix + staleSuffix;
     const isClaude = !!process.env.CLAUDE_PROJECT_DIR;
     const output = isClaude
       ? { systemMessage: msg }

--- a/.planning/.session-end-marker.json
+++ b/.planning/.session-end-marker.json
@@ -1,0 +1,6 @@
+{
+  "session_id": "fc759ad3-6102-4681-9b0c-738bbed69a23",
+  "ended_at": "2026-03-09T01:44:32.033Z",
+  "reason": "prompt_input_exit",
+  "cleanup_pending": true
+}

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -43,4 +43,4 @@ _State updated: 2026-03-09 — post-milestone reset_
 
 ---
 
-_State generated from machine snapshot at 2026-03-09T01:40:02.168Z_
+_State generated from machine snapshot at 2026-03-09T01:40:11.351Z_

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -43,4 +43,4 @@ _State updated: 2026-03-09 — post-milestone reset_
 
 ---
 
-_State generated from machine snapshot at 2026-03-09T01:34:31.110Z_
+_State generated from machine snapshot at 2026-03-09T01:40:02.168Z_

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -43,4 +43,4 @@ _State updated: 2026-03-09 — post-milestone reset_
 
 ---
 
-_State generated from machine snapshot at 2026-03-09T01:40:11.351Z_
+_State generated from machine snapshot at 2026-03-09T01:48:58.438Z_

--- a/docs/brainstorm/1.workflow-redesign.md
+++ b/docs/brainstorm/1.workflow-redesign.md
@@ -1,0 +1,542 @@
+# Luca Workflow Redesign: Brainstorm
+
+> Synthesizing research from development methodologies, agentic engineering patterns,
+> and real-world team experience into a next-generation workflow for solo developer + AI agents.
+
+---
+
+## Part 1: Research Foundations
+
+### 1.1 What We Learned From Development Methodologies
+
+| Methodology    | Key Insight for Luca                                                           | What to Borrow                                                           |
+| -------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| **Scrum**      | Sprint cadence creates predictable delivery rhythm                             | Retrospective habit, grooming discipline, definition of done             |
+| **Kanban**     | WIP limits prevent cognitive overload; flow > batches                          | WIP constraints on parallel agents, cycle time tracking                  |
+| **Shape Up**   | Appetite-based scoping: "how much is this worth?" not "how long will it take?" | Fixed time / variable scope, cooldown periods, shaping before building   |
+| **XP**         | Tightest feedback loops = highest quality                                      | AI-as-pair-programmer, continuous integration, simplest thing that works |
+| **DORA**       | Speed and stability are complementary, not opposing                            | Track deployment frequency, lead time, change failure rate, MTTR         |
+| **Pre-mortem** | Prospective hindsight increases risk identification by 30%                     | Structured failure imagination before execution                          |
+
+### 1.2 What We Learned From Agentic Engineering Research
+
+From our existing research docs (`docs/research/`):
+
+**Anti-Slop Framework (doc 1):**
+
+- The Recovery Loop: diagnose → reset → fix → rerun (never manually patch slop)
+- "Tokens as fine-tuning": code in context window biases agent output quality
+- "One agent, one task, one prompt" — task granularity correlates with success rate
+- Zero-ambiguity specs: leave nothing to the agent's interpretation
+- The Pit of Success: surround agents with patterns you want them to mirror
+
+**Agent Design Patterns (doc 2):**
+
+- Sequential vs. Parallel vs. Single agent patterns with clear trade-offs
+- State Management via shared session state (scratchpad pattern)
+- Aggregation & Synthesis: a final agent unifies parallel outputs
+- Control vs. Flexibility as the fundamental design tension
+
+**Domain-Specific Memory (doc 3):**
+
+- Beyond static RAG: graph + vector hybrid storage
+- Memory Isolation Layers ("Note Sets") prevent context pollution
+- Agentic Feedback Loops: agents refine their own memory over time
+- Temporal/Time-Aware Retrieval for understanding sequences of events
+
+### 1.3 What 2025-2026 Research Tells Us
+
+**The Verification Bottleneck:**
+
+- AI boosts individual output (+21% tasks, +98% PRs merged) but org delivery stays flat (DORA 2025)
+- Root cause: review volume doubled, PRs are 154% larger, review time is 91% longer
+- "Verification Debt" (CACM Jan 2026): the gap between what you released and what you've proven safe
+- 96% of developers don't fully trust AI-generated code; only 48% always verify before committing
+- Key insight: **organizations winning in 2026 have the best verification layers, not the best generators**
+
+**The AI Productivity Paradox:**
+
+- METR study: AI made experienced open-source developers 19% _slower_
+- Developers _perceived_ a 20% speedup — a 39-percentage-point gap between perception and reality
+- AI behaves "like an inexperienced team member struggling with backwards compatibility"
+- Context windows force manual segmentation; 9% of time goes to reviewing AI output, 4% waiting
+
+**Cognitive Sustainability:**
+
+- AI removes natural speed governors (boilerplate that provided mental breaks)
+- "Cognitive density" increases: less easy work, more hard debugging/review
+- 67% of developers spend more time debugging AI-generated code
+- AI coding assistance reduces developer skill mastery by 17% (Anthropic study)
+- HBR (Feb 2026): "AI doesn't reduce work — it intensifies it"
+
+**The Amplification Effect:**
+
+- "AI doesn't fix a team; it amplifies what's already there"
+- Strong conventions + AI = accelerated quality
+- Weak conventions + AI = accelerated chaos
+- **Luca's process rigor IS its competitive advantage** — the framework itself is what makes AI useful
+
+---
+
+## Part 2: Current Luca Workflow Analysis
+
+### 2.1 Current Pipeline (10 Steps)
+
+```
+1. PARSE & ROUTE (/lu entry point)
+2. COGNITIVE PRE-FLIGHT (MuninnDB recall)
+3. COMPLEXITY CLASSIFICATION (lu-router)
+4. ROUTE TO HANDLER
+5. EXECUTION (direct or planned)
+6. VERIFICATION HARNESS (test, typecheck, lint, build)
+7. AGENT VERIFICATION (lu-verifier + parallel reviewers)
+8. LEARNING CAPTURE (lu-learner → MuninnDB engrams)
+9. COMMIT
+10. DONE
+```
+
+### 2.2 Gaps Identified
+
+Mapped against the user's high-performing team workflow and research findings:
+
+| Gap                               | Description                                                                      | Impact                                                             | Source                                       |
+| --------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------- |
+| **No idea validation**            | Luca jumps from request to routing without validating if the idea is well-formed | Poorly scoped work enters the pipeline                             | User's team: "initial review (3 cycles)"     |
+| **Single-pass discussion**        | `phase-discuss` does one round of gray area exploration                          | Misses blind spots that iterative review catches                   | User's team: 3 review cycles before planning |
+| **No pre-mortem**                 | `lu-cognition` flags risks from memory but doesn't imagine novel failures        | Misses 30% of risks that prospective hindsight would catch         | Klein (2007), Brookings research             |
+| **No appetite constraint**        | Plans have no time/token budget ceiling                                          | Agents expand scope indefinitely; convergence failures on COMPLEX+ | Shape Up, Anthropic context engineering      |
+| **No process retrospective**      | `lu-learner` captures code knowledge but not workflow improvement                | Same process mistakes repeat across sessions                       | Scrum retro, DORA continuous improvement     |
+| **No user feedback loop**         | Nothing happens after shipping                                                   | Can't learn if features are actually useful                        | User's team: 1-5 star rating post-release    |
+| **No cooldown**                   | Milestones flow directly into next milestone                                     | Quality degradation curve; cognitive density burnout               | Shape Up, HBR (2026)                         |
+| **Verification only at boundary** | Harness runs after phase completes, not during                                   | Late error detection for COMPLEX+ tasks                            | XP continuous integration, shift-left        |
+| **No WIP enforcement**            | Autopilot can theoretically overload parallel work                               | Context explosion, token waste                                     | Kanban WIP limits                            |
+
+### 2.3 Strengths to Preserve
+
+These are working well and should not be disrupted:
+
+- **Mandatory verification at all complexity levels** — this is rare and valuable
+- **Complexity-gated model routing** — efficient resource allocation
+- **Wave-based parallelization** — maximizes throughput for independent tasks
+- **MuninnDB memory system** — enables genuine learning across sessions
+- **Dual-write guarantee** — reliable state management
+- **Recovery loop philosophy** (from anti-slop research) — never manually patch bad output
+
+---
+
+## Part 3: Proposed Enhanced Workflow
+
+### 3.1 Philosophy: The Verification-Centered Development Cycle
+
+The central insight from all research is: **the bottleneck has moved from generation to verification.** Luca's workflow should be optimized around verification quality, not generation speed.
+
+Core principles:
+
+1. **Verify early, verify often** — shift verification left into planning, not just post-execution
+2. **Fixed appetite, variable scope** — declare investment ceiling before planning
+3. **Learn from process, not just code** — retrospectives target workflow, not just knowledge
+4. **Sustainable pace through cooldown** — explicit recovery periods prevent cognitive decay
+5. **Close the outer loop** — user feedback flows back into planning
+
+### 3.2 The Enhanced Pipeline
+
+```
+PHASE 0: INTAKE & APPETITE
+  ├─ Parse request (existing)
+  ├─ Cognitive pre-flight (existing, enhanced with user feedback recall)
+  ├─ Complexity classification (existing)
+  └─ Appetite declaration (NEW: "this is worth N context-hours")
+
+PHASE 1: MULTI-LENS REVIEW (NEW, COMPLEX+ only)
+  ├─ Architecture lens: "What structural risks exist?"
+  ├─ Performance lens: "What could be slow or expensive?"
+  ├─ UX/Usability lens: "What will confuse users?"
+  ├─ Data lens: "What edge cases exist?"
+  └─ (Parallel agents, each produces risk flags + constraints)
+
+PHASE 2: PRE-MORTEM (NEW, COMPLEX+ only)
+  ├─ "This shipped and it's broken. Why?"
+  ├─ Double-barreled variant: also "We didn't ship this. Why is that bad?"
+  ├─ 5 failure scenarios generated
+  ├─ Each scenario gets a mitigation strategy
+  └─ Mitigations become plan constraints
+
+PHASE 3: PLANNING (existing, enhanced)
+  ├─ PLAN.md creation with appetite constraint (scope cut to fit)
+  ├─ Mitigations from pre-mortem baked into tasks
+  ├─ Risk flags from multi-lens review as verification criteria
+  └─ Plan verification (existing, iteration count complexity-gated)
+
+PHASE 4: EXECUTION (existing, enhanced)
+  ├─ Wave-based parallel execution (existing)
+  ├─ Mid-wave checkpoint (NEW, COMPLEX+ only)
+  ├─ WIP limit enforcement (NEW: max tasks per wave)
+  └─ Appetite guard (NEW: halt if exceeding declared budget)
+
+PHASE 5: VERIFICATION (existing, enhanced)
+  ├─ Harness: test + typecheck + lint + build (existing)
+  ├─ lu-verifier: EXISTS / SUBSTANTIVE / WIRED (existing)
+  ├─ Code review: 5 parallel reviewers (existing)
+  └─ Pre-mortem validation (NEW): "Did we mitigate the failure scenarios?"
+
+PHASE 6: RETROSPECTIVE (enhanced)
+  ├─ lu-learner: code knowledge capture (existing)
+  ├─ Process reflection (NEW): "What about our workflow should change?"
+  │   ├─ Was the appetite accurate?
+  │   ├─ Did multi-lens review catch real issues?
+  │   ├─ Did pre-mortem mitigations matter?
+  │   ├─ Which agents produced useful output vs. rework?
+  │   └─ Store as process:* engrams in MuninnDB
+  └─ DORA metrics logging (NEW): lead time, change failure rate
+
+PHASE 7: USER FEEDBACK (NEW, post-shipping)
+  ├─ Prompt for 1-5 star rating + optional details
+  ├─ Store as feedback:* engrams in MuninnDB
+  └─ Feed into future cognitive pre-flights
+
+COOLDOWN (NEW, milestone boundary)
+  ├─ No new features
+  ├─ Bug fixes, polish, tech debt
+  ├─ Exploration / experimentation
+  └─ Duration: 1-2 sessions per milestone
+```
+
+### 3.3 Detailed Design: New Components
+
+#### A. Appetite Declaration
+
+**What:** Before planning begins, the developer declares how much investment a piece of work deserves. This is a ceiling, not an estimate.
+
+**Why:** Shape Up's insight that appetite inverts the estimation problem. Instead of "how long will this take?" → "how much is this worth?" Prevents AI agents from expanding scope indefinitely (a documented failure mode from Anthropic's context engineering research).
+
+**Mechanism:**
+
+- Expressed in context-hours (a unit representing approximate context window sessions)
+- Stored in STATE.md as `Appetite: 2 context-hours`
+- lu-planner shapes scope to fit within appetite
+- If plan exceeds appetite, scope is cut (variable scope, not variable time)
+- lu-executor tracks context usage against appetite; warns at 80%, halts at 100%
+
+**Appetite Levels:**
+
+| Appetite         | Meaning                                 | Typical Complexity | Example                                       |
+| ---------------- | --------------------------------------- | ------------------ | --------------------------------------------- |
+| Micro (< 30 min) | Quick fix, not worth extensive planning | TRIVIAL            | Fix a typo, update a config value             |
+| Small (1-2 hrs)  | Worth a focused session                 | SIMPLE-MODERATE    | Add a new utility function, refactor a module |
+| Medium (3-5 hrs) | Worth a half-day of deep work           | MODERATE-COMPLEX   | New feature with multiple files               |
+| Large (1-2 days) | Worth significant investment            | COMPLEX            | Cross-cutting feature, architecture change    |
+| XL (3-5 days)    | Major initiative                        | CRITICAL           | New subsystem, major refactor                 |
+
+**Integration with complexity gating:**
+
+- Appetite is declared by the developer (subjective: "how much is this worth?")
+- Complexity is assessed by lu-router (objective: "how complex is this technically?")
+- If appetite < complexity's natural scope, scope is cut
+- If appetite > complexity's natural scope, that's fine — leftover budget isn't wasted
+
+#### B. Multi-Lens Review
+
+**What:** Before planning, spawn parallel agents to review the task from different perspectives. Each lens produces risk flags and architectural constraints that feed into the plan.
+
+**Why:** The user's high-performing team did 3 review cycles with different lenses (UX, architecture, data, performance) before writing code. This is "shift-left" for design quality — catching issues in the design phase costs 10-100x less than catching them in code review.
+
+**Mechanism:**
+
+- Only runs for COMPLEX+ tasks (TRIVIAL/SIMPLE/MODERATE skip this)
+- 4 parallel lens agents, each with a focused prompt:
+  1. **Architecture Lens** — Structural risks, module boundary violations, dependency concerns
+  2. **Performance Lens** — Potential bottlenecks, bundle impact, O(n) concerns
+  3. **UX/Usability Lens** — User confusion points, accessibility gaps, interaction patterns
+  4. **Data Lens** — Edge cases, validation gaps, state management concerns
+- Each agent outputs a structured report: `{ risks: [], constraints: [], recommendations: [] }`
+- Aggregated into a `REVIEW.md` artifact
+- Constraints become mandatory plan elements
+- Risk flags become verification criteria
+
+**Model routing:** DEEP_ANALYSIS preset (fast → balanced → capable as complexity increases)
+
+**Relationship to existing review:**
+
+- Multi-lens review happens BEFORE planning (preventive)
+- Code review happens AFTER execution (detective)
+- They're complementary: multi-lens catches design issues, code review catches implementation issues
+
+#### C. Pre-Mortem
+
+**What:** After multi-lens review and before planning, a structured exercise in prospective hindsight. "This shipped and it's broken. Why?"
+
+**Why:** Gary Klein's research shows prospective hindsight increases risk identification accuracy by 30%. The double-barreled variant (Klein 2025) also asks "we didn't ship this — why is that bad?" to prevent over-cautious planning. Microsoft's 2025 taxonomy of AI agent failure modes provides a structured framework for AI-specific failures.
+
+**Mechanism:**
+
+- Only runs for COMPLEX+ tasks
+- Agent generates 5 failure scenarios, each with:
+  - **Failure description**: What went wrong?
+  - **Root cause**: Why did it happen?
+  - **Detection**: How would we notice?
+  - **Mitigation**: How do we prevent it?
+  - **Verification criteria**: How do we prove it's mitigated?
+- Failure categories cover AI-specific modes:
+  - Hallucination (agent generates plausible but incorrect code)
+  - Context drift (agent loses original intent mid-execution)
+  - Architectural drift (changes violate module boundaries or conventions)
+  - Slop accumulation (code works but is unmaintainable)
+  - Integration failure (changes break existing functionality)
+- Double-barreled: also generates "cost of inaction" scenarios
+- Mitigations become plan constraints; verification criteria feed harness
+
+**Model routing:** DEEP_ANALYSIS preset
+
+**Artifact:** `PREMORTEM.md` stored in phase directory
+
+#### D. Process Retrospective
+
+**What:** After learning capture, reflect on the workflow itself — not just what was learned about code, but what was learned about process.
+
+**Why:** Luca's `lu-learner` captures patterns/decisions/pitfalls about the _codebase_. But it never asks: "Was our process right? Should we change how we work?" This is the core of Scrum's retrospective — the inspect-and-adapt loop applied to the process itself.
+
+**Mechanism:**
+
+- Runs after lu-learner (code learning) at every complexity level
+- Lightweight for TRIVIAL/SIMPLE (single question: "anything to improve?")
+- Structured for MODERATE+ with these prompts:
+  1. Was the appetite accurate? (Over/under/right-sized?)
+  2. Did multi-lens review catch real issues? (Valuable or noise?)
+  3. Did pre-mortem mitigations matter? (Which ones were actually relevant?)
+  4. Which agents produced useful output vs. rework? (Agent performance tracking)
+  5. Where did the developer spend review time? (Verification bottleneck tracking)
+- Stores as `process:*` engrams in MuninnDB
+- Fed into future cognitive pre-flights: "Last time we did X, the process was slow because Y"
+
+**DORA metrics captured:**
+
+- Lead time (time from /lu invocation to commit)
+- Change failure rate (did verification catch issues? did post-ship bugs appear?)
+- Context efficiency (tokens spent per useful outcome)
+- Rework ratio (how much agent output required significant rework?)
+
+#### E. User Feedback Loop
+
+**What:** After shipping, prompt for a 1-5 star rating with optional details. Store in MuninnDB for future cognitive pre-flights.
+
+**Why:** The user's team systematically collected user feedback on recently released features. This closes the outermost feedback loop — did the thing we built actually help? Without this, we're optimizing generation and verification but never validating product decisions.
+
+**Mechanism:**
+
+- Triggered after PR merge or manual `/feedback` command
+- Simple prompt: "How well is [feature] working? (1-5) + optional details"
+- Stored as `feedback:*` engrams in MuninnDB with metadata:
+  - Feature/phase reference
+  - Rating (1-5)
+  - Details (optional freeform)
+  - Timestamp
+- Future cognitive pre-flights recall relevant feedback:
+  - "Last feature in this area got 2/5 — users found X confusing"
+  - "Features in this domain consistently rate 4+, patterns are solid"
+
+**Integration with planning:**
+
+- Low-rated features get flagged during cognitive pre-flight for similar work
+- High-rated features reinforce the patterns used to build them
+
+#### F. Cooldown Periods
+
+**What:** After a milestone completes, a deliberate pause for polish, bugs, exploration, and recovery. No new features.
+
+**Why:** Shape Up's cooldown prevents burnout. HBR's 2026 finding that "AI intensifies work" makes this more critical — AI removes natural speed governors. The cognitive density increase (less easy work, more hard review) requires explicit recovery periods.
+
+**Mechanism:**
+
+- Triggered at milestone boundary (after milestone-complete)
+- Duration: 1-2 sessions (adjustable)
+- Activities allowed: bug fixes, tech debt, exploration, documentation
+- Activities prohibited: new feature work, new phases
+- State machine transition: `done` → `cooldown` → `idle`
+- Optional: run repo-audit during cooldown to identify accumulated drift
+
+**Relationship to existing workflow:**
+
+- Currently, milestones flow directly into next milestone
+- Cooldown inserts a buffer that prevents quality degradation
+- Also serves as a natural point for the developer to step back and think strategically
+
+---
+
+## Part 4: Complexity Gating for New Steps
+
+### 4.1 What Runs When
+
+| Step                 | TRIVIAL         | SIMPLE                 | MODERATE                           | COMPLEX                          | CRITICAL                                          |
+| -------------------- | --------------- | ---------------------- | ---------------------------------- | -------------------------------- | ------------------------------------------------- |
+| Appetite Declaration | Auto (Micro)    | Auto (Small)           | Developer declares                 | Developer declares               | Developer declares                                |
+| Multi-Lens Review    | Skip            | Skip                   | Skip                               | Run (4 lenses)                   | Run (4 lenses)                                    |
+| Pre-Mortem           | Skip            | Skip                   | Skip                               | Run (5 scenarios)                | Run (5 scenarios + double-barreled)               |
+| Planning             | Skip            | Lightweight            | Full                               | Full + appetite constraint       | Full + appetite + 3 plan verification iterations  |
+| Execution            | Direct          | Direct                 | Wave-based                         | Wave-based + mid-wave checkpoint | Wave-based + mid-wave checkpoint + WIP limit      |
+| Verification         | Harness only    | Harness + quick verify | Harness + standard verify + review | Harness + full verify + review   | Harness + full verify + review + human            |
+| Process Retro        | Single question | Single question        | Structured (5 questions)           | Structured + DORA metrics        | Structured + DORA metrics + full session analysis |
+| User Feedback        | Optional prompt | Optional prompt        | Prompt after PR                    | Prompt after PR                  | Prompt after PR + scheduled follow-up             |
+| Cooldown             | N/A             | N/A                    | N/A                                | Recommended at milestone         | Required at milestone                             |
+
+### 4.2 Model Routing for New Steps
+
+| New Step          | Routing Preset | TRIVIAL | SIMPLE | MODERATE | COMPLEX  | CRITICAL |
+| ----------------- | -------------- | ------- | ------ | -------- | -------- | -------- |
+| Multi-Lens Agents | DEEP_ANALYSIS  | --      | --     | --       | balanced | capable  |
+| Pre-Mortem Agent  | DEEP_ANALYSIS  | --      | --     | --       | balanced | capable  |
+| Process Retro     | FAST_PROMOTED  | fast    | fast   | fast     | fast     | balanced |
+| Appetite Guard    | ALWAYS_FAST    | fast    | fast   | fast     | fast     | fast     |
+
+---
+
+## Part 5: Integration With Existing Research
+
+### 5.1 Anti-Slop Framework Alignment
+
+| Anti-Slop Principle                            | Current Luca                                       | Enhanced Workflow                                                            |
+| ---------------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Recovery Loop (diagnose → reset → fix → rerun) | Harness fix iterations (up to 3)                   | Preserved + pre-mortem prevents needing recovery                             |
+| Quality Gates (100% pass rate)                 | Pre-commit gate + harness                          | Preserved + multi-lens review as design-phase gate                           |
+| Zero-Ambiguity Specs                           | PLAN.md with tasks + verification criteria         | Enhanced: plan includes pre-mortem mitigations + appetite constraint         |
+| Pit of Success                                 | MuninnDB recall biases agents toward good patterns | Enhanced: process retro captures _workflow_ patterns, not just code patterns |
+| One Agent, One Task, One Prompt                | Wave-based task decomposition                      | Preserved + WIP limit enforcement                                            |
+
+### 5.2 Agent Design Patterns Alignment
+
+| Pattern                                 | Current Luca                                       | Enhanced Workflow                                               |
+| --------------------------------------- | -------------------------------------------------- | --------------------------------------------------------------- |
+| Parallel Agent Pattern                  | Wave execution, 5 parallel reviewers               | Extended: 4 parallel multi-lens reviewers (pre-planning)        |
+| Sequential Agent Pattern                | Phase pipeline (discuss → plan → execute → verify) | Extended: review → pre-mortem → plan → execute → verify → retro |
+| State Management (Shared Session State) | MuninnDB session context                           | Extended: appetite tracking + DORA metrics in session state     |
+| Aggregation & Synthesis                 | lu-verifier aggregates reviewer findings           | Extended: multi-lens aggregator produces REVIEW.md              |
+| Supervisor/Coordinator Pattern          | lu (router) orchestrates sub-skills                | Preserved                                                       |
+
+### 5.3 Domain-Specific Memory Alignment
+
+| Memory Concept                | Current Luca                                    | Enhanced Workflow                                                 |
+| ----------------------------- | ----------------------------------------------- | ----------------------------------------------------------------- |
+| Memory Isolation (Note Sets)  | Vault-based MuninnDB                            | Extended: new vault categories (process:_, feedback:_, metric:\*) |
+| Agentic Feedback Loops        | lu-learner captures patterns/decisions/pitfalls | Extended: process retro captures workflow learnings               |
+| Temporal/Time-Aware Retrieval | Session engrams with timestamps                 | Extended: DORA metrics as time-series for trend analysis          |
+| Dynamic Knowledge Refinement  | Engrams evolve via lu-learner                   | Extended: process engrams evolve via process retro                |
+
+---
+
+## Part 6: Risk Analysis
+
+### 6.1 Risks of the Enhanced Workflow
+
+| Risk                                              | Probability | Impact | Mitigation                                                                 |
+| ------------------------------------------------- | ----------- | ------ | -------------------------------------------------------------------------- |
+| Multi-lens review adds latency for COMPLEX+ tasks | High        | Medium | Run in parallel; target < 60s total                                        |
+| Pre-mortem generates generic/unhelpful failures   | Medium      | Medium | Use domain-specific failure taxonomy (Microsoft 2025); refine via feedback |
+| Appetite constraint causes premature scope cuts   | Medium      | High   | Allow developer override; track accuracy in process retro                  |
+| Process retro becomes performative                | Medium      | Low    | Keep lightweight (5 questions max); skip if no signal                      |
+| User feedback loop requires discipline            | High        | Medium | Make it a natural part of the PR workflow, not a separate step             |
+| Cooldown periods feel like wasted time            | Medium      | Low    | Frame as investment in quality; track bug rates pre/post cooldown          |
+| Token overhead from new steps                     | Medium      | Medium | Gate to COMPLEX+ only; use ALWAYS_FAST routing where possible              |
+
+### 6.2 Risks of NOT Doing This
+
+Applying Klein's double-barreled pre-mortem to our own proposal:
+
+| Risk of Inaction                                         | Probability | Impact   |
+| -------------------------------------------------------- | ----------- | -------- |
+| Verification debt accumulates as AI output increases     | High        | Critical |
+| Same process mistakes repeat because no process learning | High        | High     |
+| Over-scoped work causes convergence failures             | High        | High     |
+| Cognitive burnout from always-on intensity               | Medium      | High     |
+| Building features nobody values (no user feedback)       | Medium      | High     |
+| Design issues caught too late (only in code review)      | Medium      | Medium   |
+
+---
+
+## Part 7: Implementation Roadmap
+
+### Phase 1: Quick Wins (1-2 sessions)
+
+1. **Appetite field in STATE.md** — Add `Appetite:` field, read in lu-planner
+2. **Process retro in lu-learner** — Add 5 process questions after code learning
+3. **User feedback skill** — `/feedback` command that stores to MuninnDB
+
+### Phase 2: Shift-Left Verification (2-3 sessions)
+
+4. **Multi-lens review step** — 4 parallel agents before planning for COMPLEX+
+5. **Pre-mortem step** — Structured failure imagination for COMPLEX+
+6. **PREMORTEM.md + REVIEW.md artifacts** — New phase directory artifacts
+
+### Phase 3: Metrics & Sustainability (1-2 sessions)
+
+7. **DORA metrics capture** — Lead time, change failure rate in session ledger
+8. **Cooldown state machine transition** — `done` → `cooldown` → `idle`
+9. **Appetite guard in lu-executor** — Token tracking against declared budget
+
+### Phase 4: Refinement (ongoing)
+
+10. **Tune multi-lens prompts** based on process retro feedback
+11. **Tune pre-mortem prompts** based on which mitigations actually mattered
+12. **Dashboard for DORA metrics** (optional, in observer)
+
+---
+
+## Part 8: Open Questions
+
+1. **Should multi-lens review run for MODERATE tasks too?** Currently gated to COMPLEX+. MODERATE tasks are 3-5 files — might benefit from at least 1-2 lenses.
+
+2. **How do we measure appetite accuracy?** Need a feedback mechanism: "Was this over/under/right-sized?" stored in process retro.
+
+3. **Should pre-mortem be AI-only or developer-involved?** Could be fully automated (AI generates failure scenarios) or interactive (developer reviews and adds scenarios).
+
+4. **How often should cooldown happen?** Per-milestone? Per-N-phases? Fixed calendar interval?
+
+5. **Should we track developer cognitive load explicitly?** Self-reported burnout score after each session? Or too much overhead?
+
+6. **How do multi-lens review and existing code review interact?** Do code reviewers see the REVIEW.md? Does it change their focus?
+
+7. **What's the right number of pre-mortem failure scenarios?** 5 is arbitrary. Research suggests 5-7 is the sweet spot for a team; might be different for AI generation.
+
+---
+
+## Sources
+
+### Development Methodologies
+
+- Schwaber & Sutherland, _The Scrum Guide_ (2020)
+- Anderson, _Kanban: Successful Evolutionary Change for Your Technology Business_ (2010)
+- Basecamp, _Shape Up: Stop Running in Circles and Ship Work that Matters_ (2019)
+- DORA, _State of AI-Assisted Software Development Report_ (2025)
+- Beck, _Extreme Programming Explained_ (2nd ed., 2004)
+
+### AI Agent Engineering
+
+- Microsoft, _Taxonomy of Failure Modes in Agentic AI Systems_ (April 2025)
+- Anthropic, _Effective Context Engineering for AI Agents_ (2025)
+- CACM, _Verification Debt: When Generative AI Speeds Change Faster Than Proof_ (January 2026)
+- METR, _Early 2025 AI Experienced OS Dev Study_ (July 2025)
+- Sonar, _The Inevitable Rise of Poor Code Quality in AI-Accelerated Codebases_ (2025)
+- Qodo, _Building the Verification Layer_ (2026)
+- HBR, _AI Doesn't Reduce Work — It Intensifies It_ (February 2026)
+- Anthropic, _2026 Agentic Coding Trends Report_ (2026)
+- Osmani, _My LLM Coding Workflow Going Into 2026_ (2026)
+
+### Pre-Mortem Research
+
+- Klein, _Performing a Project Premortem_, Harvard Business Review (2007)
+- Klein, _Double-Barreled Pre-Mortems_, Psychology Today (2025)
+- Brookings, _The Art and Science of Pre-Mortems_ (2024)
+- Mitchell, Russo & Pennington, _Back to the Future: Temporal Perspective in the Explanation of Events_ (1989)
+- PayPal Engineering, _Pre-Mortem: Technically Working Backwards in Software Design_ (2024)
+
+### Cognitive Sustainability
+
+- InfoQ, _AI Coding Assistance Reduces Developer Skill Mastery by 17%_ (February 2026)
+- Axify, _State of DevOps_ (2025)
+- WebProNews, _AI Coding Tools: Working Longer Hours_ (2025)
+- Organization Science, _Slack Time and Innovation_ (2018)
+- Worklytics, _Software Engineering Productivity Benchmarks 2025_ (2025)
+
+### Internal Research
+
+- `docs/research/1.anti-slop.md` — Anti-Slop Framework
+- `docs/research/2.agent-design-patterns.md` — Agent Design Patterns (Google Cloud)
+- `docs/research/3.domain-specific-memory.md` — Domain-Specific Memory (Cognee)

--- a/docs/brainstorm/2.premortem-hardening-report.md
+++ b/docs/brainstorm/2.premortem-hardening-report.md
@@ -1,0 +1,350 @@
+# Pre-Mortem Hardening Report: Workflow Redesign
+
+> Cross-functional expert analysis synthesized from 5 independent reviews:
+> Systems Architect, Process Expert, Cognitive Scientist, Red Team, Token Economist.
+
+---
+
+## 1. Consensus Findings (All Experts Agree)
+
+### 1.1 The Cheap Wins Are Real
+
+All 5 experts independently rated **appetite declaration**, **process data capture**, **outcome tracking**, and **cooldown-as-advisory** as low-cost, positive-ROI additions. These should be implemented first.
+
+| Component            | Architect | Process                        | Cognitive                      | Red Team                 | Economist         | Consensus                 |
+| -------------------- | --------- | ------------------------------ | ------------------------------ | ------------------------ | ----------------- | ------------------------- |
+| Appetite Declaration | FEASIBLE  | VALUABLE                       | SUSTAINABLE                    | FRAGILE (unit undefined) | HIGH ROI ($0.006) | **GO — with hardening**   |
+| Process Data Capture | FEASIBLE  | QUESTIONABLE (AI self-eval)    | CONCERNING (needs human input) | BROKEN (echo chamber)    | HIGH ROI ($0.003) | **GO — redesigned**       |
+| Outcome Tracking     | FEASIBLE  | QUESTIONABLE (wrong mechanism) | SUSTAINABLE                    | BROKEN (self-rating)     | HIGH ROI ($0)     | **GO — reconceptualized** |
+| Cooldown             | FEASIBLE  | QUESTIONABLE (solo dev)        | CONCERNING (duration)          | BROKEN (no enforcement)  | HIGH ROI ($0)     | **GO — advisory only**    |
+
+### 1.2 Multi-Lens Review Is the Weakest Component
+
+Every expert flagged multi-lens review as problematic:
+
+- **Architect**: Risky — timeout deadlock, context pollution, 60-120s latency
+- **Process**: Questionable — simulated diversity, duplicates existing reviewers
+- **Cognitive**: Concerning — 4 reports exceeds working memory, 8-15 min attention cost
+- **Red Team**: Fragile — convergence problem, no conflict resolution, generic output trap
+- **Economist**: Marginal-to-negative ROI — $1.08/run, 74% of all new costs, 12-25% catch rate needed
+
+**Consensus: DEFER multi-lens review.** Implement only after cheaper components prove their value. If implemented, reduce to 2 lenses max with ORCHESTRATOR routing.
+
+### 1.3 Artifact Consolidation Is Critical
+
+Three experts independently converged on the same solution:
+
+- **Cognitive Scientist**: Tiered artifact model — developer reads ONE synthesized brief, not 7+ docs
+- **Architect**: Collapse multi-lens + pre-mortem into existing `discussing` state
+- **Economist**: Cap REVIEW.md and PREMORTEM.md at 500 tokens; make agent-consumed by default
+
+**Consensus: AI synthesizes, developer approves.** No component should require the developer to read >500 words of AI-generated analysis. All detailed artifacts are Tier 2 (drill-down) or Tier 3 (AI-only).
+
+### 1.4 Decision Fatigue Is the Hidden Risk
+
+The cognitive scientist quantified what others intuited:
+
+- Enhanced pipeline = ~22 decisions per COMPLEX task (up from ~6)
+- Decision quality degrades after 7-10 sequential decisions (Baumeister et al.)
+- 14-28% of appetite budget goes to process overhead (above the 10-15% healthy range)
+
+**Consensus: Batch all developer decisions into max 2 checkpoints** (pre-planning + post-execution). Everything between should be AI-autonomous.
+
+---
+
+## 2. Contested Findings (Experts Disagree)
+
+### 2.1 Pre-Mortem: Valuable or Generic Trap?
+
+| Position         | Held By                   | Argument                                                                                                             |
+| ---------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| **Valuable**     | Process Expert, Architect | Klein's 30% improvement is well-researched; AI-specific failure taxonomy is directly relevant; reduce to 3 scenarios |
+| **Fragile**      | Red Team                  | Klein's finding is for human teams, not LLMs; same 5 scenarios will repeat; creates false sense of security          |
+| **Marginal ROI** | Economist                 | $0.37/run; needs to catch 1 novel risk per 11-22 runs to break even                                                  |
+
+**Resolution:** Implement with **novelty enforcement**. Pre-mortem agent must exclude the 5 generic categories (hallucination, context drift, etc.) and generate domain-specific scenarios seeded with past failures from MuninnDB. Track "pre-mortem-only catches" metric. If unique catch rate is <10% after 20 COMPLEX runs, demote or drop.
+
+### 2.2 Process Retro: Learnable or Echo Chamber?
+
+| Position                  | Held By             | Argument                                                                                 |
+| ------------------------- | ------------------- | ---------------------------------------------------------------------------------------- |
+| **Valuable (redesigned)** | Process Expert      | Redesign as data presentation — show metrics, ask developer 1 question                   |
+| **Concerning**            | Cognitive Scientist | Too frequent per-session; batch to milestones; needs active developer engagement         |
+| **Broken**                | Red Team            | Inherently circular; AI can't assess its own false negatives; self-fulfilling validation |
+
+**Resolution:** Red team is right that pure AI self-evaluation is circular. Process expert and cognitive scientist converge on the fix: **AI prepares data, developer provides judgment**. Specifically:
+
+- AI computes 3 metrics: appetite accuracy, rework ratio, agent usefulness score
+- Developer answers 1 question: "Anything to change about the process?" (free-form, optional)
+- Runs at milestone boundaries, not per-session
+- Developer's input is the engram; AI metrics are the context
+
+### 2.3 Cooldown: Genuine Recovery or Process Theater?
+
+| Position                | Held By             | Argument                                                                         |
+| ----------------------- | ------------------- | -------------------------------------------------------------------------------- |
+| **Valuable (reframed)** | Process Expert      | Reframe as "divergent mode" — exploration vs. convergent building                |
+| **Concerning**          | Cognitive Scientist | Must be calendar-time (1-2 days), not sessions; needs non-coding activities      |
+| **Broken**              | Red Team            | Zero enforcement; developer will skip; "required" without enforcement is theater |
+
+**Resolution:** All three are partially right. Synthesis:
+
+- Drop "required" language — it's advisory, and honesty about that is better than false authority
+- Reframe as "divergent mode" (process expert's suggestion)
+- Measure in calendar time, not sessions (cognitive scientist's recommendation)
+- Implement as a nudge, not a gate: "You've completed 3 consecutive milestones without a break. Consider divergent mode." (red team's suggestion for honest advisory)
+- Track whether developer takes cooldown in process metrics (for future correlation analysis)
+
+### 2.4 User Feedback: Self-Rating vs. Outcome Tracking
+
+| Position         | Held By             | Argument                                                       |
+| ---------------- | ------------------- | -------------------------------------------------------------- |
+| **Questionable** | Process Expert      | Right instinct, wrong mechanism; move to cognitive pre-flight  |
+| **Sustainable**  | Cognitive Scientist | Light load (1-5 rating), acceptable                            |
+| **Broken**       | Red Team            | Solo dev rating own work = zero information; no external users |
+
+**Resolution:** Red team's critique is strongest — a solo developer's self-rating is not user feedback. Reconceptualize as **outcome tracking**:
+
+- Binary: "Did [feature] achieve its intended goal?" (yes / no / too early to tell)
+- Evidence-based: link to measurable outcome if available (build time, error rate, workflow enabled)
+- Contextual: triggered during cognitive pre-flight when revisiting the same domain (process expert's suggestion)
+- Drop 1-5 star rating entirely
+
+---
+
+## 3. Kill List
+
+Components to **drop or radically simplify** based on cross-expert analysis:
+
+| Component                    | Action                       | Rationale                                                                                                                          |
+| ---------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Multi-Lens Review (4 agents) | **DEFER**                    | Highest cost ($1.08), weakest ROI, convergence problem, duplicates existing reviewers. Revisit after other components prove value. |
+| Double-Barreled Pre-Mortem   | **DROP**                     | Cost-of-inaction scenarios for solo dev are tautological. Red team + economist agree.                                              |
+| 1-5 Star User Feedback       | **DROP**                     | Self-rating has zero information content. Replace with outcome tracking.                                                           |
+| Per-Session Process Retro    | **DROP**                     | Too frequent, becomes noise. Batch to milestone cadence.                                                                           |
+| Hard Appetite Halt           | **DROP**                     | Halting mid-execution wastes all tokens spent. Replace with pause + developer decision.                                            |
+| "Required" Cooldown          | **DROP the word "required"** | No enforcement mechanism makes the label dishonest. Advisory + nudge instead.                                                      |
+| Task-Count WIP Limits        | **DROP**                     | AI agents aren't humans; token/context budget is the real constraint, not task count.                                              |
+
+---
+
+## 4. Hardening Recommendations
+
+Concrete changes to the workflow redesign, ordered by priority:
+
+### P0: Critical (Must fix before implementing)
+
+**H1. Define appetite units concretely.**
+
+- Use token count with model-tier weighting as the measurable unit
+- "Context-hours" is undefined and ungameable — replace with concrete thresholds
+- Auto-infer for TRIVIAL/SIMPLE/MODERATE; only require explicit declaration for COMPLEX+
+
+**H2. Replace hard halt with graceful degradation.**
+
+- Appetite guard pauses at wave boundaries (not mid-wave) and presents options:
+  - (a) Extend appetite by N tokens
+  - (b) Scope-cut remaining work
+  - (c) Halt and preserve progress
+- Route at ROUTER preset minimum (balanced at MODERATE+), not ALWAYS_FAST
+- This is the highest regression risk component — a false halt is worse than no guard
+
+**H3. Require human input in process retro.**
+
+- AI computes metrics (appetite accuracy, rework ratio, agent performance)
+- Developer provides 1 free-form input: "Anything to change?"
+- Developer's input is the engram, not AI self-assessment
+- Runs at milestone boundaries only
+
+### P1: Important (Should fix before implementing)
+
+**H4. Force pre-mortem novelty.**
+
+- Exclude generic failure categories from prompts
+- Seed with past session failures from MuninnDB
+- Require domain-specific scenarios tied to actual codebase
+- Reduce from 5 scenarios to 3
+- Track "pre-mortem-only catches" metric; drop if <10% unique catch rate after 20 runs
+
+**H5. Implement tiered artifact model.**
+
+- **Tier 1** (developer reads): Single "Risk & Plan Brief" — max 500 words, synthesized from all pre-planning analysis
+- **Tier 2** (developer drills down on exception): Full PREMORTEM.md, detailed plan
+- **Tier 3** (AI consumes, developer ignores): DORA metrics, individual lens reports, process engrams
+
+**H6. Batch developer decisions to 2 checkpoints.**
+
+- **Checkpoint 1 (pre-planning)**: Review Risk & Plan Brief, approve/modify. ~5 min.
+- **Checkpoint 2 (post-execution)**: Review verification summary, answer 1 retro question. ~3 min.
+- Everything between is AI-autonomous
+
+**H7. Add conflict resolution to multi-lens review (if ever implemented).**
+
+- 5th synthesis agent resolves contradictions between lenses
+- Explicit priority ordering: Architecture > Data > Performance > UX
+- Track lens output similarity; flag and skip degenerating lenses
+
+### P2: Nice to Have (Can iterate post-implementation)
+
+**H8. Reconceptualize feedback as outcome tracking.**
+
+- Binary: achieved goal / did not / too early
+- Evidence-linked where possible
+- Triggered contextually during cognitive pre-flight, not as a separate step
+
+**H9. Implement cooldown as advisory nudge.**
+
+- Track consecutive milestones without divergent mode
+- Surface nudge at 3+ consecutive milestones
+- Measure in calendar time for any developer who does take it
+- Track correlation between cooldown and subsequent quality metrics
+
+**H10. Add risk multiplier to complexity gating.**
+
+- Files in core domains (schemas, state machine, shared) get 2x weight
+- Can promote MODERATE → COMPLEX based on architectural risk, not just file count
+- Addresses the cliff-edge problem at the MODERATE/COMPLEX boundary
+
+---
+
+## 5. Revised Risk Matrix
+
+Incorporating all expert input:
+
+| Component (as hardened)         | Probability of Failure | Impact if Fails              | Mitigation Confidence | Net Risk     |
+| ------------------------------- | ---------------------- | ---------------------------- | --------------------- | ------------ |
+| Appetite (soft guard)           | Low                    | Low (advisory, no halt)      | High                  | **LOW**      |
+| Pre-Mortem (novelty-enforced)   | Medium                 | Medium (could produce noise) | Medium                | **MEDIUM**   |
+| Process Data (developer-judged) | Low                    | Low (worst case: ignored)    | High                  | **LOW**      |
+| Outcome Tracking                | Medium                 | Low (worst case: not used)   | Medium                | **LOW**      |
+| Cooldown (advisory nudge)       | High (skipped often)   | Low (no enforcement)         | Low                   | **LOW**      |
+| Multi-Lens Review (deferred)    | N/A                    | N/A                          | N/A                   | **DEFERRED** |
+
+**Overall redesign risk: LOW-MEDIUM.** The hardened design eliminates the three highest risks from the original proposal (hard halt regression, AI echo chamber retro, artifact overload) while preserving the four highest-value additions.
+
+---
+
+## 6. Final Go/No-Go Per Component
+
+| Component                  | Original Design                               | Hardened Design                                                  | Verdict                                      | Phase                                  |
+| -------------------------- | --------------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------- | -------------------------------------- |
+| Appetite Declaration       | Hard halt at 100% budget                      | Soft guard, pause + developer choice at wave boundary            | **GO**                                       | 1                                      |
+| Pre-Mortem                 | 5 generic scenarios, COMPLEX+                 | 3 novelty-enforced domain-specific scenarios, COMPLEX+           | **GO**                                       | 1                                      |
+| Process Retrospective      | AI answers 5 questions per session            | AI prepares 3 metrics, developer answers 1 question at milestone | **GO**                                       | 1                                      |
+| Outcome Tracking           | 1-5 star self-rating post-ship                | Binary goal achievement + evidence, contextual trigger           | **GO**                                       | 2                                      |
+| Cooldown                   | Required at milestone, state machine enforced | Advisory nudge after 3+ milestones, calendar-time measured       | **GO**                                       | 2                                      |
+| Multi-Lens Review          | 4 parallel agents, DEEP_ANALYSIS, COMPLEX+    | —                                                                | **DEFER**                                    | 3+ (pending ROI proof from pre-mortem) |
+| Double-Barreled Pre-Mortem | Cost-of-inaction scenarios at CRITICAL        | —                                                                | **DROP**                                     | —                                      |
+| Task-Count WIP Limits      | Max tasks per wave                            | —                                                                | **DROP** (use appetite/token budget instead) | —                                      |
+| 1-5 Star Feedback          | Post-ship rating                              | —                                                                | **DROP** (replaced by outcome tracking)      | —                                      |
+
+---
+
+## 7. Revised Implementation Roadmap
+
+### Phase 1: Validated Foundations (1-2 sessions)
+
+1. **Appetite declaration** — Concrete token-based units, auto-inferred for TRIVIAL-MODERATE, explicit for COMPLEX+. Soft guard at wave boundaries with developer choice.
+2. **Pre-mortem (hardened)** — 3 domain-specific scenarios, novelty-enforced, seeded from MuninnDB. Track "unique catch" metric.
+3. **Process data at milestones** — AI computes appetite accuracy, rework ratio, agent performance. Developer answers 1 question. Engram stored.
+
+### Phase 2: Outer Loops (1-2 sessions)
+
+4. **Outcome tracking** — Binary goal achievement, evidence-linked, contextual trigger during pre-flight.
+5. **Cooldown nudge** — Advisory after 3+ consecutive milestones. Calendar-time measurement. No enforcement.
+6. **DORA metrics** — Lead time, change failure rate captured in session ledger.
+
+### Phase 3: Conditional Expansion (only if Phase 1-2 prove value)
+
+7. **Multi-lens review (reduced)** — 2 lenses (Architecture + Data), ORCHESTRATOR routing, with conflict resolution. Gate on: pre-mortem unique catch rate >10% over 20 runs.
+8. **Risk multiplier for complexity** — Core-domain file weighting for MODERATE/COMPLEX promotion.
+
+### Graduation Criteria
+
+Each component has an explicit "turn off if not valuable" threshold:
+
+- **Pre-mortem**: Drop if unique catch rate <10% after 20 COMPLEX runs
+- **Process retro**: Drop developer question if response rate <30% over 10 milestones
+- **Outcome tracking**: Drop if completion rate <20% over 10 features
+- **Multi-lens**: Don't implement unless pre-mortem proves >15% unique catch rate
+
+---
+
+## 8. Late Addendums (Post Cross-Pollination)
+
+Two significant refinements emerged from expert cross-discussion after initial reports were filed.
+
+### 8.1 Attention Cost Dwarfs Token Cost (Token Economist + Cognitive Scientist)
+
+The token economist revised his analysis after the cognitive scientist's attention-minutes data:
+
+- **Token cost per COMPLEX run**: ~$1.46 (new components)
+- **Developer attention cost per COMPLEX run**: ~$27.50-52.50 (at $37.50/hr, 44-84 min)
+- **Attention is 19-36x more expensive than tokens**
+
+This creates a **hard design requirement**: multi-lens and pre-mortem outputs MUST be agent-consumed by default. The planner and executor read REVIEW.md/PREMORTEM.md automatically. The developer only sees findings flagged as HIGH severity. This converts 18-35 minutes of developer attention to ~0 while preserving the token investment.
+
+Additionally, the economist proposed a **self-tuning cost control** mechanism: track a "signal rate" metric (findings that changed the plan or prevented a real issue / total findings). If signal rate drops below 10% over 20 runs, auto-skip the component. The cheapest component (process retro at $0.003/run) governs whether the expensive components ($1.08 + $0.37) keep running.
+
+### 8.2 Three Key Refinements (Cognitive Scientist, post cross-pollination)
+
+After exchanging findings with other experts, the cognitive scientist upgraded 3 components from CONCERNING to SUSTAINABLE:
+
+**a. Collaborative Pre-Mortem (not passive review)**
+
+Instead of AI generating 5 scenarios for developer review:
+
+1. AI presents task summary
+2. Developer writes 1 failure scenario (even one sentence)
+3. AI generates 2 additional scenarios (reduced from 4)
+4. Aggregated into Risk Brief with developer's scenario highlighted
+
+This applies the "generate before evaluate" principle (Finke et al., 1992) — generating your own risk before seeing AI's prevents anchoring and preserves the developer's risk-identification skill. Addresses red team's "skill atrophy" concern.
+
+**b. "Divergent Mode" Instead of "Cooldown"**
+
+Convergent work (spec-driven, narrow attention) and divergent work (exploratory, broad attention) activate different neural networks (Default Mode Network vs. Task Positive Network). Bug fixes in the same IDE are still convergent — they don't provide recovery.
+
+Divergent mode rules:
+
+- No acceptance criteria (defining "done" makes it convergent again)
+- Encouraged activities: architecture sketching, research reading, product exploration, shaping future work
+- Minimum: 1 calendar day (COMPLEX milestones), 2 calendar days (CRITICAL milestones)
+
+**c. Dual-Purpose Tier Model**
+
+The three-tier artifact model protects not just the developer but also the AI planner from context overload. The document's own Quality Degradation Curve (30% context = peak, 70%+ = poor) means dumping full analysis into the planner's window degrades plan quality:
+
+- Developer reads Tier 1 only (synthesized Risk Brief, <500 words)
+- Planner agent consumes Tier 1 only (<500 tokens in context)
+- Tier 2/3 artifacts are stored for audit but never loaded into active contexts
+
+### 8.3 Updated Component Ratings (Final)
+
+With all cross-pollination incorporated:
+
+| Component            | Initial Average Rating              | Final Rating | Key Change                                             |
+| -------------------- | ----------------------------------- | ------------ | ------------------------------------------------------ |
+| Appetite Declaration | Feasible/Valuable                   | **GO**       | Defined units, soft guard                              |
+| Pre-Mortem           | Risky/Valuable/Fragile              | **GO**       | Collaborative format, novelty-enforced, 3 scenarios    |
+| Process Retro        | Questionable/Broken                 | **GO**       | Data dashboard + 1 developer question at milestones    |
+| Outcome Tracking     | Questionable/Broken                 | **GO**       | Binary goal achievement, not self-rating               |
+| Divergent Mode       | Questionable/Broken                 | **GO**       | Advisory nudge, calendar-time, no enforcement pretense |
+| Multi-Lens Review    | Risky/Questionable/Fragile/Negative | **DEFER**    | Most expensive, weakest ROI, simulated diversity       |
+
+---
+
+## Appendix: Expert Cross-References
+
+| Finding                                                 | Raised By            | Corroborated By                                                             |
+| ------------------------------------------------------- | -------------------- | --------------------------------------------------------------------------- |
+| Multi-lens is simulated diversity, not real diversity   | Process Expert       | Red Team, Economist                                                         |
+| Artifact overload exceeds working memory (Miller's Law) | Cognitive Scientist  | Architect, Process Expert                                                   |
+| Appetite guard is highest regression risk               | Red Team             | Architect (wave boundary fix)                                               |
+| Process retro without human input is echo chamber       | Red Team             | Process Expert (data presentation), Cognitive Scientist (active engagement) |
+| Context-hours is undefined                              | Red Team             | Economist (token-based alternative)                                         |
+| Pre-execution latency roughly triples                   | Architect (117-217s) | Economist (60-120s for multi-lens + pre-mortem)                             |
+| 99% of new costs are multi-lens + pre-mortem            | Economist            | All (supports deferral)                                                     |
+| Calendar-time cooldown, not session-count               | Cognitive Scientist  | Process Expert (mode-switching framing)                                     |
+| Tiered artifact model (1 brief, drill-down, AI-only)    | Cognitive Scientist  | Architect (collapse into discussing state)                                  |
+| Earned autonomy after proven accuracy                   | Cognitive Scientist  | Process Expert (sunset mechanism)                                           |

--- a/docs/brainstorm/3.final-workflow.md
+++ b/docs/brainstorm/3.final-workflow.md
@@ -1,0 +1,337 @@
+# Luca v4 Workflow: Final Hardened Design
+
+> The definitive workflow specification incorporating all research, expert pre-mortem
+> analysis, and developer decisions. Ready for implementation planning.
+
+---
+
+## Design Principles
+
+1. **Verification-centered** — the bottleneck is verification quality, not generation speed
+2. **Fixed appetite, variable scope** — declare investment ceiling before planning
+3. **AI synthesizes, developer approves** — max 2 developer checkpoints per session
+4. **Every component earns its place** — explicit graduation criteria; drop if not valuable
+5. **Attention cost > token cost** — optimize for developer cognitive load, not just API spend
+
+---
+
+## Design Decisions (Developer Input)
+
+| #   | Decision                                                                  | Rationale                                                                                                                                   |
+| --- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | **Pre-mortem runs at MODERATE+ (not just COMPLEX+)**                      | Agents tend to underestimate complexity; most tasks classify as TRIVIAL. The MODERATE threshold catches work that should have been COMPLEX. |
+| D2  | **Pre-mortem format: developer approve/reject (not collaborative write)** | Lower touch than writing a scenario. AI generates 3 scenarios; developer approves/rejects the Risk Brief.                                   |
+| D3  | **Outcome tracking: minimal contextual prompt + manual `/outcome` skill** | Keep the contextual trigger ultra-low-touch. Add a `/outcome` skill for manual tracking when developer wants to record proactively.         |
+| D4  | **Divergent mode nudge at 8+ milestones (not 3)**                         | Less aggressive. Developer knows when they need a break; the nudge is a gentle reminder, not a nag.                                         |
+
+---
+
+## The Pipeline
+
+```
+PHASE 0: INTAKE & APPETITE
+│
+├─ Parse request                                          [existing, AI-autonomous]
+├─ Cognitive pre-flight                                   [existing, AI-autonomous]
+│   └─ Enhanced: recalls outcome:* + process:* engrams
+│     from MuninnDB for this domain
+├─ Complexity classification (lu-router)                  [existing, AI-autonomous]
+└─ Appetite declaration                                   [NEW]
+    ├─ TRIVIAL/SIMPLE: auto-inferred from complexity
+    ├─ MODERATE+: developer declares (Micro/Small/Medium/Large/XL)
+    ├─ Unit: weighted token budget (concrete, measurable)
+    └─ Stored in STATE.md as Appetite field
+
+    Complexity = floor (objective technical reality).
+    Appetite = ceiling (subjective investment decision).
+    If appetite < complexity → scope cut OR decompose first OR don't start yet.
+
+▼
+PHASE 1: PRE-MORTEM                                [NEW, MODERATE+ only]
+│
+│   Runs within the existing `discussing` state — not a new pipeline stage.
+│
+├─ AI generates 3 domain-specific failure scenarios
+│   ├─ Novelty-enforced: excludes generic categories
+│   │   (no boilerplate "hallucination might occur")
+│   ├─ Seeded with past failures from MuninnDB
+│   └─ Each scenario: description, root cause, detection,
+│     mitigation, verification criteria
+├─ Aggregated into Risk Brief (Tier 1, ≤500 words)
+├─ Developer reviews Risk Brief                            ◄── CHECKPOINT 1
+│   Approve / reject / modify                                 (~2-3 min)
+├─ Artifacts:
+│   ├─ Tier 1: Risk Brief (≤500 words) — developer + planner read
+│   ├─ Tier 2: Full PREMORTEM.md — drill-down on exception only
+│   └─ Tier 3: Raw scenario data — AI-consumed, never in active context
+└─ Approved mitigations become plan constraints;
+    verification criteria feed the harness
+
+    Model routing: DEEP_ANALYSIS (balanced@MODERATE, balanced@COMPLEX, capable@CRITICAL)
+    Token cost: ~$0.37/run (MODERATE+), $0 (TRIVIAL/SIMPLE)
+    Developer attention: ~2-3 min (review brief, approve/reject)
+
+▼
+PHASE 2: PLANNING                                  [existing, enhanced]
+│
+├─ PLAN.md creation                                       [existing, AI-autonomous]
+│   ├─ Appetite constraint shapes scope (cut to fit budget)
+│   └─ Pre-mortem mitigations baked into tasks
+├─ Plan verification                                      [existing, AI-autonomous]
+│   └─ Iteration count complexity-gated (1/1/1/2/3)
+└─ Developer reviews plan (existing checkpoint)
+
+    Everything between here and verification is AI-autonomous.
+
+▼
+PHASE 3: EXECUTION                                 [existing, enhanced]
+│
+├─ Wave-based parallel execution                          [existing, AI-autonomous]
+├─ Appetite guard                                         [NEW, AI-autonomous]
+│   ├─ Checks token budget at wave boundaries only
+│   ├─ At 80%: logs warning, continues
+│   ├─ At 100%: PAUSES and presents developer options:
+│   │   (a) Extend appetite by N tokens
+│   │   (b) Scope-cut remaining work
+│   │   (c) Halt and preserve progress
+│   ├─ Model routing: ROUTER (balanced at MODERATE+)
+│   └─ Never interrupts mid-wave
+└─ Mid-wave checkpoint (COMPLEX+ only)                    [existing enhancement]
+
+▼
+PHASE 4: VERIFICATION                              [existing, enhanced]
+│
+├─ Harness: test + typecheck + lint + build               [existing, AI-autonomous]
+├─ lu-verifier: EXISTS / SUBSTANTIVE / WIRED              [existing, AI-autonomous]
+├─ Code review: 5 parallel reviewers                      [existing, AI-autonomous]
+│   └─ Enhanced: pre-mortem mitigations as additional review criteria
+├─ Harness fix loop (up to 3 iterations)                  [existing, AI-autonomous]
+└─ Developer reviews verification summary                  ◄── CHECKPOINT 2
+    Pass/fail + flagged items. ~2-3 min.                      (developer review)
+
+▼
+PHASE 5: LEARNING & PROCESS DATA                   [existing, enhanced]
+│
+├─ lu-learner: code knowledge capture                     [existing, AI-autonomous]
+│   (patterns, decisions, pitfalls → MuninnDB)
+├─ Process data capture                                   [NEW, AI-autonomous]
+│   ├─ Auto-computes 3 metrics:
+│   │   1. Appetite accuracy (declared vs. actual)
+│   │   2. Rework ratio (agent output requiring significant rework)
+│   │   3. Pre-mortem signal rate (mitigations that mattered)
+│   ├─ Stored as metric:* engrams in MuninnDB
+│   └─ Model routing: FAST_PROMOTED ($0.003/run)
+├─ DORA metrics logged                                    [NEW, AI-autonomous]
+│   ├─ Lead time (invocation → commit)
+│   └─ Change failure rate (verification failures per run)
+└─ Self-tuning governance                                 [NEW, AI-autonomous]
+    └─ If pre-mortem signal rate <10% over 20 runs → auto-skip
+
+▼
+PHASE 6: COMMIT                                    [existing]
+
+▼
+PROCESS RETROSPECTIVE                              [NEW, milestone boundary only]
+│
+│   Runs once per milestone, NOT per session/phase.
+│
+├─ AI surfaces process dashboard:
+│   ├─ Appetite accuracy trend
+│   ├─ Rework ratio trend
+│   ├─ Pre-mortem signal rate
+│   └─ Agent performance scores
+├─ Developer answers 1 question:
+│   "Anything to change about how we work?"
+│   (free-form, optional)
+└─ Stored as process:* engram in MuninnDB
+
+OUTCOME TRACKING                                   [NEW, two modes]
+│
+│   Mode 1: Contextual trigger (low-touch)
+│   ├─ During cognitive pre-flight when revisiting a domain
+│   │   where a feature was shipped recently
+│   ├─ Prompt: "You shipped [Feature X] here. Did it achieve
+│   │   its goal?" (yes / no / too early)
+│   └─ Stored as outcome:* engram in MuninnDB
+│
+│   Mode 2: Manual skill (/outcome)
+│   ├─ Developer runs /outcome at any time
+│   ├─ Records: feature, goal achieved (yes/no/partial),
+│   │   evidence, notes
+│   └─ Stored as outcome:* engram in MuninnDB
+
+DIVERGENT MODE                                     [NEW, advisory nudge]
+│
+│   Advisory system at milestone boundaries. No enforcement.
+│
+├─ Trigger: 8+ consecutive milestones without divergent mode
+├─ Nudge: "You've completed N milestones without a break.
+│   Consider divergent mode."
+├─ If developer opts in:
+│   ├─ No acceptance criteria
+│   ├─ Encouraged: architecture sketching, research reading,
+│   │   product exploration, shaping future work
+│   ├─ Min: 1 calendar day (COMPLEX), 2 calendar days (CRITICAL)
+│   └─ Cognitively distinct from convergent spec-driven work
+├─ If developer opts out: tracked in process metrics
+└─ No enforcement — honest advisory only
+```
+
+---
+
+## Developer Attention Budget
+
+| Checkpoint               | When               | What                                           | Time                          |
+| ------------------------ | ------------------ | ---------------------------------------------- | ----------------------------- |
+| **1**                    | Pre-planning       | Review Risk Brief (≤500 words), approve/reject | ~2-3 min                      |
+| **2**                    | Post-execution     | Review verification summary                    | ~2-3 min                      |
+| **Retro**                | Milestone boundary | Answer 1 optional question                     | ~1 min                        |
+| **Outcome**              | Contextual trigger | Yes/no/too early                               | ~15 sec                       |
+| **COMPLEX total**        |                    |                                                | **~5-7 min**                  |
+| **TRIVIAL/SIMPLE total** |                    |                                                | **~0 min** (fully autonomous) |
+
+---
+
+## Complexity Gating
+
+| Step             | TRIVIAL                 | SIMPLE                 | MODERATE                    | COMPLEX                                     | CRITICAL                                    |
+| ---------------- | ----------------------- | ---------------------- | --------------------------- | ------------------------------------------- | ------------------------------------------- |
+| Appetite         | Auto (Micro)            | Auto (Small)           | Developer declares          | Developer declares                          | Developer declares                          |
+| Pre-Mortem       | Skip                    | Skip                   | 3 scenarios                 | 3 scenarios                                 | 3 scenarios                                 |
+| Planning         | Skip                    | Lightweight            | Full + appetite             | Full + appetite                             | Full + appetite + 3 plan verifications      |
+| Execution        | Direct                  | Direct                 | Wave-based + appetite guard | Wave + appetite guard + mid-wave checkpoint | Wave + appetite guard + mid-wave checkpoint |
+| Verification     | Harness only            | Harness + quick verify | Harness + standard + review | Harness + full + review                     | Harness + full + review + human             |
+| Process Data     | Auto-log                | Auto-log               | Auto-log                    | Auto-log + DORA                             | Auto-log + DORA                             |
+| Process Retro    | —                       | —                      | At milestone                | At milestone                                | At milestone                                |
+| Outcome Tracking | Contextual (all levels) |                        |                             |                                             |                                             |
+| Divergent Mode   | —                       | —                      | —                           | Advisory at 8+                              | Advisory at 8+                              |
+
+**Key change from original:** Pre-mortem now runs at MODERATE+ (was COMPLEX+ only). This addresses the systematic under-classification problem where agents classify most tasks as TRIVIAL.
+
+---
+
+## Token Cost Per Run
+
+| Component      | TRIVIAL     | SIMPLE      | MODERATE   | COMPLEX    | CRITICAL   |
+| -------------- | ----------- | ----------- | ---------- | ---------- | ---------- |
+| Pre-Mortem     | —           | —           | ~$0.25     | ~$0.37     | ~$0.50     |
+| Appetite Guard | ~$0.001     | ~$0.001     | ~$0.003    | ~$0.006    | ~$0.006    |
+| Process Data   | ~$0.001     | ~$0.001     | ~$0.002    | ~$0.003    | ~$0.003    |
+| **New total**  | **~$0.002** | **~$0.002** | **~$0.26** | **~$0.38** | **~$0.51** |
+
+---
+
+## Model Routing
+
+| Component      | Preset        | TRIVIAL | SIMPLE | MODERATE | COMPLEX  | CRITICAL |
+| -------------- | ------------- | ------- | ------ | -------- | -------- | -------- |
+| Pre-Mortem     | DEEP_ANALYSIS | —       | —      | balanced | balanced | capable  |
+| Appetite Guard | ROUTER        | fast    | fast   | balanced | balanced | balanced |
+| Process Data   | FAST_PROMOTED | fast    | fast   | fast     | fast     | balanced |
+
+---
+
+## MuninnDB Memory Schema (New Engram Types)
+
+| Type                        | Example                                     | Stored By        | Recalled By          |
+| --------------------------- | ------------------------------------------- | ---------------- | -------------------- |
+| `process:appetite-accuracy` | "Phase 12: declared Medium, actual Large"   | Process Data     | lu-cognition         |
+| `process:workflow-change`   | "Developer: stop pre-mortem on refactors"   | Process Retro    | lu-cognition         |
+| `outcome:feature-goal`      | "Feature X achieved goal — build time -40%" | Outcome Tracking | lu-cognition         |
+| `metric:lead-time`          | "Milestone 5 avg: 23 min/phase"             | DORA logging     | Process Retro        |
+| `metric:signal-rate`        | "Pre-mortem signal: 15% over 20 runs"       | Self-tuning      | Auto-skip governance |
+
+---
+
+## Graduation Criteria (Kill Switches)
+
+| Component        | Metric                  | Threshold                   | Action                                   |
+| ---------------- | ----------------------- | --------------------------- | ---------------------------------------- |
+| Pre-Mortem       | Unique catch rate       | <10% over 20 MODERATE+ runs | Auto-skip                                |
+| Process Retro    | Developer response rate | <30% over 10 milestones     | Drop question, keep auto-metrics         |
+| Outcome Tracking | Completion rate         | <20% over 10 features       | Drop contextual trigger, keep `/outcome` |
+| Divergent Mode   | Opt-in rate             | <10% over 20 milestones     | Drop nudge                               |
+
+Self-tuning: process data ($0.003/run) monitors signal rate and can auto-disable expensive components.
+
+---
+
+## New Skills Required
+
+| Skill      | Trigger | Function                                                                |
+| ---------- | ------- | ----------------------------------------------------------------------- |
+| `/outcome` | Manual  | Record feature outcome: goal achieved (yes/no/partial), evidence, notes |
+
+---
+
+## New Agent Definitions
+
+| Agent             | Type       | Purpose                                                          | Routing       |
+| ----------------- | ---------- | ---------------------------------------------------------------- | ------------- |
+| `lu-premortem`    | Luca agent | Generate 3 domain-specific failure scenarios, produce Risk Brief | DEEP_ANALYSIS |
+| `lu-process-data` | Luca agent | Compute appetite accuracy, rework ratio, signal rate             | FAST_PROMOTED |
+
+---
+
+## State Machine Changes
+
+| Change                                    | Type                 | Details                                            |
+| ----------------------------------------- | -------------------- | -------------------------------------------------- |
+| `appetite_level` field in WorkflowContext | Context extension    | Enum: Micro/Small/Medium/Large/XL                  |
+| `appetite_budget_tokens` field            | Context extension    | Weighted token budget ceiling                      |
+| `appetite_used_tokens` field              | Context extension    | Running token consumption                          |
+| Appetite guard in wave_evaluating         | Guard addition       | Checks budget at wave boundaries                   |
+| Pre-mortem in `discussing` state          | Sub-agent invocation | Runs within existing state, no new top-level state |
+| Process data after lu-learner             | Sequential agent     | Runs in `learning` state                           |
+| `cooldown` state (advisory)               | New state            | `complete` → `cooldown` → `idle` (skippable)       |
+
+**No new top-level pipeline states.** Pre-mortem runs inside `discussing`. Process data runs inside `learning`. Appetite guard runs inside `wave_evaluating`. This preserves pipeline simplicity.
+
+---
+
+## Implementation Roadmap
+
+### Phase 1: Foundations (1-2 sessions)
+
+1. **Appetite declaration** — Token-based units, auto-inferred for TRIVIAL/SIMPLE, explicit for MODERATE+. Soft guard at wave boundaries.
+2. **Pre-mortem agent** — 3 novelty-enforced scenarios, Risk Brief artifact, approve/reject format. Runs at MODERATE+.
+3. **Process data agent** — Auto-compute 3 metrics at end of each phase. FAST_PROMOTED routing.
+
+### Phase 2: Outer Loops (1-2 sessions)
+
+4. **Outcome tracking** — Contextual trigger in pre-flight + `/outcome` skill for manual recording.
+5. **DORA metrics** — Lead time, change failure rate in session ledger.
+6. **Process retro at milestones** — Dashboard + 1 developer question.
+
+### Phase 3: Sustainability (1 session)
+
+7. **Divergent mode nudge** — Advisory at 8+ milestones. Calendar-time measurement.
+8. **Self-tuning governance** — Signal rate tracking, auto-skip for low-value components.
+9. **Graduation criteria** — Kill switch thresholds wired into process data agent.
+
+### Phase 4: Conditional Expansion (only if Phase 1-2 prove value)
+
+10. **Multi-lens review (reduced)** — 2 lenses (Architecture + Data), ORCHESTRATOR routing. Gate on: pre-mortem unique catch rate >10% over 20 runs.
+11. **Risk multiplier for complexity** — Core-domain file weighting for MODERATE/COMPLEX promotion.
+
+---
+
+## What's NOT in This Design (Explicitly Dropped)
+
+| Dropped                                              | Why                                                                      |
+| ---------------------------------------------------- | ------------------------------------------------------------------------ |
+| Multi-lens review (4 agents)                         | Deferred — simulated diversity, $1.08/run, duplicates existing reviewers |
+| Double-barreled pre-mortem                           | Cost-of-inaction is tautological for solo developer                      |
+| Collaborative pre-mortem (developer writes scenario) | Developer prefers approve/reject over writing                            |
+| 1-5 star self-rating                                 | Zero information content for solo developer                              |
+| Task-count WIP limits                                | Token budget is the real constraint, not task count                      |
+| Per-session process retro                            | Too frequent; batched to milestones                                      |
+| Hard appetite halt                                   | Wastes all tokens spent; replaced with soft pause                        |
+| "Required" cooldown                                  | No enforcement mechanism; honest advisory instead                        |
+
+---
+
+## Sources
+
+See `docs/brainstorm/1.workflow-redesign.md` for full research bibliography.
+See `docs/brainstorm/2.premortem-hardening-report.md` for expert pre-mortem analysis.

--- a/docs/research/1.anti-slop.md
+++ b/docs/research/1.anti-slop.md
@@ -8,8 +8,8 @@ This document serves as the definitive manual for managing AI agents in producti
 
 Before implementing tools, a fundamental mindset shift must occur:
 
-* **LLM Code $\neq$ Slop**: High-quality code is possible if you treat agent output as an engineering problem rather than a model limitation.
-* **The Recovery Loop**: Never manually fix bad agent output. Follow these steps:
+- **LLM Code != Slop**: High-quality code is possible if you treat agent output as an engineering problem rather than a model limitation.
+- **The Recovery Loop**: Never manually fix bad agent output. Follow these steps:
 
 1. **Diagnose**: Identify why the agent failed (e.g., poor prompt, lack of context).
 2. **Reset**: Scrap the run and delete the bad code entirely.
@@ -24,45 +24,45 @@ These systems provide the physical boundaries and safety nets required to run mu
 
 ### 1. Hooks
 
-* **Custom Harnesses**: Wrap agents in specific execution environments to capture granular logs of every action.
-* **Pre-commit Validation**: Use automated hooks to trigger linting and test suites the moment an agent attempts to commit code.
-* **Destructive Change Prevention**: Implement dry-run hooks that analyze potential impact before changes are finalized.
-* **First Layer of Defense**: Treat hooks as the mandatory checkpoint for all inbound and outbound agent data.
+- **Custom Harnesses**: Wrap agents in specific execution environments to capture granular logs of every action.
+- **Pre-commit Validation**: Use automated hooks to trigger linting and test suites the moment an agent attempts to commit code.
+- **Destructive Change Prevention**: Implement dry-run hooks that analyze potential impact before changes are finalized.
+- **First Layer of Defense**: Treat hooks as the mandatory checkpoint for all inbound and outbound agent data.
 
 ### 2. Quality Gates
 
-* **Strictest Possible Rules**: Configure linting and type-checking (e.g., TypeScript strict mode) to the maximum level of severity.
-* **Binary Pass Rates**: Enforce a strict requirement where 100% of tests must pass before an agent's work can proceed.
-* **Standard Alignment**: Sync all automated gates with existing project standards to prevent architectural drift.
-* **Automated Rejection**: Design the system to instantly fail and reset an agent run if a single gate is breached.
+- **Strictest Possible Rules**: Configure linting and type-checking (e.g., TypeScript strict mode) to the maximum level of severity.
+- **Binary Pass Rates**: Enforce a strict requirement where 100% of tests must pass before an agent's work can proceed.
+- **Standard Alignment**: Sync all automated gates with existing project standards to prevent architectural drift.
+- **Automated Rejection**: Design the system to instantly fail and reset an agent run if a single gate is breached.
 
 ### 3. Testing
 
-* **Anti-Mocking Philosophy**: Adhere to the rule: "Never mock what you can use for real" to ensure true verification.
-* **Coverage Thresholds**: Set mandatory code coverage targets that all agent-generated features must meet.
-* **Immediate Failure Resolution**: If an agent writes a failing test, it must resolve the error immediately or the run is scrapped.
-* **Real-World Verification**: Ensure tests exercise actual integrated code paths rather than isolated, hallucinated logic.
+- **Anti-Mocking Philosophy**: Adhere to the rule: "Never mock what you can use for real" to ensure true verification.
+- **Coverage Thresholds**: Set mandatory code coverage targets that all agent-generated features must meet.
+- **Immediate Failure Resolution**: If an agent writes a failing test, it must resolve the error immediately or the run is scrapped.
+- **Real-World Verification**: Ensure tests exercise actual integrated code paths rather than isolated, hallucinated logic.
 
 ### 4. Standardization
 
-* **Centralized Tracking**: Mandate that all agents report to a single source of truth for task and issue management.
-* **Unified Learning Repositories**: Store all agent insights and "learnings" in one location to prevent documentation fragmentation.
-* **Predictable Review Workflows**: Standardize whether code is reviewed by a human via PR or by a secondary "Review Agent."
-* **Work Location Uniformity**: Define exactly which directories and file structures agents are permitted to operate within.
+- **Centralized Tracking**: Mandate that all agents report to a single source of truth for task and issue management.
+- **Unified Learning Repositories**: Store all agent insights and "learnings" in one location to prevent documentation fragmentation.
+- **Predictable Review Workflows**: Standardize whether code is reviewed by a human via PR or by a secondary "Review Agent."
+- **Work Location Uniformity**: Define exactly which directories and file structures agents are permitted to operate within.
 
 ### 5. Per-Agent Isolation
 
-* **Worktree Usage**: Leverage `git worktrees` to give every agent a completely isolated directory for its operations.
-* **Conflict Avoidance**: Ensure agents working in parallel cannot overwrite or interfere with one another's file changes.
-* **Sandbox Environments**: Restrict agent tool calls to secure sandboxes to prevent side effects on the primary system.
-* **Safety Principle**: Operate under the axiom that "an isolated agent is a safe agent," especially during large-scale swarms.
+- **Worktree Usage**: Leverage `git worktrees` to give every agent a completely isolated directory for its operations.
+- **Conflict Avoidance**: Ensure agents working in parallel cannot overwrite or interfere with one another's file changes.
+- **Sandbox Environments**: Restrict agent tool calls to secure sandboxes to prevent side effects on the primary system.
+- **Safety Principle**: Operate under the axiom that "an isolated agent is a safe agent," especially during large-scale swarms.
 
 ### 6. Hard Blocks
 
-* **Command Blacklisting**: Explicitly disable high-risk commands like `git push` to prevent unverified code from hitting remote.
-* **Role-Based Permissions**: Restrict agents to specific capabilities; for example, "Scout" agents should be read-only.
-* **Minimalist Toolsets**: Limit an agent's available tools to only what is strictly required for its current decomposed task.
-* **Behavioral Enforcement**: Use hard blocks to instantly stop an agent if it attempts to wander outside its predefined task.
+- **Command Blacklisting**: Explicitly disable high-risk commands like `git push` to prevent unverified code from hitting remote.
+- **Role-Based Permissions**: Restrict agents to specific capabilities; for example, "Scout" agents should be read-only.
+- **Minimalist Toolsets**: Limit an agent's available tools to only what is strictly required for its current decomposed task.
+- **Behavioral Enforcement**: Use hard blocks to instantly stop an agent if it attempts to wander outside its predefined task.
 
 ---
 
@@ -72,53 +72,53 @@ These patterns manage the "intelligence" and focus of the agents to ensure corre
 
 ### 1. Traceability
 
-* **Attribution Mapping**: Log exactly which agent made which specific change to the codebase.
-* **Temporal Sequencing**: Record the timing of changes to assist in debugging complex multi-agent handoffs.
-* **Action-to-Prompt Mapping**: Connect every tool call back to the specific instruction or prompt that initiated it.
-* **Post-Mortem Readiness**: Ensure all agent "thought processes" and actions are available for human audit if a system failure occurs.
+- **Attribution Mapping**: Log exactly which agent made which specific change to the codebase.
+- **Temporal Sequencing**: Record the timing of changes to assist in debugging complex multi-agent handoffs.
+- **Action-to-Prompt Mapping**: Connect every tool call back to the specific instruction or prompt that initiated it.
+- **Post-Mortem Readiness**: Ensure all agent "thought processes" and actions are available for human audit if a system failure occurs.
 
 ### 2. Task Decomposition
 
-* **The Slogan**: "One agent, one task, one prompt."
-* **One-Shot Focus**: Structure goals so they can be completed from a single instruction without requiring back-and-forth dialogue.
-* **Success Correlation**: Recognize that agent success rates increase exponentially as the granularity of the task increases.
-* **Elimination of Epics**: Never assign a broad feature to an agent; break the work into tiny, verifiable functional units.
+- **The Slogan**: "One agent, one task, one prompt."
+- **One-Shot Focus**: Structure goals so they can be completed from a single instruction without requiring back-and-forth dialogue.
+- **Success Correlation**: Recognize that agent success rates increase exponentially as the granularity of the task increases.
+- **Elimination of Epics**: Never assign a broad feature to an agent; break the work into tiny, verifiable functional units.
 
 ### 3. The "Pit of Success"
 
-* **Tokens as Fine-Tuning**: Understand that the code in an agent's context window acts as immediate "training" for the model.
-* **Recursive Quality**: Clean code in the repository biases the agent toward generating clean code; slop breeds more slop.
-* **Contextual Guardrails**: Only provide the highest-quality examples and documentation within the agent's context window.
-* **Pattern Bias**: Force the agent toward the "pit of success" by surrounding it with the architectural patterns you want it to mirror.
+- **Tokens as Fine-Tuning**: Understand that the code in an agent's context window acts as immediate "training" for the model.
+- **Recursive Quality**: Clean code in the repository biases the agent toward generating clean code; slop breeds more slop.
+- **Contextual Guardrails**: Only provide the highest-quality examples and documentation within the agent's context window.
+- **Pattern Bias**: Force the agent toward the "pit of success" by surrounding it with the architectural patterns you want it to mirror.
 
 ### 4. Zero-Ambiguity Specs
 
-* **No Inference Allowed**: Write specifications that leave absolutely nothing to the agent's imagination or interpretation.
-* **Granular Specifics**: Always include exact file names, line numbers, and expected method signatures.
-* **Technical Vision**: Use the spec as a formal bridge between your mental vision and the agent's technical execution.
-* **Snippet Inclusion**: Provide reference code snippets directly within the spec to define the required implementation style.
+- **No Inference Allowed**: Write specifications that leave absolutely nothing to the agent's imagination or interpretation.
+- **Granular Specifics**: Always include exact file names, line numbers, and expected method signatures.
+- **Technical Vision**: Use the spec as a formal bridge between your mental vision and the agent's technical execution.
+- **Snippet Inclusion**: Provide reference code snippets directly within the spec to define the required implementation style.
 
 ### 5. Multi-Agent Swarms
 
-* **Chain of Command**: Organize agents into hierarchical roles such as Coordinator, Lead, Scout, Build, and Review.
-* **Gated Handoffs**: Require every agent to pass 100% of quality gates before its work is handed off to the next agent in the chain.
-* **Orchestration Logic**: Utilize a "Coordinator" agent to handle high-level decomposition and task assignment.
-* **Dedicated Reviewers**: Assign specific agents the sole role of reviewing work and checking for errors made by other agents.
+- **Chain of Command**: Organize agents into hierarchical roles such as Coordinator, Lead, Scout, Build, and Review.
+- **Gated Handoffs**: Require every agent to pass 100% of quality gates before its work is handed off to the next agent in the chain.
+- **Orchestration Logic**: Utilize a "Coordinator" agent to handle high-level decomposition and task assignment.
+- **Dedicated Reviewers**: Assign specific agents the sole role of reviewing work and checking for errors made by other agents.
 
 ### 6. Agent Scope
 
-* **File Boundaries**: Explicitly define which files an agent can edit and which it can only view.
-* **Constraint Focus**: Train agents to ignore irrelevant issues or bugs found outside of their assigned territory.
-* **Architectural Layering**: Clearly demarcate the "world" an agent lives in to prevent it from wandering into unrelated system layers.
-* **Scope Isolation**: Ensure the agent understands that its task is strictly limited to the provided scope, regardless of external complexity.
+- **File Boundaries**: Explicitly define which files an agent can edit and which it can only view.
+- **Constraint Focus**: Train agents to ignore irrelevant issues or bugs found outside of their assigned territory.
+- **Architectural Layering**: Clearly demarcate the "world" an agent lives in to prevent it from wandering into unrelated system layers.
+- **Scope Isolation**: Ensure the agent understands that its task is strictly limited to the provided scope, regardless of external complexity.
 
 ### 7. Standardization (Process)
 
-* **Zero Surprises**: Standardize agent output formats and naming conventions so human developers know exactly what to expect.
-* **Predictable Tooling**: Enforce a uniform method for how all agents interact with external APIs and the local file system.
-* **Human Decision Points**: Define clear triggers that require the agent to stop and notify the human developer.
-* **Prompt Architecture**: Maintain a consistent prompt structure across the entire engineering team to ensure behavior remains uniform.
+- **Zero Surprises**: Standardize agent output formats and naming conventions so human developers know exactly what to expect.
+- **Predictable Tooling**: Enforce a uniform method for how all agents interact with external APIs and the local file system.
+- **Human Decision Points**: Define clear triggers that require the agent to stop and notify the human developer.
+- **Prompt Architecture**: Maintain a consistent prompt structure across the entire engineering team to ensure behavior remains uniform.
 
 ---
 
-**Next Steps**: Would you like me to help you draft a **"Zero-Ambiguity Spec"** for one of your current TypeScript projects based on these guidelines?
+**Next Steps**: Apply these guidelines by drafting a **"Zero-Ambiguity Spec"** for a current TypeScript project. Start with a single well-scoped feature and validate agent output against the quality gates defined above.

--- a/docs/research/1.anti-slop.md
+++ b/docs/research/1.anti-slop.md
@@ -1,0 +1,124 @@
+# Comprehensive Guide to Agentic Engineering: The Anti-Slop Framework
+
+This document serves as the definitive manual for managing AI agents in production-grade software environments, based on the high-performance patterns used by top-tier engineers. The goal of this framework is to eliminate "slop"—low-quality, AI-generated technical debt—and ensure that agentic output meets or exceeds human standards.
+
+---
+
+## I. The Core Philosophy
+
+Before implementing tools, a fundamental mindset shift must occur:
+
+* **LLM Code $\neq$ Slop**: High-quality code is possible if you treat agent output as an engineering problem rather than a model limitation.
+* **The Recovery Loop**: Never manually fix bad agent output. Follow these steps:
+
+1. **Diagnose**: Identify why the agent failed (e.g., poor prompt, lack of context).
+2. **Reset**: Scrap the run and delete the bad code entirely.
+3. **Fix**: Update the underlying system (the spec, the prompt, or the tool).
+4. **Rerun**: Execute the agent again from scratch to verify the fix.
+
+---
+
+## II. Tier 1: Infrastructure & Tooling
+
+These systems provide the physical boundaries and safety nets required to run multiple agents simultaneously.
+
+### 1. Hooks
+
+* **Custom Harnesses**: Wrap agents in specific execution environments to capture granular logs of every action.
+* **Pre-commit Validation**: Use automated hooks to trigger linting and test suites the moment an agent attempts to commit code.
+* **Destructive Change Prevention**: Implement dry-run hooks that analyze potential impact before changes are finalized.
+* **First Layer of Defense**: Treat hooks as the mandatory checkpoint for all inbound and outbound agent data.
+
+### 2. Quality Gates
+
+* **Strictest Possible Rules**: Configure linting and type-checking (e.g., TypeScript strict mode) to the maximum level of severity.
+* **Binary Pass Rates**: Enforce a strict requirement where 100% of tests must pass before an agent's work can proceed.
+* **Standard Alignment**: Sync all automated gates with existing project standards to prevent architectural drift.
+* **Automated Rejection**: Design the system to instantly fail and reset an agent run if a single gate is breached.
+
+### 3. Testing
+
+* **Anti-Mocking Philosophy**: Adhere to the rule: "Never mock what you can use for real" to ensure true verification.
+* **Coverage Thresholds**: Set mandatory code coverage targets that all agent-generated features must meet.
+* **Immediate Failure Resolution**: If an agent writes a failing test, it must resolve the error immediately or the run is scrapped.
+* **Real-World Verification**: Ensure tests exercise actual integrated code paths rather than isolated, hallucinated logic.
+
+### 4. Standardization
+
+* **Centralized Tracking**: Mandate that all agents report to a single source of truth for task and issue management.
+* **Unified Learning Repositories**: Store all agent insights and "learnings" in one location to prevent documentation fragmentation.
+* **Predictable Review Workflows**: Standardize whether code is reviewed by a human via PR or by a secondary "Review Agent."
+* **Work Location Uniformity**: Define exactly which directories and file structures agents are permitted to operate within.
+
+### 5. Per-Agent Isolation
+
+* **Worktree Usage**: Leverage `git worktrees` to give every agent a completely isolated directory for its operations.
+* **Conflict Avoidance**: Ensure agents working in parallel cannot overwrite or interfere with one another's file changes.
+* **Sandbox Environments**: Restrict agent tool calls to secure sandboxes to prevent side effects on the primary system.
+* **Safety Principle**: Operate under the axiom that "an isolated agent is a safe agent," especially during large-scale swarms.
+
+### 6. Hard Blocks
+
+* **Command Blacklisting**: Explicitly disable high-risk commands like `git push` to prevent unverified code from hitting remote.
+* **Role-Based Permissions**: Restrict agents to specific capabilities; for example, "Scout" agents should be read-only.
+* **Minimalist Toolsets**: Limit an agent's available tools to only what is strictly required for its current decomposed task.
+* **Behavioral Enforcement**: Use hard blocks to instantly stop an agent if it attempts to wander outside its predefined task.
+
+---
+
+## III. Tier 2: Strategic Techniques
+
+These patterns manage the "intelligence" and focus of the agents to ensure correct logic.
+
+### 1. Traceability
+
+* **Attribution Mapping**: Log exactly which agent made which specific change to the codebase.
+* **Temporal Sequencing**: Record the timing of changes to assist in debugging complex multi-agent handoffs.
+* **Action-to-Prompt Mapping**: Connect every tool call back to the specific instruction or prompt that initiated it.
+* **Post-Mortem Readiness**: Ensure all agent "thought processes" and actions are available for human audit if a system failure occurs.
+
+### 2. Task Decomposition
+
+* **The Slogan**: "One agent, one task, one prompt."
+* **One-Shot Focus**: Structure goals so they can be completed from a single instruction without requiring back-and-forth dialogue.
+* **Success Correlation**: Recognize that agent success rates increase exponentially as the granularity of the task increases.
+* **Elimination of Epics**: Never assign a broad feature to an agent; break the work into tiny, verifiable functional units.
+
+### 3. The "Pit of Success"
+
+* **Tokens as Fine-Tuning**: Understand that the code in an agent's context window acts as immediate "training" for the model.
+* **Recursive Quality**: Clean code in the repository biases the agent toward generating clean code; slop breeds more slop.
+* **Contextual Guardrails**: Only provide the highest-quality examples and documentation within the agent's context window.
+* **Pattern Bias**: Force the agent toward the "pit of success" by surrounding it with the architectural patterns you want it to mirror.
+
+### 4. Zero-Ambiguity Specs
+
+* **No Inference Allowed**: Write specifications that leave absolutely nothing to the agent's imagination or interpretation.
+* **Granular Specifics**: Always include exact file names, line numbers, and expected method signatures.
+* **Technical Vision**: Use the spec as a formal bridge between your mental vision and the agent's technical execution.
+* **Snippet Inclusion**: Provide reference code snippets directly within the spec to define the required implementation style.
+
+### 5. Multi-Agent Swarms
+
+* **Chain of Command**: Organize agents into hierarchical roles such as Coordinator, Lead, Scout, Build, and Review.
+* **Gated Handoffs**: Require every agent to pass 100% of quality gates before its work is handed off to the next agent in the chain.
+* **Orchestration Logic**: Utilize a "Coordinator" agent to handle high-level decomposition and task assignment.
+* **Dedicated Reviewers**: Assign specific agents the sole role of reviewing work and checking for errors made by other agents.
+
+### 6. Agent Scope
+
+* **File Boundaries**: Explicitly define which files an agent can edit and which it can only view.
+* **Constraint Focus**: Train agents to ignore irrelevant issues or bugs found outside of their assigned territory.
+* **Architectural Layering**: Clearly demarcate the "world" an agent lives in to prevent it from wandering into unrelated system layers.
+* **Scope Isolation**: Ensure the agent understands that its task is strictly limited to the provided scope, regardless of external complexity.
+
+### 7. Standardization (Process)
+
+* **Zero Surprises**: Standardize agent output formats and naming conventions so human developers know exactly what to expect.
+* **Predictable Tooling**: Enforce a uniform method for how all agents interact with external APIs and the local file system.
+* **Human Decision Points**: Define clear triggers that require the agent to stop and notify the human developer.
+* **Prompt Architecture**: Maintain a consistent prompt structure across the entire engineering team to ensure behavior remains uniform.
+
+---
+
+**Next Steps**: Would you like me to help you draft a **"Zero-Ambiguity Spec"** for one of your current TypeScript projects based on these guidelines?

--- a/docs/research/2.agent-design-patterns.md
+++ b/docs/research/2.agent-design-patterns.md
@@ -12,23 +12,23 @@ The fundamental trade-off in agent design is between **flexibility** and **contr
 
 These patterns define the physical organization of how agents and tools interact.
 
-* **Single Agent Pattern**
-* **Reasoning-Centric Execution**: The agent receives a set of tools and must figure out the sequence of steps required to fulfill a goal autonomously.
-* **Simplified Implementation**: Ideal for straightforward tasks where the logic can be contained within a single system instruction and a few tool definitions.
-* **Determinism Weakness**: As tasks grow, the agent may fail to follow multi-step logic perfectly due to the non-deterministic nature of LLMs.
-* **Scaling Limitations**: Fails when "prompt bloating" occurs—massive instructions often lead to hallucinations or tool-calling errors.
+- **Single Agent Pattern**
+- **Reasoning-Centric Execution**: The agent receives a set of tools and must figure out the sequence of steps required to fulfill a goal autonomously.
+- **Simplified Implementation**: Ideal for straightforward tasks where the logic can be contained within a single system instruction and a few tool definitions.
+- **Determinism Weakness**: As tasks grow, the agent may fail to follow multi-step logic perfectly due to the non-deterministic nature of LLMs.
+- **Scaling Limitations**: Fails when "prompt bloating" occurs—massive instructions often lead to hallucinations or tool-calling errors.
 
-* **Sequential Agent Pattern**
-* **Assembly Line Structure**: Operates on a fixed order of operations where specialized agents handle specific parts of a task in a chain.
-* **Input-Output Chaining**: The direct results of an upstream agent are injected as the context for the downstream agent.
-* **High Control & Reliability**: By restricting the agent's "world" to one specific step, the developer ensures predictable behavior for repeatable workflows.
-* **Inflexible Execution**: The rigid nature of the chain means the system cannot easily adapt to dynamic changes that require skipping or reordering steps.
+- **Sequential Agent Pattern**
+- **Assembly Line Structure**: Operates on a fixed order of operations where specialized agents handle specific parts of a task in a chain.
+- **Input-Output Chaining**: The direct results of an upstream agent are injected as the context for the downstream agent.
+- **High Control & Reliability**: By restricting the agent's "world" to one specific step, the developer ensures predictable behavior for repeatable workflows.
+- **Inflexible Execution**: The rigid nature of the chain means the system cannot easily adapt to dynamic changes that require skipping or reordering steps.
 
-* **Parallel Agent Pattern**
-* **Concurrent Execution**: Multiple specialized agents (e.g., Museum Finder, Concert Finder) kick off independent searches at the exact same time.
-* **Latency Minimization**: Drastically reduces the "total time to response" compared to waiting for a sequential chain to finish step-by-step.
-* **Independent Subtasks**: Best utilized for tasks that have no dependencies on each other's outputs.
-* **Resource & Cost Overhead**: Running several agents simultaneously increases token consumption and design complexity.
+- **Parallel Agent Pattern**
+- **Concurrent Execution**: Multiple specialized agents (e.g., Museum Finder, Concert Finder) kick off independent searches at the exact same time.
+- **Latency Minimization**: Drastically reduces the "total time to response" compared to waiting for a sequential chain to finish step-by-step.
+- **Independent Subtasks**: Best utilized for tasks that have no dependencies on each other's outputs.
+- **Resource & Cost Overhead**: Running several agents simultaneously increases token consumption and design complexity.
 
 ---
 
@@ -36,38 +36,41 @@ These patterns define the physical organization of how agents and tools interact
 
 These are the strategic methods used to manage information flow and optimize performance.
 
-* **Task Decomposition**
-* **Specialized Agent Roles**: Breaking a general "Trip Planner" into narrow roles like "Food Finder" and "Transportation Specialist."
-* **Logic Isolation**: Preventing prompt confusion by giving each agent its own unique system instructions and restricted tool access.
-* **Complexity Reduction**: Solving a large problem by managing several smaller, highly achievable sub-goals.
-* **Focused System Instructions**: Replacing one massive, error-prone prompt with several small, precise instructions.
+- **Task Decomposition**
+- **Specialized Agent Roles**: Breaking a general "Trip Planner" into narrow roles like "Food Finder" and "Transportation Specialist."
+- **Logic Isolation**: Preventing prompt confusion by giving each agent its own unique system instructions and restricted tool access.
+- **Complexity Reduction**: Solving a large problem by managing several smaller, highly achievable sub-goals.
+- **Focused System Instructions**: Replacing one massive, error-prone prompt with several small, precise instructions.
 
-* **State Management (Shared Session State)**
-* **Shared Scratchpad**: A central data store where agents can read from and write to, preserving the context of the entire run.
-* **Short-Term Memory**: Allows the system to "remember" what the first agent discovered so the second agent can act upon it.
-* **Dynamic Variable Injection**: Using curly braces `{}` in prompts to automatically pull specific values from the session state.
-* **Context Preservation**: Ensures that even in complex swarms, the "current state" of the project is never lost between handoffs.
+- **State Management (Shared Session State)**
+- **Shared Scratchpad**: A central data store where agents can read from and write to, preserving the context of the entire run.
+- **Short-Term Memory**: Allows the system to "remember" what the first agent discovered so the second agent can act upon it.
+- **Dynamic Variable Injection**: Using curly braces `{}` in prompts to automatically pull specific values from the session state.
+- **Context Preservation**: Ensures that even in complex swarms, the "current state" of the project is never lost between handoffs.
 
-* **Aggregation & Synthesis**
-* **The Aggregator Agent**: A final sequential step that runs after parallel tasks to gather and unify disparate data points.
-* **Cohesive Plan Generation**: Synthesizing raw data (e.g., three separate search results) into a single, user-friendly trip plan.
-* **Conflict Resolution**: Identifying and resolving overlaps or contradictions between the outputs of parallel agents.
-* **Final Delivery Formatting**: Ensuring the end result feels like a human-curated response rather than a series of disconnected lists.
+- **Aggregation & Synthesis**
+- **The Aggregator Agent**: A final sequential step that runs after parallel tasks to gather and unify disparate data points.
+- **Cohesive Plan Generation**: Synthesizing raw data (e.g., three separate search results) into a single, user-friendly trip plan.
+- **Conflict Resolution**: Identifying and resolving overlaps or contradictions between the outputs of parallel agents.
+- **Final Delivery Formatting**: Ensuring the end result feels like a human-curated response rather than a series of disconnected lists.
 
-* **Tracing & Debugging**
-* **Web UI Tracing**: Using visual tools to watch the agent's internal reasoning and tool-calling chain in real-time.
-* **Logic Verification**: Identifying exactly where an agent "lost the thread" in a multi-step process by examining the trace logs.
-* **State Monitoring**: Using a dedicated "Session State Tab" to inspect the variables being passed between agents.
-* **Performance Auditing**: Analyzing the latency of individual agents within a parallel swarm to optimize the overall workflow.
+- **Tracing & Debugging**
+- **Web UI Tracing**: Using visual tools to watch the agent's internal reasoning and tool-calling chain in real-time.
+- **Logic Verification**: Identifying exactly where an agent "lost the thread" in a multi-step process by examining the trace logs.
+- **State Monitoring**: Using a dedicated "Session State Tab" to inspect the variables being passed between agents.
+- **Performance Auditing**: Analyzing the latency of individual agents within a parallel swarm to optimize the overall workflow.
 
 ---
 
 ### **Summary Table: Choosing a Pattern**
 
-| Pattern | Control | Flexibility | Latency | Complexity |
-| --- | --- | --- | --- | --- |
-| **Single** | Low | High | Medium | Low |
-| **Sequential** | High | Low | High | Medium |
-| **Parallel** | Medium | Medium | Low | High |
+| Pattern        | Control | Flexibility | Latency | Complexity |
+| -------------- | ------- | ----------- | ------- | ---------- |
+| **Single**     | Low     | High        | Medium  | Low        |
+| **Sequential** | High    | Low         | High    | Medium     |
+| **Parallel**   | Medium  | Medium      | Low     | High       |
 
-Would you like me to create a **Python or TypeScript code snippet** demonstrating how to implement the **Sequential vs. Parallel handoff** logic using these patterns?
+### Further Work
+
+- Implement Sequential vs. Parallel handoff logic in TypeScript using these patterns.
+- Benchmark latency and token cost trade-offs across pattern combinations.

--- a/docs/research/2.agent-design-patterns.md
+++ b/docs/research/2.agent-design-patterns.md
@@ -1,0 +1,73 @@
+# AI Agent Design Patterns
+
+This analysis provides a meticulous breakdown of the **AI Agent Design Patterns** presented by Google Cloud Tech. The framework focuses on the evolution from single-agent systems to sophisticated multi-agent architectures using the Agent Development Kit (ADK).
+
+### **The Core Philosophy: Reasoning vs. Structure**
+
+The fundamental trade-off in agent design is between **flexibility** and **control**. While a single agent relies on the model's internal reasoning to solve problems, multi-agent patterns introduce structural guardrails to ensure reliability in complex, non-deterministic workflows.
+
+---
+
+### **Tier 1: Architectural Patterns (The Infrastructure)**
+
+These patterns define the physical organization of how agents and tools interact.
+
+* **Single Agent Pattern**
+* **Reasoning-Centric Execution**: The agent receives a set of tools and must figure out the sequence of steps required to fulfill a goal autonomously.
+* **Simplified Implementation**: Ideal for straightforward tasks where the logic can be contained within a single system instruction and a few tool definitions.
+* **Determinism Weakness**: As tasks grow, the agent may fail to follow multi-step logic perfectly due to the non-deterministic nature of LLMs.
+* **Scaling Limitations**: Fails when "prompt bloating" occurs—massive instructions often lead to hallucinations or tool-calling errors.
+
+* **Sequential Agent Pattern**
+* **Assembly Line Structure**: Operates on a fixed order of operations where specialized agents handle specific parts of a task in a chain.
+* **Input-Output Chaining**: The direct results of an upstream agent are injected as the context for the downstream agent.
+* **High Control & Reliability**: By restricting the agent's "world" to one specific step, the developer ensures predictable behavior for repeatable workflows.
+* **Inflexible Execution**: The rigid nature of the chain means the system cannot easily adapt to dynamic changes that require skipping or reordering steps.
+
+* **Parallel Agent Pattern**
+* **Concurrent Execution**: Multiple specialized agents (e.g., Museum Finder, Concert Finder) kick off independent searches at the exact same time.
+* **Latency Minimization**: Drastically reduces the "total time to response" compared to waiting for a sequential chain to finish step-by-step.
+* **Independent Subtasks**: Best utilized for tasks that have no dependencies on each other's outputs.
+* **Resource & Cost Overhead**: Running several agents simultaneously increases token consumption and design complexity.
+
+---
+
+### **Tier 2: Design Techniques (The Strategy)**
+
+These are the strategic methods used to manage information flow and optimize performance.
+
+* **Task Decomposition**
+* **Specialized Agent Roles**: Breaking a general "Trip Planner" into narrow roles like "Food Finder" and "Transportation Specialist."
+* **Logic Isolation**: Preventing prompt confusion by giving each agent its own unique system instructions and restricted tool access.
+* **Complexity Reduction**: Solving a large problem by managing several smaller, highly achievable sub-goals.
+* **Focused System Instructions**: Replacing one massive, error-prone prompt with several small, precise instructions.
+
+* **State Management (Shared Session State)**
+* **Shared Scratchpad**: A central data store where agents can read from and write to, preserving the context of the entire run.
+* **Short-Term Memory**: Allows the system to "remember" what the first agent discovered so the second agent can act upon it.
+* **Dynamic Variable Injection**: Using curly braces `{}` in prompts to automatically pull specific values from the session state.
+* **Context Preservation**: Ensures that even in complex swarms, the "current state" of the project is never lost between handoffs.
+
+* **Aggregation & Synthesis**
+* **The Aggregator Agent**: A final sequential step that runs after parallel tasks to gather and unify disparate data points.
+* **Cohesive Plan Generation**: Synthesizing raw data (e.g., three separate search results) into a single, user-friendly trip plan.
+* **Conflict Resolution**: Identifying and resolving overlaps or contradictions between the outputs of parallel agents.
+* **Final Delivery Formatting**: Ensuring the end result feels like a human-curated response rather than a series of disconnected lists.
+
+* **Tracing & Debugging**
+* **Web UI Tracing**: Using visual tools to watch the agent's internal reasoning and tool-calling chain in real-time.
+* **Logic Verification**: Identifying exactly where an agent "lost the thread" in a multi-step process by examining the trace logs.
+* **State Monitoring**: Using a dedicated "Session State Tab" to inspect the variables being passed between agents.
+* **Performance Auditing**: Analyzing the latency of individual agents within a parallel swarm to optimize the overall workflow.
+
+---
+
+### **Summary Table: Choosing a Pattern**
+
+| Pattern | Control | Flexibility | Latency | Complexity |
+| --- | --- | --- | --- | --- |
+| **Single** | Low | High | Medium | Low |
+| **Sequential** | High | Low | High | Medium |
+| **Parallel** | Medium | Medium | Low | High |
+
+Would you like me to create a **Python or TypeScript code snippet** demonstrating how to implement the **Sequential vs. Parallel handoff** logic using these patterns?

--- a/docs/research/3.domain-specific-memory.md
+++ b/docs/research/3.domain-specific-memory.md
@@ -1,0 +1,89 @@
+This analysis covers the video **"Why Your AI Agents Keep Forgetting (And How To Fix That)"** by Vasilije Markovic, founder of Cognee. The presentation focuses on solving the "statelessness" of AI agents by implementing a sophisticated memory layer that goes beyond traditional Retrieval-Augmented Generation (RAG).
+
+### **The Core Philosophy: Beyond Static RAG**
+
+The fundamental problem identified is that agents are typically stateless, forgetting previous sessions and struggling with the ambiguity of traditional vector searches (e.g., confusing "Apple" the fruit with "Apple" the company). Cognee proposes a **memory representation layer** that uses neuroscience-inspired approaches to create a structured knowledge graph on top of vector embeddings.
+
+---
+
+### **Tier 1: Architectural Patterns & Tooling**
+
+These are the technical components and frameworks required to build a persistent memory system for agents.
+
+* **Cognify (Transformation Engine) [[09:34](http://www.youtube.com/watch?v=E8-is7OH3UI&t=574)]**
+* **Graph-Vector Synthesis**: Automatically transforms unstructured data into a dual representation: a graph for relationships and a vector for semantic search.
+* **Standardized Pipeline**: Uses a default `cognify` command to handle complex data ingestion without manual feature engineering.
+* **Pydantic Integration**: Leverages Python and Pydantic structures to simplify the definition of how data should be represented in the memory layer.
+* **Feedback Injection**: Allows the transformation process to be adjusted based on agent feedback, refining how memory is stored over time.
+
+* **Memory Isolation Layers (Note Sets) [[11:43](http://www.youtube.com/watch?v=E8-is7OH3UI&t=703)]**
+* **Domain Partitioning**: Divides the global knowledge base into specific "Note Sets" (e.g., Billing, Support, Contracts) to prevent context pollution.
+* **Role-Based Access**: Restricts agents to only the memory domains relevant to their function, mimicking professional data security.
+* **Soft and Hard Isolation**: Supports both logical separation for reasoning and physical separation for data privacy between different agent sessions.
+* **Retrieval Optimization**: Speeds up queries by limiting the search space to a specific "layer" of the memory representation.
+
+* **Hybrid Storage (Graph + Vector) [[04:16](http://www.youtube.com/watch?v=E8-is7OH3UI&t=256)]**
+* **Neo4j Integration**: Uses graph databases (primarily Neo4j) to map complex ontologies and relationships that vectors cannot capture.
+* **Relational Mapping**: Connects disparate data silos—like SQL records and PDF documents—into a single, traversable knowledge graph.
+* **Contextual Anchoring**: Uses the graph to provide "anchors" for vector searches, ensuring an agent understands the specific entity it is retrieving.
+* **Persistent State**: Stores agent reasoning and session info permanently in the graph so it can be resumed weeks later.
+
+---
+
+### **Tier 2: Strategic Techniques**
+
+These are the methods used to manage agent intelligence, focus, and memory updates.
+
+* **Agentic Feedback Loops [[04:52](http://www.youtube.com/watch?v=E8-is7OH3UI&t=292)]**
+* **Self-Refining Memory**: Agents provide feedback on the data they find, which is used to update and "clean" the memory layer for future runs.
+* **Correction of Ambiguity**: If an agent discovers an error in reconciliation, it feeds that back into the system to adjust future retrieval patterns.
+* **Dynamic Instruction Updates**: Agents can store "learnings" (e.g., "I should search for invoice status first") that act as instructions for subsequent agents.
+* **Automated Ontology Adjustment**: Uses agent reasoning to suggest changes to the underlying data structure (ontology) based on real-world usage.
+
+* **The Supervisor/Coordinator Pattern [[08:14](http://www.youtube.com/watch?v=E8-is7OH3UI&t=494)]**
+* **Signal Stitching**: A supervisor agent (e.g., "Entitlement Agent") reviews findings from specialized "Billing" and "Support" agents to form a final conclusion.
+* **Independent Investigation**: Specialized agents perform deep dives into their specific memory domains without being overwhelmed by the full data set.
+* **Outcome Hardcoding**: (Used in demos) Establishing clear expected outcomes for sub-agents to verify that the supervisor's reasoning remains sound.
+* **Global vs. Local View**: The supervisor maintains a global context, while sub-agents focus on local, domain-specific problem-solving.
+
+* **Temporal and Time-Aware Retrieval [[14:53](http://www.youtube.com/watch?v=E8-is7OH3UI&t=893)]**
+* **Timeline Auditing**: Maintains a time-organized audit stream of events, allowing agents to understand the sequence of failures.
+* **Time-Specific Retrievers**: Uses specialized algorithms that prioritize or interpret data based on when it was recorded (e.g., "What changed in the last hour?").
+* **Event Emission Tracking**: Tracks specific status changes over time to identify where asynchronous systems (like Stripe and production DBs) fell out of sync.
+* **Historical Context Restoration**: Allows an agent to "travel back" in the memory state to understand the conditions leading to a current incident.
+
+---
+
+### **Final Compilation: The Cognitive Memory Framework**
+
+# Cognitive Memory for AI Agents
+
+## 1. The Memory Layer Architecture
+
+**Core Concept**: Moving from stateless RAG to a persistent, neuroscience-inspired memory layer.
+
+* **Mechanism**: A dual-store (Neo4j for graphs and Vector for semantics) managed by the **Cognify** transformation pipeline.
+* **Key Command**: `cognify` turns unstructured data into actionable, multi-layer memory.
+
+## 2. Structured Domain Management
+
+**Core Concept**: Using "Note Sets" to prevent context collision and enforce data permissions.
+
+* **Mechanism**: Partitioning memory into domains like "Finance," "Legal," or "User Sessions."
+* **Benefit**: Reduces hallucinations by ensuring agents only "see" relevant, authorized information.
+
+## 3. Dynamic Knowledge Refinement
+
+**Core Concept**: Using agent feedback to evolve the system's memory continuously.
+
+* **Mechanism**: Agents log feedback that automatically triggers updates to the knowledge graph and search indices.
+* **Benefit**: The system gets smarter over time as it learns from past failures and human-agent interactions.
+
+**Summary Table**
+
+| Component | Function | Advantage |
+| --- | --- | --- |
+| **Cognify** | Data Transformation | Automated graph creation |
+| **Note Sets** | Memory Partitioning | Security & focus |
+| **Feedback Loop** | System Learning | Continuous accuracy improvement |
+| **Knowledge Graph** | Relationship Mapping | Contextual awareness |

--- a/packages/luca-framework/src/state/ledger.ts
+++ b/packages/luca-framework/src/state/ledger.ts
@@ -7,7 +7,6 @@
  *
  * @module luca-state/ledger
  */
-import orderBy from "lodash/orderBy";
 import { z } from "zod";
 // node:fs/promises retained: Bun.write() does not support append mode.
 // appendFile is the correct API for the append-only ledger pattern.

--- a/src/hooks/scripts/session-start.sh
+++ b/src/hooks/scripts/session-start.sh
@@ -349,20 +349,23 @@ fi
 
 # Step 9: Output summary if anything was created
 if [ -n "$CREATED" ]; then
-  HOOK_CREATED="$CREATED" HOOK_NOTES_MSG="$NOTES_MSG" bun -e "
+  HOOK_CREATED="$CREATED" HOOK_NOTES_MSG="$NOTES_MSG" HOOK_STALE_MSG="$STALE_SESSION_MSG" bun -e "
     const created = process.env.HOOK_CREATED.trim();
     const notesSuffix = process.env.HOOK_NOTES_MSG || '';
+    const staleSuffix = process.env.HOOK_STALE_MSG ? ' ' + process.env.HOOK_STALE_MSG : '';
     const files = created.split(' ').filter(Boolean);
-    const msg = '[Luca] Initialized .planning/ directory. Created: ' + files.join(', ') + notesSuffix;
+    const msg = '[Luca] Initialized .planning/ directory. Created: ' + files.join(', ') + notesSuffix + staleSuffix;
     const isClaude = !!process.env.CLAUDE_PROJECT_DIR;
     const output = isClaude
       ? { systemMessage: msg }
       : { followup_message: msg };
     process.stdout.write(JSON.stringify(output));
   "
-elif [ -n "$NOTES_MSG" ]; then
-  HOOK_NOTES_MSG="$NOTES_MSG" bun -e "
-    const msg = '[Luca]' + process.env.HOOK_NOTES_MSG;
+elif [ -n "$NOTES_MSG" ] || [ -n "$STALE_SESSION_MSG" ]; then
+  HOOK_NOTES_MSG="$NOTES_MSG" HOOK_STALE_MSG="$STALE_SESSION_MSG" bun -e "
+    const notesSuffix = process.env.HOOK_NOTES_MSG || '';
+    const staleSuffix = process.env.HOOK_STALE_MSG ? ' ' + process.env.HOOK_STALE_MSG : '';
+    const msg = '[Luca]' + notesSuffix + staleSuffix;
     const isClaude = !!process.env.CLAUDE_PROJECT_DIR;
     const output = isClaude
       ? { systemMessage: msg }

--- a/src/shared/__helpers/memory-context-builder.ts
+++ b/src/shared/__helpers/memory-context-builder.ts
@@ -16,7 +16,7 @@ import { z } from "zod";
 /**
  * Configuration schema for buildMemoryContextBlock.
  *
- * Uses snake_case internally since this is not an API payload.
+ * Uses camelCase since this is an internal schema, not an API payload.
  */
 export const MemoryContextConfigSchema = z.object({
   agentName: z.string().min(1),

--- a/src/shared/__helpers/session-digest.ts
+++ b/src/shared/__helpers/session-digest.ts
@@ -9,7 +9,6 @@
  */
 
 import { z } from "zod";
-import uniq from "lodash/uniq";
 
 // ─── Schema ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Remove unused `lodash/uniq` import from `session-digest.ts`
- Remove unused `lodash/orderBy` import from `ledger.ts`
- Fix misleading "snake_case" JSDoc in `memory-context-builder.ts` (schema fields are camelCase)
- Wire `STALE_SESSION_MSG` into `session-start.sh` JSON summary output (was computed but never included)
- Add brainstorm and research docs from parallel agent session (6 files)

## Test plan

- [x] `bunx --bun tsc --noEmit` passes clean
- [ ] Verify session-start hook outputs stale session message when marker exists
- [ ] Confirm no runtime regressions from removed unused imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)