### PR TITLE
fix(init): update MuninnDB download to use official install script

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -55,4 +55,4 @@ _State updated: 2026-03-14 — v4.4.0 milestone archived, state reset for next m
 
 ---
 
-_State generated from machine snapshot at 2026-03-18T13:38:02.112Z_
+_State generated from machine snapshot at 2026-03-18T14:53:20.506Z_

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -55,4 +55,4 @@ _State updated: 2026-03-14 — v4.4.0 milestone archived, state reset for next m
 
 ---
 
-_State generated from machine snapshot at 2026-03-18T14:59:08.486Z_
+_State generated from machine snapshot at 2026-03-18T16:00:54.832Z_

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -55,4 +55,4 @@ _State updated: 2026-03-14 — v4.4.0 milestone archived, state reset for next m
 
 ---
 
-_State generated from machine snapshot at 2026-03-18T14:53:20.506Z_
+_State generated from machine snapshot at 2026-03-18T14:59:08.486Z_

--- a/packages/luca-framework/package.json
+++ b/packages/luca-framework/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alecsibilia/luca-framework",
   "description": "Luca - Agentic development framework for AI-powered development workflows",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "bin": {
     "luca": "./bin/luca.js",
     "luca-bridge": "./bin/luca-bridge.js"

--- a/packages/luca-framework/src/utils/muninndb-download.ts
+++ b/packages/luca-framework/src/utils/muninndb-download.ts
@@ -25,13 +25,13 @@ const MUNINNDB_DOWNLOAD_BASE =
   process.env.MUNINNDB_DOWNLOAD_BASE ?? "https://muninndb.com";
 
 /**
- * GitHub repository slug for MuninnDB.
+ * Trusted hosts for the install script URL.
  *
- * Override via `MUNINNDB_REPO_SLUG` environment variable if the repository
- * has moved or you want to point at a fork.
+ * When `MUNINNDB_INSTALL_SCRIPT_URL` is overridden via env var, the URL
+ * hostname must match one of these entries. Set `MUNINNDB_ALLOW_UNTRUSTED=1`
+ * to bypass this restriction (e.g. for local development servers).
  */
-const MUNINNDB_REPO_SLUG =
-  process.env.MUNINNDB_REPO_SLUG ?? "scrypster/muninndb";
+const TRUSTED_INSTALL_HOSTS = new Set(["muninndb.com", "www.muninndb.com"]);
 
 /**
  * URL to the official MuninnDB install script.
@@ -141,11 +141,16 @@ async function findInstalledBinary(
     return preferredPath;
   }
 
-  // Check common install locations
+  // Check common install locations (only include HOME-based paths when HOME is defined)
+  const home = process.env.HOME;
   const commonPaths = [
-    join(process.env.HOME ?? "", ".local", "bin", MUNINNDB_BINARY_NAME),
+    ...(home
+      ? [
+          join(home, ".local", "bin", MUNINNDB_BINARY_NAME),
+          join(home, "bin", MUNINNDB_BINARY_NAME),
+        ]
+      : []),
     join("/usr", "local", "bin", MUNINNDB_BINARY_NAME),
-    join(process.env.HOME ?? "", "bin", MUNINNDB_BINARY_NAME),
   ];
 
   for (const candidate of commonPaths) {
@@ -154,15 +159,10 @@ async function findInstalledBinary(
     }
   }
 
-  // Fallback: use `which` to find it on PATH
-  try {
-    const result = await Bun.$`which ${MUNINNDB_BINARY_NAME}`.quiet();
-    const path = result.stdout.toString().trim();
-    if (path && existsSync(path)) {
-      return path;
-    }
-  } catch {
-    // `which` failed -- binary not on PATH
+  // Fallback: use Bun.which() to find it on PATH (more portable than shelling out)
+  const whichResult = Bun.which(MUNINNDB_BINARY_NAME);
+  if (whichResult && existsSync(whichResult)) {
+    return whichResult;
   }
 
   return null;
@@ -213,6 +213,24 @@ export async function downloadMuninndbBinary(
     });
   }
 
+  // Validate the URL hostname is trusted (prevents arbitrary script execution via env override)
+  if (process.env.MUNINNDB_ALLOW_UNTRUSTED !== "1") {
+    try {
+      const parsed = new URL(MUNINNDB_INSTALL_SCRIPT_URL);
+      if (!TRUSTED_INSTALL_HOSTS.has(parsed.hostname)) {
+        return MuninndbInstallResultSchema.parse({
+          success: false,
+          binaryPath: null,
+          error:
+            `Install script URL hostname "${parsed.hostname}" is not in the trusted hosts list. ` +
+            `Set MUNINNDB_ALLOW_UNTRUSTED=1 to bypass this check.`,
+        });
+      }
+    } catch {
+      // URL parsing already validated above
+    }
+  }
+
   // Resolve platform (early check before running install script)
   const platformResult = resolvePlatformTarget();
   if (!platformResult.success) {
@@ -233,10 +251,38 @@ export async function downloadMuninndbBinary(
       `Installing MuninnDB via official install script (${platformResult.target})...`,
     );
 
-    // Run the official install script.
-    // The script handles platform detection, binary download, and verification.
-    const installResult =
-      await Bun.$`curl -sSL ${MUNINNDB_INSTALL_SCRIPT_URL} | sh`.quiet();
+    // Download the install script first, then execute it.
+    // This avoids the curl|sh pipefail issue where curl failures are masked
+    // by the shell's exit code. Download separately so HTTP errors fail fast.
+    const curlResult = await Bun.$`curl -sSL -f ${MUNINNDB_INSTALL_SCRIPT_URL}`
+      .nothrow()
+      .quiet();
+
+    if (curlResult.exitCode !== 0) {
+      const stderr = curlResult.stderr.toString().trim();
+      const errorMsg = stderr
+        ? `Failed to download install script (exit ${curlResult.exitCode}): ${stderr}`
+        : `Failed to download install script (exit ${curlResult.exitCode}) from ${MUNINNDB_INSTALL_SCRIPT_URL}`;
+      spinner?.stop(`Install failed: ${errorMsg}`);
+      return MuninndbInstallResultSchema.parse({
+        success: false,
+        binaryPath: null,
+        error: errorMsg,
+      });
+    }
+
+    const scriptContent = curlResult.stdout.toString();
+    if (!scriptContent.trim()) {
+      spinner?.stop("Install failed: downloaded script is empty");
+      return MuninndbInstallResultSchema.parse({
+        success: false,
+        binaryPath: null,
+        error: "Downloaded install script is empty.",
+      });
+    }
+
+    // Execute the downloaded script
+    const installResult = await Bun.$`sh -c ${scriptContent}`.nothrow().quiet();
 
     if (installResult.exitCode !== 0) {
       const stderr = installResult.stderr.toString().trim();

--- a/packages/luca-framework/src/utils/muninndb-download.ts
+++ b/packages/luca-framework/src/utils/muninndb-download.ts
@@ -1,6 +1,5 @@
 import * as p from "@clack/prompts";
-import { createHash } from "crypto";
-import { unlinkSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join } from "pathe";
 
 import { getLucaHomePaths } from "./luca-home";
@@ -16,100 +15,37 @@ import type {
 } from "./muninndb-schemas";
 
 /**
- * Base URL for MuninnDB GitHub release assets.
+ * Base URL for the MuninnDB website.
  *
  * Override via `MUNINNDB_DOWNLOAD_BASE` environment variable for testing
  * or pointing at a private mirror. The default points to the official
- * MuninnDB GitHub releases page.
+ * MuninnDB website.
  */
 const MUNINNDB_DOWNLOAD_BASE =
-  process.env.MUNINNDB_DOWNLOAD_BASE ??
-  "https://github.com/nicholasgasior/muninn/releases/download";
+  process.env.MUNINNDB_DOWNLOAD_BASE ?? "https://muninndb.com";
 
 /**
- * Default MuninnDB version to download when none is specified.
- *
- * Override via `MUNINNDB_VERSION` environment variable.
- */
-const MUNINNDB_DEFAULT_VERSION = process.env.MUNINNDB_VERSION ?? "latest";
-
-/**
- * GitHub repository slug for MuninnDB releases.
+ * GitHub repository slug for MuninnDB.
  *
  * Override via `MUNINNDB_REPO_SLUG` environment variable if the repository
  * has moved or you want to point at a fork.
  */
 const MUNINNDB_REPO_SLUG =
-  process.env.MUNINNDB_REPO_SLUG ?? "nicholasgasior/muninn";
+  process.env.MUNINNDB_REPO_SLUG ?? "scrypster/muninndb";
 
 /**
- * Module-level cache for the resolved latest release tag.
+ * URL to the official MuninnDB install script.
  *
- * Once resolved, the tag is cached for the lifetime of the process
- * to avoid repeated GitHub API calls.
+ * The install script handles platform detection, downloading the correct
+ * binary, and placing it in the appropriate location. Override via
+ * `MUNINNDB_INSTALL_SCRIPT_URL` environment variable for testing or
+ * pointing at a custom install script.
+ *
+ * @see https://github.com/scrypster/muninndb
  */
-let cachedLatestTag: string | null = null;
-
-/**
- * Resolve the `"latest"` MuninnDB version to an actual GitHub release tag.
- *
- * Queries the GitHub Releases API for the latest release of `MUNINNDB_REPO_SLUG`
- * and returns the `tag_name` (e.g. `"v0.5.0"`). The result is cached at
- * module scope so subsequent calls within the same process return instantly
- * without a network round-trip.
- *
- * On any failure (network error, rate limit, 404, malformed response),
- * returns `null` so the caller can fall back to the redirect-based
- * download URL pattern.
- *
- * @returns The release tag string (e.g. `"v0.5.0"`), or `null` on failure.
- *
- * @example
- * ```typescript
- * const tag = await resolveLatestReleaseTag();
- * if (tag) {
- *   console.log(`Latest release: ${tag}`); // "v0.5.0"
- * } else {
- *   console.log("Could not resolve latest tag, using fallback URL");
- * }
- * ```
- */
-async function resolveLatestReleaseTag(): Promise<string | null> {
-  if (cachedLatestTag) {
-    return cachedLatestTag;
-  }
-
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 5_000);
-
-  try {
-    const response = await fetch(
-      `https://api.github.com/repos/${MUNINNDB_REPO_SLUG}/releases/latest`,
-      {
-        headers: { Accept: "application/vnd.github+json" },
-        signal: controller.signal,
-      },
-    );
-
-    if (!response.ok) {
-      return null;
-    }
-
-    const data = (await response.json()) as { tag_name?: string };
-    const tagName = data.tag_name;
-
-    if (!tagName || typeof tagName !== "string") {
-      return null;
-    }
-
-    cachedLatestTag = tagName;
-    return tagName;
-  } catch {
-    return null;
-  } finally {
-    clearTimeout(timeoutId);
-  }
-}
+const MUNINNDB_INSTALL_SCRIPT_URL =
+  process.env.MUNINNDB_INSTALL_SCRIPT_URL ??
+  `${MUNINNDB_DOWNLOAD_BASE}/install.sh`;
 
 /**
  * Validate that a download URL uses the HTTPS scheme.
@@ -123,10 +59,10 @@ async function resolveLatestReleaseTag(): Promise<string | null> {
  *
  * @example
  * ```typescript
- * const result = validateDownloadUrl("https://github.com/releases/v1/binary");
+ * const result = validateDownloadUrl("https://muninndb.com/install.sh");
  * // { valid: true }
  *
- * const bad = validateDownloadUrl("http://evil.com/binary");
+ * const bad = validateDownloadUrl("http://evil.com/install.sh");
  * // { valid: false, error: "Download URL must use HTTPS. Got: http:" }
  * ```
  */
