### PR TITLE
fix(init): correct API key env var, tour prefix, and global mode display

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -55,4 +55,4 @@ _State updated: 2026-03-14 — v4.4.0 milestone archived, state reset for next m
 
 ---
 
-_State generated from machine snapshot at 2026-03-18T20:15:16.363Z_
+_State generated from machine snapshot at 2026-03-18T20:53:30.032Z_

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -55,4 +55,4 @@ _State updated: 2026-03-14 — v4.4.0 milestone archived, state reset for next m
 
 ---
 
-_State generated from machine snapshot at 2026-03-18T20:53:30.032Z_
+_State generated from machine snapshot at 2026-03-18T21:06:55.728Z_

--- a/packages/luca-framework/package.json
+++ b/packages/luca-framework/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alecsibilia/luca-framework",
   "description": "Luca - Agentic development framework for AI-powered development workflows",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "bin": {
     "luca": "./bin/luca.js",
     "luca-bridge": "./bin/luca-bridge.js"

--- a/packages/luca-framework/src/commands/vault-init.ts
+++ b/packages/luca-framework/src/commands/vault-init.ts
@@ -252,7 +252,11 @@ export const vaultInitCommand = defineCommand({
         await writeVaultConfig(vaultResult.vaultName, configPath);
         p.log.success(`Vault name written to .planning/config.json`);
 
-        await writeApiKeyToEnv(vaultResult.apiKey, envPath);
+        await writeApiKeyToEnv(
+          vaultResult.apiKey,
+          envPath,
+          vaultResult.vaultName,
+        );
         p.log.success(`API key written to .env`);
 
         await ensureEnvInGitignore(cwd);

--- a/packages/luca-framework/src/commands/vault-init.ts
+++ b/packages/luca-framework/src/commands/vault-init.ts
@@ -293,7 +293,7 @@ export const vaultInitCommand = defineCommand({
       : `- ${harnessNames} (harness-specific files)`;
 
     const vaultStatus = vaultConfigured
-      ? `- .planning/config.json (vault: ${vaultName})\n- .env (MUNINN_API_KEY configured)`
+      ? `- .planning/config.json (vault: ${vaultName})\n- .env (MuninnDB API keys configured)`
       : "- MuninnDB vault: not configured (run interactively to set up)";
 
     logger.box(`

--- a/packages/luca-framework/src/utils/detect.ts
+++ b/packages/luca-framework/src/utils/detect.ts
@@ -62,16 +62,19 @@ export async function detectProjectContext(
     existsSync(join(cwd, "app")) ||
     existsSync(join(cwd, "lib"));
 
-  // Suggest first command based on project state
+  // Suggest first command hint based on project state.
+  // Uses {PREFIX} placeholder — resolved by tour.ts with the configured commandPrefix.
   const hasPlanning = existsSync(join(cwd, ".planning"));
   const hasReadme = await Bun.file(join(cwd, "README.md")).exists();
 
   if (hasReadme && !hasPlanning) {
-    context.suggestedFirstCommand = '/lu "help me understand this codebase"';
+    context.suggestedFirstCommand =
+      '/{PREFIX} "help me understand this codebase"';
   } else if (context.hasExistingSource) {
-    context.suggestedFirstCommand = '/lu "review the architecture"';
+    context.suggestedFirstCommand = '/{PREFIX} "review the architecture"';
   } else {
-    context.suggestedFirstCommand = "/lu";
+    // null — tour.ts will use /${commandPrefix} as the default
+    context.suggestedFirstCommand = undefined;
   }
 
   return context;

--- a/packages/luca-framework/src/utils/tour.ts
+++ b/packages/luca-framework/src/utils/tour.ts
@@ -109,20 +109,42 @@ function buildTourSteps(
   });
 
   // Step: Generated Files Summary (dynamic or static)
-  const step2Body = stats
-    ? `Installed ${stats.agent_count} agents, ${stats.skill_count} skills, ` +
+  // In global mode, stats are zero because harness files live in ~/.claude/
+  const isGlobalMode =
+    stats !== undefined &&
+    stats.agent_count === 0 &&
+    stats.skill_count === 0 &&
+    stats.rule_count === 0 &&
+    stats.hook_count === 0;
+
+  let step2Body: string;
+  if (isGlobalMode) {
+    step2Body =
+      `Agents, skills, rules, and hooks are deployed globally to ~/.claude/\n` +
+      `(via luca init). This project uses the global install.\n\n` +
+      `  Agents   (orchestration, code review, verification)\n` +
+      `  Skills   (git, planning, testing workflows)\n` +
+      `  Rules    (code conventions, architecture patterns)\n` +
+      `  Hooks    (pre-commit gate, type checking, formatting)\n\n` +
+      `To update global artifacts: luca init`;
+  } else if (stats) {
+    step2Body =
+      `Installed ${stats.agent_count} agents, ${stats.skill_count} skills, ` +
       `${stats.rule_count} rules, ${stats.hook_count} hooks into ${harnessNames}\n\n` +
       `  Agents   (orchestration, code review, verification)\n` +
       `  Skills   (git, planning, testing workflows)\n` +
       `  Rules    (code conventions, architecture patterns)\n` +
       `  Hooks    (pre-commit gate, type checking, formatting)\n\n` +
-      `These are generated from src/ -- edit sources, then bun run build:all.`
-    : `Installed into ${harnessNames}:\n\n` +
+      `These are generated from src/ -- edit sources, then bun run build:all.`;
+  } else {
+    step2Body =
+      `Installed into ${harnessNames}:\n\n` +
       `  Agents   (orchestration, code review, verification)\n` +
       `  Skills   (git, planning, testing workflows)\n` +
       `  Rules    (code conventions, architecture patterns)\n` +
       `  Hooks    (pre-commit gate, type checking, formatting)\n\n` +
       `These are generated from src/ -- edit sources, then bun run build:all.`;
+  }
 
   steps.push({
     title: `Step ${steps.length + 1}: What Was Generated`,
@@ -140,7 +162,8 @@ function buildTourSteps(
   });
 
   // Step: Suggested First Command (uses enhanced context detection)
-  const suggestedCommand = context.suggestedFirstCommand ?? `/${commandPrefix}`;
+  const rawSuggestion = context.suggestedFirstCommand ?? `/${commandPrefix}`;
+  const suggestedCommand = rawSuggestion.replace(/\{PREFIX\}/g, commandPrefix);
   steps.push({
     title: `Step ${steps.length + 1}: Your First Command`,
     body:

--- a/packages/luca-framework/src/utils/vault-setup.ts
+++ b/packages/luca-framework/src/utils/vault-setup.ts
@@ -292,36 +292,57 @@ export async function writeVaultConfig(
  * @example
  * ```typescript
  * await writeApiKeyToEnv("sk-abc123", "/path/to/.env");
- * // .env now contains: MUNINN_API_KEY=sk-abc123
+ * // .env now contains:
+ * //   MUNINN_DB_MY_PROJECT_API_KEY=sk-abc123
+ * //   MUNINN_DB_DEFAULT_API_KEY=sk-abc123
  * // File permissions: 0600 (owner read/write only)
  * ```
  */
 export async function writeApiKeyToEnv(
   apiKey: string,
   envPath: string,
+  vaultName?: string,
 ): Promise<void> {
-  const envLine = `MUNINN_API_KEY=${apiKey}`;
+  // MuninnDB expects per-vault env vars: MUNINN_DB_<VAULT>_API_KEY
+  // Also write the default vault key since it's required for cross-cutting access
+  const vaultKey = vaultName
+    ? `MUNINN_DB_${vaultName.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_API_KEY`
+    : "MUNINN_API_KEY";
+  const envLines = [
+    `${vaultKey}=${apiKey}`,
+    // Default vault key is always needed for cross-cutting memories
+    ...(vaultName && vaultName !== "default"
+      ? [`MUNINN_DB_DEFAULT_API_KEY=${apiKey}`]
+      : []),
+  ];
+
   const file = Bun.file(envPath);
 
   if (await file.exists()) {
-    const content = await file.text();
-    const lines = content.split("\n");
-    const existingIndex = lines.findIndex((line) =>
-      line.startsWith("MUNINN_API_KEY="),
-    );
+    let content = await file.text();
 
-    if (existingIndex >= 0) {
-      // Replace existing line
-      lines[existingIndex] = envLine;
-      await Bun.write(envPath, lines.join("\n"));
-    } else {
-      // Append to end, ensuring newline before the new entry
-      const separator = content.endsWith("\n") ? "" : "\n";
-      await Bun.write(envPath, content + separator + envLine + "\n");
+    for (const envLine of envLines) {
+      const keyName = envLine.split("=")[0];
+      const lines = content.split("\n");
+      const existingIndex = lines.findIndex((line) =>
+        line.startsWith(`${keyName}=`),
+      );
+
+      if (existingIndex >= 0) {
+        // Replace existing line
+        lines[existingIndex] = envLine;
+        content = lines.join("\n");
+      } else {
+        // Append to end, ensuring newline before the new entry
+        const separator = content.endsWith("\n") ? "" : "\n";
+        content = content + separator + envLine + "\n";
+      }
     }
+
+    await Bun.write(envPath, content);
   } else {
     // Create new .env file
-    await Bun.write(envPath, envLine + "\n");
+    await Bun.write(envPath, envLines.join("\n") + "\n");
   }
 
   // Restrict permissions: owner read/write only (SEC-002)

--- a/packages/luca-framework/src/utils/vault-setup.ts
+++ b/packages/luca-framework/src/utils/vault-setup.ts
@@ -277,24 +277,30 @@ export async function writeVaultConfig(
 }
 
 /**
- * Append `MUNINN_API_KEY=<key>` to a `.env` file.
+ * Write MuninnDB API key(s) to a `.env` file using per-vault naming.
  *
- * Creates the `.env` file if it does not exist. If the file already contains
- * a `MUNINN_API_KEY=` line, the existing value is replaced. Otherwise the
- * key is appended on a new line.
+ * Creates the `.env` file if it does not exist. Writes up to three env vars:
+ * - `MUNINN_DB_<VAULT>_API_KEY` — per-vault key (when vaultName provided)
+ * - `MUNINN_DB_DEFAULT_API_KEY` — default vault key (for cross-cutting access)
+ * - `MUNINN_DB_API_KEY` — generic fallback (for runtime code that reads this)
+ *
+ * If the file already contains a matching line, the existing value is replaced.
+ * Otherwise the key is appended on a new line.
  *
  * After writing, the file permissions are set to `0600` (owner read/write
  * only) to prevent other users on the system from reading the API key.
  *
  * @param apiKey - The MuninnDB API key value to write.
  * @param envPath - Absolute path to the `.env` file.
+ * @param vaultName - Vault name for per-vault env var (e.g. "my-project").
  *
  * @example
  * ```typescript
- * await writeApiKeyToEnv("sk-abc123", "/path/to/.env");
+ * await writeApiKeyToEnv("sk-abc123", "/path/to/.env", "my-project");
  * // .env now contains:
  * //   MUNINN_DB_MY_PROJECT_API_KEY=sk-abc123
  * //   MUNINN_DB_DEFAULT_API_KEY=sk-abc123
+ * //   MUNINN_DB_API_KEY=sk-abc123
  * // File permissions: 0600 (owner read/write only)
  * ```
  */
@@ -304,16 +310,18 @@ export async function writeApiKeyToEnv(
   vaultName?: string,
 ): Promise<void> {
   // MuninnDB expects per-vault env vars: MUNINN_DB_<VAULT>_API_KEY
-  // Also write the default vault key since it's required for cross-cutting access
+  // Also write the default vault key and generic fallback for runtime consumers
   const vaultKey = vaultName
     ? `MUNINN_DB_${vaultName.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_API_KEY`
-    : "MUNINN_API_KEY";
+    : "MUNINN_DB_API_KEY";
   const envLines = [
     `${vaultKey}=${apiKey}`,
     // Default vault key is always needed for cross-cutting memories
     ...(vaultName && vaultName !== "default"
       ? [`MUNINN_DB_DEFAULT_API_KEY=${apiKey}`]
       : []),
+    // Generic fallback read by runtime code (bridge, emitter)
+    `MUNINN_DB_API_KEY=${apiKey}`,
   ];
 
   const file = Bun.file(envPath);


### PR DESCRIPTION
## Summary

Three bugs in `vault:init` and the post-init tour:

1. **API key env var name** — wrote `MUNINN_API_KEY=<key>` but MuninnDB expects `MUNINN_DB_<VAULT>_API_KEY` per vault. Now writes both:
   - `MUNINN_DB_PERCENT_UI_API_KEY=<key>` (vault-specific)
   - `MUNINN_DB_DEFAULT_API_KEY=<key>` (required for cross-cutting access to default vault)

2. **Tour shows `/lu` instead of configured prefix** — `detect.ts` hardcoded `/lu` in `suggestedFirstCommand`. Now uses `{PREFIX}` placeholder resolved by `tour.ts` with the configured `commandPrefix` (e.g. `/pt`).

3. **Tour shows "Installed 0 agents, 0 skills..."** — counted local `.claude/` files but global install puts them in `~/.claude/`. Now detects global mode (all stats zero) and shows "deployed globally to ~/.claude/" instead.

## Test plan

- [ ] Run `luca vault:init` — `.env` should contain `MUNINN_DB_<VAULT>_API_KEY` and `MUNINN_DB_DEFAULT_API_KEY`
- [ ] Tour should show configured command prefix (e.g. `/pt`), not `/lu`
- [ ] Tour "What Was Generated" step should reference global `~/.claude/` in global install mode
- [ ] `bunx --bun tsc --noEmit` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)