### PR TITLE
fix(init): correct MuninnDB binary name from 'muninndb' to 'muninn'

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -55,4 +55,4 @@ _State updated: 2026-03-14 — v4.4.0 milestone archived, state reset for next m
 
 ---
 
-_State generated from machine snapshot at 2026-03-18T18:54:32.773Z_
+_State generated from machine snapshot at 2026-03-18T19:52:44.297Z_

--- a/packages/luca-framework/src/commands/init.ts
+++ b/packages/luca-framework/src/commands/init.ts
@@ -761,7 +761,7 @@ export const initCommand = defineCommand({
       }
     } else {
       readout.push(
-        "  Not running (start with `muninndb` or re-run `luca init`)",
+        "  Not running (start with `muninn start` or re-run `luca init`)",
       );
     }
 

--- a/packages/luca-framework/src/utils/doctor/checks/muninndb-health.ts
+++ b/packages/luca-framework/src/utils/doctor/checks/muninndb-health.ts
@@ -70,8 +70,8 @@ export const muninndbHealthCheck: DoctorCheck = {
         name: this.name,
         status: "warning",
         message: `Binary installed${versionSuffix}, service not running`,
-        fixCommand: "muninndb",
-        details: `Binary at ${binary.path}. Start the service with: muninndb`,
+        fixCommand: "muninn start",
+        details: `Binary at ${binary.path}. Start the service with: muninn start`,
       };
     }
 

--- a/packages/luca-framework/src/utils/muninndb-download.ts
+++ b/packages/luca-framework/src/utils/muninndb-download.ts
@@ -127,13 +127,16 @@ export interface DownloadMuninndbOptions {
  * @returns Absolute path to the binary mentioned in output, or `null`.
  */
 function extractPathFromOutput(stdout: string): string | null {
+  const binaryName = MUNINNDB_BINARY_NAME;
   const lines = stdout.split("\n");
   for (const line of lines) {
-    // Match patterns like: "Installed to /some/path/muninndb"
-    // or "MuninnDB installed: /some/path/muninndb"
-    const installMatch = line.match(
-      /(?:installed?\s+(?:to|at|in)?|saved?\s+(?:to|at|in)?|binary\s+(?:at|in)?)\s+(\S*muninndb\S*)/i,
+    // Match patterns like: "Installed to /some/path/muninn"
+    // or "MuninnDB installed: /some/path/muninn"
+    const installPattern = new RegExp(
+      `(?:installed?\\s+(?:to|at|in)?|saved?\\s+(?:to|at|in)?|binary\\s+(?:at|in)?)\\s+(\\S*${binaryName}\\S*)`,
+      "i",
     );
+    const installMatch = line.match(installPattern);
     if (installMatch?.[1]) {
       const candidate = installMatch[1].replace(/['"]+/g, "");
       if (candidate.startsWith("/") && existsSync(candidate)) {
@@ -141,8 +144,9 @@ function extractPathFromOutput(stdout: string): string | null {
       }
     }
 
-    // Match any absolute path ending with /muninndb on its own
-    const pathMatch = line.match(/(\/\S*\/muninndb)(?:\s|$)/);
+    // Match any absolute path ending with /muninn on its own
+    const pathPattern = new RegExp(`(\\/\\S*\\/${binaryName})(?:\\s|$)`);
+    const pathMatch = line.match(pathPattern);
     if (pathMatch?.[1]) {
       const candidate = pathMatch[1].replace(/['"]+/g, "");
       if (existsSync(candidate)) {

--- a/packages/luca-framework/src/utils/muninndb-schemas.ts
+++ b/packages/luca-framework/src/utils/muninndb-schemas.ts
@@ -139,7 +139,7 @@ export function resolvePlatformTarget():
 export const MUNINNDB_DEFAULT_PORT = 8476;
 
 /** Default binary name. */
-export const MUNINNDB_BINARY_NAME = "muninndb";
+export const MUNINNDB_BINARY_NAME = "muninn";
 
 /**
  * Resolve the MuninnDB port from an explicit value, environment variable, or default.

--- a/packages/luca-framework/src/utils/muninndb-service.ts
+++ b/packages/luca-framework/src/utils/muninndb-service.ts
@@ -321,12 +321,12 @@ async function cleanStalePidfile(pidfilePath: string): Promise<void> {
  * Verify that a given PID belongs to a MuninnDB process.
  *
  * Uses `ps -p <pid> -o comm=` to retrieve the process command name and
- * checks whether it contains "muninndb" (case-insensitive). This prevents
+ * checks whether it contains "muninn" (case-insensitive). This prevents
  * sending signals to unrelated processes if the PID file is stale or
  * has been tampered with.
  *
  * @param pid - Process ID to verify.
- * @returns `true` if the process command name contains "muninndb".
+ * @returns `true` if the process command name contains "muninn".
  *
  * @example
  * ```typescript
@@ -339,7 +339,7 @@ async function verifyProcessIdentity(pid: number): Promise<boolean> {
   try {
     const result = await Bun.$`ps -p ${pid} -o comm=`.quiet();
     const comm = result.text().trim().toLowerCase();
-    return comm.includes("muninndb");
+    return comm.includes("muninn");
   } catch {
     // ps failed — process may not exist or command unavailable
     return false;


### PR DESCRIPTION
## Summary

- The official MuninnDB install script installs the binary as `muninn`, not `muninndb`
- `MUNINNDB_BINARY_NAME` was set to `"muninndb"`, causing `luca init` to report "binary not found" even after successful installation to `/usr/local/bin/muninn`
- Fixed the constant and all downstream references (regex patterns, process identity check, doctor/init user-facing messages)

## Changes

| File | Change |
|------|--------|
| `muninndb-schemas.ts` | `MUNINNDB_BINARY_NAME`: `"muninndb"` → `"muninn"` |
| `muninndb-download.ts` | `extractPathFromOutput` regex uses constant instead of hardcoded name |
| `muninndb-service.ts` | `verifyProcessIdentity` checks for `"muninn"` in process name |
| `doctor/checks/muninndb-health.ts` | Fix command: `muninndb` → `muninn start` |
| `commands/init.ts` | Summary message: `muninndb` → `muninn start` |

## Test plan

- [ ] Run `luca init` on clean machine — binary should be found at `/usr/local/bin/muninn`
- [ ] Run `luca doctor` — MuninnDB check should pass when `muninn` is installed
- [ ] `bunx --bun tsc --noEmit` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)