@@ -174,157 +110,81 @@ export function resolvePlatformForDownload():
 }
 
 /**
- * Build the download URL for a MuninnDB binary release asset.
- *
- * Constructs a URL of the form:
- * `{base}/{version}/muninndb-{target}`
- *
- * **Important:** This function is synchronous and cannot resolve the
- * `"latest"` version to an actual tag. Callers should resolve `"latest"`
- * via {@link resolveLatestReleaseTag} before calling this function.
- * Passing `"latest"` directly will produce a URL with `/download/latest/`
- * which is not a valid GitHub release URL pattern.
- *
- * The base URL can be overridden via `MUNINNDB_DOWNLOAD_BASE` env var.
- * When overridden, the constructed URL is validated to use HTTPS.
- * Throws if the resulting URL uses a non-HTTPS scheme or is malformed.
- *
- * @param target - Validated platform target (e.g. "darwin-arm64").
- * @param version - Release version tag (e.g. "v0.5.0"). Should be a
- *   concrete tag, not `"latest"`.
- * @returns The fully-qualified download URL.
- * @throws {Error} If the resolved URL does not use HTTPS.
- *
- * @see resolveLatestReleaseTag — resolves `"latest"` to a concrete tag
- *   via the GitHub API before calling this function.
- *
- * @example
- * ```typescript
- * const url = buildDownloadUrl("darwin-arm64", "v0.5.0");
- * // "https://github.com/nicholasgasior/muninn/releases/download/v0.5.0/muninndb-darwin-arm64"
- * ```
- */
-export function buildDownloadUrl(
-  target: MuninndbPlatformTarget,
-  version: string = MUNINNDB_DEFAULT_VERSION,
-): string {
-  const url = `${MUNINNDB_DOWNLOAD_BASE}/${version}/${MUNINNDB_BINARY_NAME}-${target}`;
-
-  const validation = validateDownloadUrl(url);
-  if (!validation.valid) {
-    throw new Error(validation.error);
-  }
-
-  return url;
-}
-
-/**
  * Options for `downloadMuninndbBinary()`.
  */
 export interface DownloadMuninndbOptions {
-  /** Release version tag to download (default: env var or "latest"). */
-  version?: string;
-  /** Whether to show a @clack/prompts spinner during download. */
+  /** Whether to show a @clack/prompts spinner during install. */
   showProgress?: boolean;
-  /**
-   * Skip SHA-256 checksum verification of the downloaded binary.
-   *
-   * When `true`, the checksum sidecar file is not fetched and the binary
-   * is accepted without verification. Can also be set via the
-   * `MUNINNDB_SKIP_CHECKSUM` environment variable.
-   *
-   * @default false
-   */
-  skipChecksum?: boolean;
 }
 
 /**
- * Fetch the SHA-256 checksum sidecar file for a binary URL.
+ * Locate the installed muninndb binary after the install script runs.
  *
- * Expects the sidecar at `{binaryUrl}.sha256` in standard `sha256sum`
- * output format: `<hex-digest>  <filename>` (or just the hex digest).
- * Extracts and returns the first whitespace-delimited field as the digest.
+ * Checks common install locations and uses `which` as a fallback.
+ * Returns the absolute path to the binary if found, or `null` if not.
  *
- * @param binaryUrl - The URL of the binary whose sidecar to fetch.
- * @returns The expected hex digest string, or `null` if the sidecar is unavailable.
+ * @param preferredDir - The preferred target directory (e.g. `~/.luca/bin/`).
+ * @returns Absolute path to the binary, or `null` if not found.
  *
  * @example
  * ```typescript
- * const digest = await fetchChecksumSidecar("https://example.com/muninndb-darwin-arm64");
- * // "a1b2c3..." or null
+ * const path = await findInstalledBinary("/home/user/.luca/bin");
+ * if (path) console.log(`Found at: ${path}`);
  * ```
  */
