### PR TITLE
chore(release): bump package version to 5.3.0

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -55,4 +55,4 @@ _State updated: 2026-03-14 — v4.4.0 milestone archived, state reset for next m
 
 ---
 
-_State generated from machine snapshot at 2026-03-18T13:25:32.785Z_
+_State generated from machine snapshot at 2026-03-18T13:38:02.112Z_

--- a/packages/luca-framework/package.json
+++ b/packages/luca-framework/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alecsibilia/luca-framework",
   "description": "Luca - Agentic development framework for AI-powered development workflows",
-  "version": "2.4.0",
+  "version": "5.3.0",
   "bin": {
     "luca": "./bin/luca.js",
     "luca-bridge": "./bin/luca-bridge.js"


### PR DESCRIPTION
## Summary

- Bumps `packages/luca-framework/package.json` version from `2.4.0` to `5.3.0`
- Aligns npm package version with git tag `v5.3.0`
- Fixes CI publish failure: `npm publish` was rejected because `2.4.0` already exists on the registry

## Test plan

- [x] Version field updated in package.json
- [ ] CI publish succeeds after merge + re-tag

After merging, re-tag `v5.3.0` on the merge commit to trigger CI:
```bash
git tag -a v5.3.0 -m "v5.3.0 — Dogfood via Global Install" && git push origin v5.3.0
```