### PR TITLE
docs: add intent-first response directive for meta-prompting

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -13,6 +13,12 @@
 - **Session ID:** fc759ad3-6102-4681-9b0c-738bbed69a23
 - **GitHub Issue:** #63
 
+## Appetite
+
+- **Level:** Medium
+- **Token Ceiling:** 100000
+- **Context Budget:** 50%
+
 ## Progress
 
 ```
@@ -48,4 +54,4 @@ _State updated: 2026-03-09 — v3.3.0 milestone complete, ready for next_
 
 ---
 
-_State generated from machine snapshot at 2026-03-10T15:24:34.293Z_
+_State generated from machine snapshot at 2026-03-10T17:36:32.392Z_

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,23 @@
 
 These cover 90% of what agents need; see “Cursor Cloud specific instructions” below for more detail.
 
+## Intent-First Response
+
+Before responding to a request, consider what the user **actually needs**, not just what they literally asked. Then provide the best possible answer for that underlying need.
+
+**When to surface follow-up questions:** Not every response needs them. Use this checklist:
+
+| Signal                                                                                       | Action                                                                                         |
+| -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Request is ambiguous or underspecified                                                       | Ask clarifying questions **before** acting                                                     |
+| Multiple valid approaches exist with meaningful trade-offs                                   | Present the chosen approach, note alternatives, suggest questions that would refine the choice |
+| The request hints at a deeper problem (e.g., asking for a workaround when a root fix exists) | Address both the literal ask and the underlying issue; suggest follow-ups to confirm direction |
+| Request is clear and straightforward                                                         | Just answer it — no follow-up questions needed                                                 |
+
+**Format when follow-ups apply:** Append a short “Questions to go deeper” section (2-4 questions max) at the end of the response. These should help the user explore dimensions they may not have considered — architectural implications, edge cases, alternative approaches, or scope decisions.
+
+**Do not** pad every response with follow-up questions. The goal is signal, not noise.
+
 ## Development Setup
 
 **Prerequisite:** Bun (v1.0+). Node.js 20+ is useful but not required for core workflows.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,4 +42,8 @@ test("hello world", () => {
   - Bun is required (repo uses `bun.lock` and `bunfig.toml`). If Bun is missing, install it before running any commands.
   - No `.env` is required for core development; Jira adapter env vars are optional.
 
+## Response approach
+
+See "Intent-First Response" in `AGENTS.md`. In short: think about what the user actually needs, not just what they asked. Suggest follow-up questions only when the request is ambiguous, has meaningful trade-offs, or hints at a deeper problem — not on every response.
+
 For anything more detailed than this, prefer the main `README.md`, `AGENTS.md`, and the docs under `docs/` rather than expanding this file.


### PR DESCRIPTION
Adds guidance for AI agents to consider the user's underlying need, not
just the literal request. Includes a decision matrix for when follow-up
questions add value vs when they're noise.

https://claude.ai/code/session_01S5KZ48Mmj3Q8F4nB1MPbgc