-export async function fetchChecksumSidecar(
-  binaryUrl: string,
+async function findInstalledBinary(
+  preferredDir: string,
 ): Promise<string | null> {
-  const sidecarUrl = `${binaryUrl}.sha256`;
-
-  try {
-    const response = await fetch(sidecarUrl);
-    if (!response.ok) {
-      return null;
-    }
-
-    const text = (await response.text()).trim();
-    // sha256sum format: "<hex>  <filename>" -- extract first field
-    const digest = text.split(/\s+/)[0];
-    if (!digest || !/^[a-fA-F0-9]{64}$/.test(digest)) {
-      return null;
-    }
-
-    return digest.toLowerCase();
-  } catch {
-    return null;
+  // Check preferred location first
+  const preferredPath = join(preferredDir, MUNINNDB_BINARY_NAME);
+  if (existsSync(preferredPath)) {
+    return preferredPath;
   }
+
+  // Check common install locations
+  const commonPaths = [
+    join(process.env.HOME ?? "", ".local", "bin", MUNINNDB_BINARY_NAME),
+    join("/usr", "local", "bin", MUNINNDB_BINARY_NAME),
+    join(process.env.HOME ?? "", "bin", MUNINNDB_BINARY_NAME),
+  ];
+
+  for (const candidate of commonPaths) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Fallback: use `which` to find it on PATH
+  try {
+    const result = await Bun.$`which ${MUNINNDB_BINARY_NAME}`.quiet();
+    const path = result.stdout.toString().trim();
+    if (path && existsSync(path)) {
+      return path;
+    }
+  } catch {
+    // `which` failed -- binary not on PATH
+  }
+
+  return null;
 }
 
 /**
- * Verify the SHA-256 checksum of a binary file on disk.
+ * Download and install the MuninnDB binary using the official install script.
  *
- * Reads the file using `Bun.file()`, computes its SHA-256 hash via
- * `crypto.createHash()`, and compares the hex digest against the expected value.
+ * Runs the MuninnDB install script from `https://muninndb.com/install.sh`
+ * (or a custom URL via `MUNINNDB_INSTALL_SCRIPT_URL` env var). The install
+ * script handles platform detection, binary download, and integrity
+ * verification internally.
  *
- * @param binaryPath - Absolute path to the binary file to verify.
- * @param expectedHash - The expected lowercase hex SHA-256 digest.
- * @returns `true` if the computed hash matches the expected hash.
- *
- * @example
- * ```typescript
- * const valid = await verifyBinaryChecksum("/path/to/muninndb", "a1b2c3...");
- * if (!valid) console.error("Checksum mismatch!");
- * ```
- */
-export async function verifyBinaryChecksum(
-  binaryPath: string,
-  expectedHash: string,
-): Promise<boolean> {
-  const file = Bun.file(binaryPath);
-  const buffer = await file.arrayBuffer();
-  const computed = createHash("sha256")
-    .update(Buffer.from(buffer))
-    .digest("hex");
-  return computed === expectedHash.toLowerCase();
-}
-
-/**
- * Download the MuninnDB binary for the current platform.
- *
- * Resolves the platform target, constructs the download URL (with HTTPS
- * validation), fetches the binary via `fetch()`, writes it to
- * `{targetDir}/muninndb` via `Bun.write()`, and sets executable permissions
- * (0o755) via `Bun.$`.
- *
- * After downloading, verifies the binary against a SHA-256 sidecar file
- * (`{url}.sha256`). On checksum mismatch the binary is deleted and a
- * failure result is returned. If the sidecar is unavailable, the download
- * fails unless `skipChecksum` is set (option or `MUNINNDB_SKIP_CHECKSUM`
- * env var).
+ * After the script completes, the function locates the installed binary
+ * and optionally copies it to `targetDir` if it was installed elsewhere.
  *
  * All errors are caught and returned in the result object -- this function
  * never throws.
  *
- * @param targetDir - Directory to write the binary to (default: `~/.luca/bin/`).
- * @param options - Download options (version, progress display, skipChecksum).
+ * @param targetDir - Directory to ensure the binary is in (default: `~/.luca/bin/`).
+ *   If the install script places the binary elsewhere, it will be copied here.
+ * @param options - Install options (progress display).
  * @returns A validated `MuninndbInstallResult` with success/failure details.
  *
  * @example
@@ -341,11 +201,19 @@ export async function downloadMuninndbBinary(
   targetDir?: string,
   options: DownloadMuninndbOptions = {},
 ): Promise<MuninndbInstallResult> {
-  const { version, showProgress = true } = options;
-  const skipChecksum =
-    options.skipChecksum ?? process.env.MUNINNDB_SKIP_CHECKSUM === "1";
+  const { showProgress = true } = options;
 
-  // Resolve platform
+  // Validate the install script URL uses HTTPS
+  const urlValidation = validateDownloadUrl(MUNINNDB_INSTALL_SCRIPT_URL);
+  if (!urlValidation.valid) {
+    return MuninndbInstallResultSchema.parse({
+      success: false,
+      binaryPath: null,
+      error: urlValidation.error,
+    });
+  }
+
+  // Resolve platform (early check before running install script)
   const platformResult = resolvePlatformTarget();
   if (!platformResult.success) {
     return MuninndbInstallResultSchema.parse({
@@ -357,65 +225,25 @@ export async function downloadMuninndbBinary(
 
   // Resolve target directory
   const dir = targetDir ?? getLucaHomePaths().bin;
-  const binaryPath = join(dir, MUNINNDB_BINARY_NAME);
-
-  // Resolve effective version: when "latest", try API tag resolution first
-  const requestedVersion = version ?? MUNINNDB_DEFAULT_VERSION;
-  let effectiveVersion = requestedVersion;
-  let usingRedirectFallback = false;
-
-  if (requestedVersion === "latest") {
-    const resolvedTag = await resolveLatestReleaseTag();
-    if (resolvedTag) {
-      effectiveVersion = resolvedTag;
-    } else {
-      // API resolution failed — will use redirect-based URL pattern below
-      usingRedirectFallback = true;
-    }
-  }
-
-  // Build and validate URL (catches non-HTTPS schemes from env override)
-  let url: string;
-  try {
-    if (usingRedirectFallback) {
-      // GitHub supports: /releases/latest/download/{asset}
-      // Construct from MUNINNDB_REPO_SLUG to avoid fragile string replacement
-      // on MUNINNDB_DOWNLOAD_BASE which may not contain "/releases/download"
-      const redirectBase = `https://github.com/${MUNINNDB_REPO_SLUG}/releases/latest/download`;
-      url = `${redirectBase}/${MUNINNDB_BINARY_NAME}-${platformResult.target}`;
-
-      const validation = validateDownloadUrl(url);
-      if (!validation.valid) {
-        throw new Error(validation.error);
-      }
-    } else {
-      url = buildDownloadUrl(platformResult.target, effectiveVersion);
-    }
-  } catch (err) {
-    const errorMsg =
-      err instanceof Error ? err.message : "Invalid download URL";
-    return MuninndbInstallResultSchema.parse({
-      success: false,
-      binaryPath: null,
-      error: errorMsg,
-    });
-  }
-
-  // When using the redirect fallback, skip checksum since the sidecar
-  // may not be available at the redirect location
-  const effectiveSkipChecksum = skipChecksum || usingRedirectFallback;
 
   const spinner = showProgress ? p.spinner() : null;
 
   try {
-    spinner?.start(`Downloading MuninnDB (${platformResult.target})...`);
+    spinner?.start(
+      `Installing MuninnDB via official install script (${platformResult.target})...`,
+    );
 
-    // Fetch binary
-    const response = await fetch(url);
+    // Run the official install script.
+    // The script handles platform detection, binary download, and verification.
+    const installResult =
+      await Bun.$`curl -sSL ${MUNINNDB_INSTALL_SCRIPT_URL} | sh`.quiet();
 
-    if (!response.ok) {
-      const errorMsg = `HTTP ${response.status} from ${url}`;
-      spinner?.stop(`Download failed: ${errorMsg}`);
+    if (installResult.exitCode !== 0) {
+      const stderr = installResult.stderr.toString().trim();
+      const errorMsg = stderr
+        ? `Install script failed (exit ${installResult.exitCode}): ${stderr}`
+        : `Install script failed with exit code ${installResult.exitCode}`;
+      spinner?.stop(`Install failed: ${errorMsg}`);
       return MuninndbInstallResultSchema.parse({
         success: false,
         binaryPath: null,
@@ -423,91 +251,50 @@ export async function downloadMuninndbBinary(
       });
     }
 
-    // Write binary to disk
-    const arrayBuffer = await response.arrayBuffer();
-    await Bun.write(binaryPath, arrayBuffer);
+    // Locate the installed binary
+    const foundPath = await findInstalledBinary(dir);
 
-    // Set executable permissions
-    await Bun.$`chmod 755 ${binaryPath}`.quiet();
-
-    // --- Binary file-size verification (REQ-02) ---
-    const downloadedFile = Bun.file(binaryPath);
-    const fileSize = downloadedFile.size;
-    if (fileSize === 0) {
-      spinner?.stop("Download failed: binary is empty (0 bytes)");
-      try {
-        unlinkSync(binaryPath);
-      } catch {
-        // Best-effort cleanup
-      }
+    if (!foundPath) {
+      spinner?.stop("Install script succeeded but binary not found on system");
       return MuninndbInstallResultSchema.parse({
         success: false,
         binaryPath: null,
         error:
-          "Downloaded binary is empty (0 bytes). The release asset may be " +
-          "missing or the download was interrupted.",
+          "MuninnDB install script completed successfully but the binary " +
+          "could not be found. Check that the install script placed it in " +
+          "a standard location (~/.local/bin/, /usr/local/bin/, or ~/bin/).",
       });
     }
 
-    // --- Checksum verification (SEC-001) ---
-    if (!effectiveSkipChecksum) {
-      spinner?.message("Verifying checksum...");
-
-      const expectedHash = await fetchChecksumSidecar(url);
-
-      if (!expectedHash) {
-        // Sidecar unavailable -- fail unless explicitly skipped
-        spinner?.stop(
-          "Checksum verification failed: sidecar file not available",
-        );
-        try {
-          unlinkSync(binaryPath);
-        } catch {
-          // Best-effort cleanup
-        }
+    // If the binary was installed outside our preferred directory, copy it there
+    const preferredPath = join(dir, MUNINNDB_BINARY_NAME);
+    if (foundPath !== preferredPath) {
+      try {
+        const sourceFile = Bun.file(foundPath);
+        await Bun.write(preferredPath, sourceFile);
+        await Bun.$`chmod 755 ${preferredPath}`.quiet();
+      } catch (copyErr) {
+        // Binary exists at foundPath but we could not copy it -- still usable
+        spinner?.stop(`MuninnDB installed at ${foundPath}`);
         return MuninndbInstallResultSchema.parse({
-          success: false,
-          binaryPath: null,
-          error:
-            "Checksum sidecar (.sha256) not available for this release. " +
-            "Set MUNINNDB_SKIP_CHECKSUM=1 to bypass verification.",
-        });
-      }
-
-      const checksumValid = await verifyBinaryChecksum(
-        binaryPath,
-        expectedHash,
-      );
-
-      if (!checksumValid) {
-        // Mismatch -- delete the binary and fail
-        try {
-          unlinkSync(binaryPath);
-        } catch {
-          // Best-effort cleanup
-        }
-        spinner?.stop("Checksum verification failed: hash mismatch");
-        return MuninndbInstallResultSchema.parse({
-          success: false,
-          binaryPath: null,
-          error:
-            "SHA-256 checksum mismatch. The downloaded binary does not match " +
-            "the expected hash. The file has been deleted for safety.",
+          success: true,
+          binaryPath: foundPath,
+          error: null,
         });
       }
     }
 
-    spinner?.stop("MuninnDB downloaded and verified successfully");
+    spinner?.stop("MuninnDB installed successfully");
 
     return MuninndbInstallResultSchema.parse({
       success: true,
-      binaryPath,
+      binaryPath: preferredPath,
       error: null,
     });
   } catch (err) {
     const errorMsg =
-      err instanceof Error ? err.message : "Unknown download error";
-    spinner?.stop(`Download failed: ${errorMsg}`);
+      err instanceof Error ? err.message : "Unknown install error";
+    spinner?.stop(`Install failed: ${errorMsg}`);
 
     return MuninndbInstallResultSchema.parse({
       success: false,


### PR DESCRIPTION
## Summary

- Replaces incorrect MuninnDB binary download URL (`nicholasgasior/muninn`) with the official install script from `scrypster/muninndb`
- Uses `curl -sSL https://muninndb.com/install.sh | sh` per the [official docs](https://github.com/scrypster/muninndb)
- Bumps package version to `5.3.1` for patch release

## Changes

- `packages/luca-framework/src/utils/muninndb-download.ts`:
  - Updated `MUNINNDB_DOWNLOAD_BASE` to `https://muninndb.com`
  - Updated `MUNINNDB_REPO_SLUG` to `scrypster/muninndb`
  - Added `MUNINNDB_INSTALL_SCRIPT_URL` constant (`https://muninndb.com/install.sh`)
  - Replaced direct binary fetch with install script execution via `Bun.$`
  - Added `findInstalledBinary()` to locate binary after install
  - Removed manual version resolution, checksum verification (install script handles both)
- `packages/luca-framework/package.json`: version `5.3.0` → `5.3.1`

## Test plan

- [x] TypeScript type-check passes
- [ ] Run `luca init` on a fresh machine and verify MuninnDB downloads from the correct URL
- [ ] Verify `MUNINNDB_INSTALL_SCRIPT_URL` env override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)