### PR TITLE
fix(init): broaden binary check and remove stale .cursor/luca references

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -55,4 +55,4 @@ _State updated: 2026-03-14 — v4.4.0 milestone archived, state reset for next m
 
 ---
 
-_State generated from machine snapshot at 2026-03-18T20:08:26.254Z_
+_State generated from machine snapshot at 2026-03-18T20:15:16.363Z_

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -55,4 +55,4 @@ _State updated: 2026-03-14 — v4.4.0 milestone archived, state reset for next m
 
 ---
 
-_State generated from machine snapshot at 2026-03-18T19:55:13.209Z_
+_State generated from machine snapshot at 2026-03-18T20:05:19.895Z_

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -55,4 +55,4 @@ _State updated: 2026-03-14 — v4.4.0 milestone archived, state reset for next m
 
 ---
 
-_State generated from machine snapshot at 2026-03-18T20:05:19.895Z_
+_State generated from machine snapshot at 2026-03-18T20:08:26.254Z_

--- a/packages/luca-framework/package.json
+++ b/packages/luca-framework/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alecsibilia/luca-framework",
   "description": "Luca - Agentic development framework for AI-powered development workflows",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "bin": {
     "luca": "./bin/luca.js",
     "luca-bridge": "./bin/luca-bridge.js"

--- a/packages/luca-framework/src/commands/update.ts
+++ b/packages/luca-framework/src/commands/update.ts
@@ -136,7 +136,7 @@ async function getNewFrameworkFiles(
     join(templatesDir, "framework"),
     newFiles,
     context,
-    join(".cursor", "luca"),
+    ".planning",
   );
 
   // Collect per-harness templates (agents, rules, skills, hooks, settings)
@@ -220,7 +220,7 @@ async function createBackup(
   manifest: LucaManifest,
   cwd: string,
 ): Promise<string> {
-  const backupDir = join(cwd, ".cursor", "luca", ".backup");
+  const backupDir = join(cwd, ".planning", ".backup");
 
   // Remove old backup if exists
   if (existsSync(backupDir)) {
@@ -274,7 +274,7 @@ async function handleConflicts(
 ): Promise<void> {
   if (conflicts.length === 0) return;
 
-  const conflictsDir = join(cwd, ".cursor", "luca", "conflicts");
+  const conflictsDir = join(cwd, ".planning", "conflicts");
   await mkdir(conflictsDir, { recursive: true });
 
   for (const conflict of conflicts) {

--- a/packages/luca-framework/src/commands/update.ts
+++ b/packages/luca-framework/src/commands/update.ts
@@ -44,7 +44,7 @@ import { VALID_PRESETS, getPresetDefaults } from "../utils/presets";
  * @param sourceDir - Template source directory
  * @param output - Map to write results into (relative path -> content)
  * @param context - EJS template context
- * @param destPrefix - Optional prefix prepended to output paths (e.g. '.cursor/luca')
+ * @param destPrefix - Optional prefix prepended to output paths (e.g. '.planning')
  */
 async function collectTemplateFiles(
   sourceDir: string,
@@ -265,7 +265,7 @@ async function restoreBackup(backupDir: string, cwd: string): Promise<void> {
 }
 
 /**
- * Write conflicts to .cursor/luca/conflicts/ directory.
+ * Write conflicts to .planning/conflicts/ directory.
  */
 async function handleConflicts(
   conflicts: FileComparison[],
@@ -828,9 +828,9 @@ Update Summary:
 
 Updated:    ${updated.length} files
 Skipped:    ${skipped.length} files (user modifications kept)
-Conflicts:  ${conflicted.length} files (saved to .cursor/luca/conflicts/)
+Conflicts:  ${conflicted.length} files (saved to .planning/conflicts/)
 
-${conflicted.length > 0 ? "Review conflicts in .cursor/luca/conflicts/ and resolve manually." : ""}
+${conflicted.length > 0 ? "Review conflicts in .planning/conflicts/ and resolve manually." : ""}
       `);
     } catch (error) {
       spinner.stop("Update failed");

--- a/packages/luca-framework/src/commands/vault-init.ts
+++ b/packages/luca-framework/src/commands/vault-init.ts
@@ -145,7 +145,7 @@ export const vaultInitCommand = defineCommand({
       logger.info(
         "To reinitialize from scratch (this will overwrite existing config):",
       );
-      logger.info("  rm -rf .planning/ .cursor/luca/ && bunx luca vault:init");
+      logger.info("  rm -rf .planning/ && luca vault:init");
       process.exit(1);
     }
 

--- a/packages/luca-framework/src/commands/vault-init.ts
+++ b/packages/luca-framework/src/commands/vault-init.ts
@@ -140,7 +140,7 @@ export const vaultInitCommand = defineCommand({
       logger.error("Luca is already installed in this project.");
       logger.info("");
       logger.info("To update to the latest version:");
-      logger.info("  bunx luca update");
+      logger.info("  luca update");
       logger.info("");
       logger.info(
         "To reinitialize from scratch (this will overwrite existing config):",

--- a/packages/luca-framework/src/utils/muninndb-download.ts
+++ b/packages/luca-framework/src/utils/muninndb-download.ts
@@ -7,6 +7,7 @@ import {
   resolvePlatformTarget,
   MuninndbInstallResultSchema,
   MUNINNDB_BINARY_NAME,
+  getCommonBinaryPaths,
 } from "./muninndb-schemas";
 
 import type {
@@ -192,21 +193,8 @@ async function findInstalledBinary(
     }
   }
 
-  // Check common install locations (only include HOME-based paths when HOME is defined)
-  const home = process.env.HOME;
-  const commonPaths = [
-    ...(home
-      ? [
-          join(home, ".local", "bin", MUNINNDB_BINARY_NAME),
-          join(home, "bin", MUNINNDB_BINARY_NAME),
-          // Tool-specific directories that install scripts commonly use
-          join(home, ".muninndb", "bin", MUNINNDB_BINARY_NAME),
-          join(home, ".muninndb", MUNINNDB_BINARY_NAME),
-          join(home, ".cargo", "bin", MUNINNDB_BINARY_NAME),
-        ]
-      : []),
-    join("/usr", "local", "bin", MUNINNDB_BINARY_NAME),
-  ];
+  // Check common install locations via shared helper
+  const commonPaths = getCommonBinaryPaths();
 
   for (const candidate of commonPaths) {
     if (existsSync(candidate)) {
@@ -221,6 +209,7 @@ async function findInstalledBinary(
   }
 
   // Last resort: limited find search in HOME directory (maxdepth 4 to keep it fast)
+  const home = process.env.HOME;
   if (home) {
     try {
       const findResult =

--- a/packages/luca-framework/src/utils/muninndb-health.ts
+++ b/packages/luca-framework/src/utils/muninndb-health.ts
@@ -5,6 +5,7 @@ import {
   MuninndbBinaryStatusSchema,
   MuninndbServiceStatusSchema,
   MUNINNDB_BINARY_NAME,
+  getCommonBinaryPaths,
   resolveMuninndbPort,
 } from "./muninndb-schemas";
 
@@ -42,18 +43,7 @@ export async function checkMuninndbBinary(
   const exists = await Bun.file(resolvedPath).exists();
   if (!exists) {
     // Search common install locations before reporting "not found"
-    const home = process.env.HOME;
-    const candidates = [
-      ...(home
-        ? [
-            join(home, ".local", "bin", MUNINNDB_BINARY_NAME),
-            join(home, "bin", MUNINNDB_BINARY_NAME),
-            join(home, ".muninndb", "bin", MUNINNDB_BINARY_NAME),
-            join(home, ".muninn", "bin", MUNINNDB_BINARY_NAME),
-          ]
-        : []),
-      join("/usr", "local", "bin", MUNINNDB_BINARY_NAME),
-    ];
+    const candidates = getCommonBinaryPaths();
 
     let found = false;
     for (const candidate of candidates) {

--- a/packages/luca-framework/src/utils/muninndb-health.ts
+++ b/packages/luca-framework/src/utils/muninndb-health.ts
@@ -35,18 +35,52 @@ import type {
 export async function checkMuninndbBinary(
   binaryPath?: string,
 ): Promise<MuninndbBinaryStatus> {
-  const resolvedPath =
-    binaryPath ?? join(getLucaHomePaths().bin, MUNINNDB_BINARY_NAME);
+  const preferredPath = join(getLucaHomePaths().bin, MUNINNDB_BINARY_NAME);
+  let resolvedPath = binaryPath ?? preferredPath;
 
-  // Check existence
+  // Check preferred location first, then fall back to common locations
   const exists = await Bun.file(resolvedPath).exists();
   if (!exists) {
-    return MuninndbBinaryStatusSchema.parse({
-      installed: false,
-      path: null,
-      version: null,
-      executable: false,
-    });
+    // Search common install locations before reporting "not found"
+    const home = process.env.HOME;
+    const candidates = [
+      ...(home
+        ? [
+            join(home, ".local", "bin", MUNINNDB_BINARY_NAME),
+            join(home, "bin", MUNINNDB_BINARY_NAME),
+            join(home, ".muninndb", "bin", MUNINNDB_BINARY_NAME),
+            join(home, ".muninn", "bin", MUNINNDB_BINARY_NAME),
+          ]
+        : []),
+      join("/usr", "local", "bin", MUNINNDB_BINARY_NAME),
+    ];
+
+    let found = false;
+    for (const candidate of candidates) {
+      if (await Bun.file(candidate).exists()) {
+        resolvedPath = candidate;
+        found = true;
+        break;
+      }
+    }
+
+    // Fallback: Bun.which()
+    if (!found) {
+      const whichResult = Bun.which(MUNINNDB_BINARY_NAME);
+      if (whichResult && (await Bun.file(whichResult).exists())) {
+        resolvedPath = whichResult;
+        found = true;
+      }
+    }
+
+    if (!found) {
+      return MuninndbBinaryStatusSchema.parse({
+        installed: false,
+        path: null,
+        version: null,
+        executable: false,
+      });
+    }
   }
 
   // Check executable permission

--- a/packages/luca-framework/src/utils/muninndb-schemas.ts
+++ b/packages/luca-framework/src/utils/muninndb-schemas.ts
@@ -1,3 +1,4 @@
+import { join } from "pathe";
 import { z } from "zod";
 
 import { checkPlatform } from "./prerequisites";
@@ -140,6 +141,33 @@ export const MUNINNDB_DEFAULT_PORT = 8476;
 
 /** Default binary name. */
 export const MUNINNDB_BINARY_NAME = "muninn";
+
+/**
+ * Common install locations to search for the MuninnDB binary.
+ *
+ * Used by both `checkMuninndbBinary()` (health check) and
+ * `findInstalledBinary()` (post-install search) to keep the
+ * search paths consistent. Returns only HOME-based paths when
+ * `process.env.HOME` is defined, plus `/usr/local/bin/`.
+ *
+ * @returns Array of absolute paths to check for the binary.
+ */
+export function getCommonBinaryPaths(): string[] {
+  const home = process.env.HOME;
+  return [
+    ...(home
+      ? [
+          join(home, ".local", "bin", MUNINNDB_BINARY_NAME),
+          join(home, "bin", MUNINNDB_BINARY_NAME),
+          join(home, ".muninndb", "bin", MUNINNDB_BINARY_NAME),
+          join(home, ".muninndb", MUNINNDB_BINARY_NAME),
+          join(home, ".muninn", "bin", MUNINNDB_BINARY_NAME),
+          join(home, ".cargo", "bin", MUNINNDB_BINARY_NAME),
+        ]
+      : []),
+    join("/usr", "local", "bin", MUNINNDB_BINARY_NAME),
+  ];
+}
 
 /**
  * Resolve the MuninnDB port from an explicit value, environment variable, or default.


### PR DESCRIPTION
## Summary

- **`checkMuninndbBinary()` now searches broadly**: Previously only checked `~/.luca/bin/muninn`. If the binary was already at `/usr/local/bin/muninn` (from a prior `muninn init`), it reported "not found" and triggered a redundant reinstall. Now searches `~/.local/bin/`, `~/bin/`, `~/.muninndb/bin/`, `~/.muninn/bin/`, `/usr/local/bin/`, and `Bun.which()` before giving up.
- **Removed stale `.cursor/luca/` references**: `vault-init` and `update` commands referenced `.cursor/luca/` paths from the pre-global-install era. Updated to use `.planning/` (the correct local project directory).

## Test plan

- [ ] Install muninn via `muninn init` (places binary at `/usr/local/bin/muninn`)
- [ ] Run `luca init` — should find existing binary without reinstalling
- [ ] Run `luca vault:init` in an already-initialized project — error message should reference `.planning/`, not `.cursor/luca/`
- [ ] `bunx --bun tsc --noEmit` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)