### PR TITLE
chore(release): bump package version to 5.3.3

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -55,4 +55,4 @@ _State updated: 2026-03-14 — v4.4.0 milestone archived, state reset for next m
 
 ---
 
-_State generated from machine snapshot at 2026-03-18T19:52:44.297Z_
+_State generated from machine snapshot at 2026-03-18T19:55:13.209Z_

--- a/packages/luca-framework/package.json
+++ b/packages/luca-framework/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alecsibilia/luca-framework",
   "description": "Luca - Agentic development framework for AI-powered development workflows",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "bin": {
     "luca": "./bin/luca.js",
     "luca-bridge": "./bin/luca-bridge.js"


### PR DESCRIPTION
## Summary

- Bump `@alecsibilia/luca-framework` version from 5.3.2 to 5.3.3

## Changes in this release

- fix(init): correct MuninnDB binary name from 'muninndb' to 'muninn' (#94)

## Post-merge

Tag `v5.3.3` and create GitHub release after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)