### PR TITLE
feat(mastracode): v10.2.0 #143 bundled skills and rules system

### DIFF
--- a/.planning/todos/pending/add-active-synthesis-directives-to-orchestrators.md
+++ b/.planning/todos/pending/add-active-synthesis-directives-to-orchestrators.md
@@ -1,0 +1,70 @@
+---
+title: "Add active synthesis directives to execute and review orchestrators"
+area: prompt-engineering
+created: 2026-04-13
+priority: high
+source: research
+sprint: 1
+---
+
+## Task
+
+Add "synthesize, don't relay" directives to execute.md and review.md orchestrator instructions, and add behavioral refresh to continuation messages in index.ts.
+
+## Context
+
+Claude Code's coordinator mode explicitly says: "Do not rubber-stamp weak work. Never write 'based on your findings' — these phrases delegate understanding to workers instead of doing it yourself." luca-mastracode's orchestrator modes contain zero such directives. The execute mode "consolidates" review findings but is not told to challenge them. The review mode can passively relay subagent opinions without owning the verdict.
+
+## Research References
+
+- [04-multi-agent-coordination.md](../../docs/research/prompt-architecture/04-multi-agent-coordination.md) — Section 4: Coordinator prompt design principles, active synthesis
+- [08-advanced-patterns-and-hidden-systems.md](../../docs/research/prompt-architecture/08-advanced-patterns-and-hidden-systems.md) — Section 6: "Do not rubber-stamp weak work"
+- [10-final-actionable-review.md](../../docs/research/prompt-architecture/10-final-actionable-review.md) — Sprint 1, item 1.7
+
+## Implementation
+
+### Part A: execute.md
+
+**File:** `packages/luca-mastracode/src/instructions/execute.md`
+
+Add to Behavioral Guidelines section:
+
+```markdown
+- **Synthesize, don't relay.** When subagents return results, YOU must understand them.
+  Never write "based on the reviewer's findings" or "as the verifier reported."
+  Resolve conflicts between subagents and present a unified assessment.
+  If two reviewers contradict each other, investigate — don't average.
+```
+
+### Part B: review.md
+
+**File:** `packages/luca-mastracode/src/instructions/review.md`
+
+Add to Behavioral Guidelines section:
+
+```markdown
+- **Own the verdict.** You are the decision-maker, not a relay for subagent opinions.
+  If all 4 reviewers approve but you see an issue, flag it. If a reviewer flags a
+  false positive, dismiss it with explanation. Never defer understanding to subagents.
+```
+
+### Part C: Continuation Messages
+
+**File:** `packages/luca-mastracode/src/index.ts` (`buildContinuationMessage` function)
+
+Add behavioral refresh to every continuation message:
+
+```typescript
+const BEHAVIORAL_REFRESH = [
+  `<luca-reminder>`,
+  `- Synthesize subagent results yourself — never relay passively`,
+  `- A verification without tool execution is a guess, not a check`,
+  `- Do not rubber-stamp weak work from subagents`,
+  `</luca-reminder>`,
+].join('\n');
+```
+
+## Constraints
+
+- Do NOT change the continuation message structure — only add the behavioral refresh block
+- Keep additions under 100 words each

--- a/.planning/todos/pending/add-anti-sycophancy-to-reviewer-subagent.md
+++ b/.planning/todos/pending/add-anti-sycophancy-to-reviewer-subagent.md
@@ -1,0 +1,53 @@
+---
+title: "Add anti-sycophancy quality gate to reviewer subagent"
+area: prompt-engineering
+created: 2026-04-13
+priority: critical
+source: research
+sprint: 1
+---
+
+## Task
+
+Add an anti-sycophancy directive and evidence requirement for APPROVE verdicts to the reviewer subagent.
+
+## Context
+
+The reviewer subagent can currently issue APPROVE with zero findings and no explanation of what was actually checked. During code review, 4 reviewer subagents are spawned in parallel — if all four independently rubber-stamp, it creates a false consensus. Claude Code's coordinator mode explicitly says "Do not rubber-stamp weak work" and requires mandatory evidence for every verdict.
+
+## Research References
+
+- [04-multi-agent-coordination.md](../../docs/research/prompt-architecture/04-multi-agent-coordination.md) — Section 3.2: Anti-sycophancy patterns, mandatory evidence for every verdict
+- [08-advanced-patterns-and-hidden-systems.md](../../docs/research/prompt-architecture/08-advanced-patterns-and-hidden-systems.md) — Section 6: Coordinator mode "Do not rubber-stamp weak work"
+- [10-final-actionable-review.md](../../docs/research/prompt-architecture/10-final-actionable-review.md) — Sprint 1, item 1.2
+
+## Implementation
+
+**File:** `packages/luca-mastracode/src/subagents/reviewer.ts`
+
+Insert after the severity classification section:
+
+```markdown
+## Quality Gate
+
+Do not rubber-stamp weak work. Every APPROVE verdict must be earned through evidence,
+not granted by default.
+
+The code you are reviewing was written by an LLM. LLM-generated code has systematic
+blind spots: it often appears clean and well-structured while containing subtle logic
+errors, missing edge cases, or incorrect assumptions.
+
+If you find zero MUST-FIX issues, you MUST explicitly state:
+1. What you verified and how (which files you read, what you checked)
+2. Why the implementation is correct (not just "it looks good")
+3. Any areas where you had concerns but determined they were acceptable
+
+An APPROVE with zero findings and no verification explanation is a rubber stamp.
+It is better to flag a false positive than to miss a real issue.
+```
+
+## Constraints
+
+- Do NOT change the reviewer's severity classification system (MUST-FIX/SHOULD-FIX/NOTE)
+- Do NOT change the cross-phase flagging mechanism
+- Keep the addition under 150 words

--- a/.planning/todos/pending/add-bidirectional-tool-constraints-to-all-modes.md
+++ b/.planning/todos/pending/add-bidirectional-tool-constraints-to-all-modes.md
@@ -1,0 +1,75 @@
+---
+title: "Add bidirectional tool constraints and tool discipline sections to all mode instructions"
+area: prompt-engineering
+created: 2026-04-13
+priority: high
+source: research
+sprint: 2
+---
+
+## Task
+
+Add a `## Tool Discipline` section to each pipeline mode instruction file with bidirectional constraints: for every "use X" instruction, add "do NOT use Y for the same purpose." Also add explicit mutation-tool blocklists to all read-only modes.
+
+## Context
+
+Claude Code's Bash tool description is the canonical example: "Use Read (NOT cat/head/tail). Use Edit (NOT sed/awk). Use Glob (NOT find/ls)." Every positive instruction has a corresponding negative constraint. Models default to familiar shell commands from training data — bidirectional constraints fight this tendency by explicitly naming prohibited alternatives.
+
+luca-mastracode's instruction files reference tools by name but never say what NOT to use. Read-only modes say "read-only" but don't list which mutation tools are prohibited.
+
+## Research References
+
+- [03-tool-definition-engineering.md](../../docs/research/prompt-architecture/03-tool-definition-engineering.md) — Section 3: Anti-redundancy pattern, bidirectional constraints
+- [00-overview.md](../../docs/research/prompt-architecture/00-overview.md) — Section 3: "Every positive instruction has a corresponding negative constraint"
+- [10-final-actionable-review.md](../../docs/research/prompt-architecture/10-final-actionable-review.md) — Sprint 2, item 2.2
+
+## Implementation
+
+### Pipeline Modes — Add Tool Discipline Section
+
+**execute.md:**
+```markdown
+## Tool Discipline
+- Use `runChecks` for all automated checks. Do NOT run tsc/eslint/tests directly via execute_command.
+- Use `workflowState` for all state reads and transitions. Do NOT read .planning/luca-state.json directly.
+- Use `manageTodos` for backlog operations. Do NOT create or modify todo files directly.
+- Use `verificationResult` for structured verification output. Do NOT write verification results as prose.
+```
+
+**architect.md:**
+```markdown
+## Tool Discipline
+- Use `manageRoadmap` for ROADMAP.md operations. Do NOT write ROADMAP.md via writePlanningFile.
+- Use `workflowState(action: "save-plan-artifacts")` to record plan paths. Do NOT write state.json directly.
+- Use `manageTodos(action: "assign-batch")` for bulk assignment. Do NOT move todos one at a time.
+```
+
+### Read-Only Modes — Add Explicit Blocklists
+
+**triage.md** (after "read-only + classification only"):
+```markdown
+Do NOT use `manageTodos(action: "add")`, `writePlanningFile`, `string_replace_lsp`,
+`write_file`, or `execute_command`. The only mutation tools permitted are
+`workflowState`, `classifyComplexity`, and `pipelineLock`.
+```
+
+**research.md:**
+```markdown
+Do NOT use `string_replace_lsp`, `write_file`, or `execute_command` for code modifications.
+Use ONLY `writePlanningFile` for .planning/ output.
+```
+
+**review.md:**
+```markdown
+Do NOT use `string_replace_lsp`, `write_file`, or `execute_command` for file changes.
+Use ONLY `writePlanningFile` for .planning/ output.
+```
+
+## Files Changed
+
+All 10 files in `packages/luca-mastracode/src/instructions/`
+
+## Constraints
+
+- Do NOT duplicate tool schema information — focus on behavioral when/when-not guidance
+- Keep each Tool Discipline section under 100 words

--- a/.planning/todos/pending/add-cross-tool-coordination-sections-to-mode-instructions.md
+++ b/.planning/todos/pending/add-cross-tool-coordination-sections-to-mode-instructions.md
@@ -1,0 +1,70 @@
+---
+title: "Add cross-tool coordination and tool usage priority sections to mode instructions"
+area: prompt-engineering
+created: 2026-04-13
+priority: medium
+source: research
+sprint: 3
+---
+
+## Task
+
+Add a `## Tool Usage Priority` section to each pipeline mode instruction file that lists tools in order of typical usage for that mode, with explicit cross-tool disambiguation.
+
+## Context
+
+Tool descriptions (enriched in the tool enrichment todo) address per-tool behavior, but modes need coordination guidance that spans tools. When should you use workflowState vs sessionLedger? When runChecks vs verificationResult? This cross-tool coordination lives in the mode instructions, not individual tool descriptions.
+
+## Research References
+
+- [03-tool-definition-engineering.md](../../docs/research/prompt-architecture/03-tool-definition-engineering.md) — Section 5: Cross-agent comparison, tool coordination patterns
+- [10-final-actionable-review.md](../../docs/research/prompt-architecture/10-final-actionable-review.md) — Sprint 3, item 3.3
+
+## Implementation
+
+### Execute Mode
+
+**File:** `packages/luca-mastracode/src/instructions/execute.md`
+
+```markdown
+## Tool Usage Priority
+1. workflowState("read") — Always first, to understand current phase/wave position
+2. workflowState("start-phase") — Once per phase, before beginning work
+3. runChecks — After each code change to validate
+4. workflowState("record-iteration") — After each fix-check cycle
+5. verificationResult("write") — After final check pass or stall
+6. workflowState("complete-phase") — To finalize the phase
+
+Do NOT use sessionLedger during execute — it is for finalize only.
+Do NOT use manageTodos("add") during execute — capture new work in review notes instead.
+```
+
+### Review Mode
+
+```markdown
+## Tool Usage Priority
+1. workflowState("read") — Check current state
+2. runChecks — Verify current code status
+3. verificationResult("read") — Get latest verification
+4. writePlanningFile — Write capture files and review report
+5. workflowState("save-review-results") — Persist the iteration plan
+
+Do NOT use sessionLedger during review. Do NOT use repoCleanup("apply-fix").
+```
+
+### Similar sections for triage, research, architect, finalize modes.
+
+## Files Changed
+
+- `packages/luca-mastracode/src/instructions/execute.md`
+- `packages/luca-mastracode/src/instructions/review.md`
+- `packages/luca-mastracode/src/instructions/triage.md`
+- `packages/luca-mastracode/src/instructions/architect.md`
+- `packages/luca-mastracode/src/instructions/research.md`
+- `packages/luca-mastracode/src/instructions/finalize.md`
+
+## Constraints
+
+- Each section should be under 100 words
+- Tool names must match actual tool IDs from the tool registry
+- This todo should be done AFTER the tool enrichment todo so descriptions and mode instructions are consistent

--- a/.planning/todos/pending/add-self-distrust-to-verifier-subagent.md
+++ b/.planning/todos/pending/add-self-distrust-to-verifier-subagent.md
@@ -1,0 +1,61 @@
+---
+title: "Add self-distrust mandate to verifier subagent"
+area: prompt-engineering
+created: 2026-04-13
+priority: critical
+source: research
+sprint: 1
+---
+
+## Task
+
+Add an explicit self-distrust mandate and failure-mode resistance list to the verifier subagent instructions.
+
+## Context
+
+The verifier is the last quality gate before code ships. Research found that Claude Code's verification specialist contains a hardcoded list of rationalizations to actively resist, with the directive: "The implementer is an LLM. Verify independently." luca-mastracode's verifier has **zero self-distrust patterns** — it can issue PASS verdicts based on reading code and reasoning about correctness instead of running checks.
+
+The agent drift math is sobering: at 95% per-step reliability over 25 agent turns in a typical MODERATE pipeline, combined success is only ~28%. Self-distrust in the verifier directly targets the per-step reliability number.
+
+## Research References
+
+- [04-multi-agent-coordination.md](../../docs/research/prompt-architecture/04-multi-agent-coordination.md) — Section 3.1: Claude Code's verification specialist with explicit self-distrust and "mandatory evidence" patterns
+- [10-final-actionable-review.md](../../docs/research/prompt-architecture/10-final-actionable-review.md) — Sprint 1, item 1.1
+- [00-overview.md](../../docs/research/prompt-architecture/00-overview.md) — Section 7: "Add explicit self-distrust to lu-verifier"
+
+## Implementation
+
+**File:** `packages/luca-mastracode/src/subagents/verifier.ts`
+
+Insert after the opening role description, before "## Verification Modes":
+
+```markdown
+## Independence Mandate
+
+The code you are verifying was written by an LLM. Do not trust that it is correct.
+Verify independently by running checks and inspecting actual behavior, not by
+reading code and reasoning about correctness.
+
+**A check without a tool execution is not a PASS.**
+
+Every criterion marked `met: true` MUST have evidence from a tool execution
+(test output, tsc output, or file content at a specific line). Evidence that
+consists only of "the code looks correct" is not evidence — it is a guess.
+Mark it `met: false` with gap: "Not independently verified."
+
+### Failure Modes to Resist
+
+You are an LLM and are susceptible to these failure modes. Actively resist them:
+
+1. **Reading code and concluding it "looks correct"** without running it
+2. **Trusting the executor's commit message** about what changed — verify the actual diff
+3. **Hedging** ("this appears to work") instead of declaring PASS or FAIL
+4. **Reducing severity** of real issues to avoid blocking progress
+5. **Confirming your own earlier assessment** — treat each verification pass as independent
+```
+
+## Constraints
+
+- Do NOT change the verifier's output schema or convergence tracking logic
+- Do NOT change the verification modes (quick/full) — only add behavioral framing
+- The self-distrust section should be ~150 words to stay within instruction token budget

--- a/.planning/todos/pending/compress-procedural-templates-to-principles.md
+++ b/.planning/todos/pending/compress-procedural-templates-to-principles.md
@@ -1,0 +1,80 @@
+---
+title: "Compress procedural templates to principles in pipeline instruction files"
+area: prompt-engineering
+created: 2026-04-13
+priority: high
+source: research
+sprint: 2
+---
+
+## Task
+
+Replace verbose procedural templates (ROADMAP structure, PLAN structure, MuninnDB code blocks, capture file templates) with concise principle-based descriptions across all pipeline instruction files. Target: ~510 tokens freed.
+
+## Context
+
+Research shows principles generalize to unanticipated scenarios while procedures fail when the situation doesn't match the script. Multiple instruction files contain full markdown templates and MuninnDB code blocks that consume attention-trough tokens. The model can generate markdown structure from principles — it doesn't need pre-formatted examples.
+
+Comprehension drops ~12% per 100 words beyond 500 words (research finding). Several pipeline files exceed 500 words significantly: architect.md (~1,350 tokens), execute.md (~1,500 tokens), finalize.md (~1,200 tokens).
+
+## Research References
+
+- [09-instruction-budget-and-prompt-economics.md](../../docs/research/prompt-architecture/09-instruction-budget-and-prompt-economics.md) — Sections 1-2: Shared instruction budget, dilution effect
+- [00-overview.md](../../docs/research/prompt-architecture/00-overview.md) — Section 3: "Principles Over Procedures"
+- [10-final-actionable-review.md](../../docs/research/prompt-architecture/10-final-actionable-review.md) — Sprint 2, item 2.3
+
+## Implementation
+
+### Compression Targets
+
+| File | Section | Current | Compressed To | Token Savings |
+|------|---------|---------|--------------|---------------|
+| `architect.md` | ROADMAP template (lines ~119-138) | 20 lines | 3 lines + principles | ~80 tokens |
+| `architect.md` | PLAN template (lines ~163-203) | 40 lines | 8 lines + principles | ~120 tokens |
+| `architect.md` | Step 1 Git Setup (lines ~26-35) | 10 lines | 3 lines | ~40 tokens |
+| `execute.md` | Review capture template (lines ~260-284) | 25 lines | 4 lines | ~60 tokens |
+| `execute.md` | Review dimensions (lines ~226-258) | 32 lines | 6 lines | ~80 tokens |
+| `research.md` | MuninnDB storage blocks (lines ~216-257) | 30 lines | 6 lines | ~80 tokens |
+| `finalize.md` | Session Archive template (lines ~89-107) | 19 lines | 2 lines | ~50 tokens |
+| **Total** | | | | **~510 tokens** |
+
+### Example Compression
+
+**architect.md ROADMAP template — before** (20 lines):
+Full markdown template with headers, phases, WSJF table
+
+**After** (3 lines):
+```markdown
+ROADMAP.md must contain: overview, phases ordered by WSJF score (highest first), each with
+objective, dependencies, estimated scope (S/M/L/XL), and task count. Use WSJF =
+(Business Value + Time Criticality + Risk Reduction) / Job Size, each factor 1-5.
+```
+
+### Procedural-to-Principle Conversions
+
+**architect.md Step 1 — before:**
+```
+1. Create GitHub issue describing the work
+2. Create feature branch from default branch using naming convention...
+3. Store issue number and branch name in workflow_state
+```
+
+**After:**
+```
+Unless `--skip-branch` is set, create a GitHub issue and feature branch before planning.
+Branch: `<type>/<issue-number>-<short-description>` where type is feat|fix|refactor.
+Store issue number and branch in workflow state.
+```
+
+## Files Changed
+
+- `packages/luca-mastracode/src/instructions/architect.md`
+- `packages/luca-mastracode/src/instructions/execute.md`
+- `packages/luca-mastracode/src/instructions/research.md`
+- `packages/luca-mastracode/src/instructions/finalize.md`
+
+## Constraints
+
+- Do NOT remove information — compress it. Every piece of behavioral guidance must survive.
+- Do NOT compress the execution loop pseudo-code in execute.md — its structured format is valuable
+- The 510-token savings offsets the ~200-token cost of dual HARD_CONSTRAINTS injection

--- a/.planning/todos/pending/create-shared-subagent-prefix-for-cache-and-behavior.md
+++ b/.planning/todos/pending/create-shared-subagent-prefix-for-cache-and-behavior.md
@@ -1,0 +1,73 @@
+---
+title: "Create shared subagent instruction prefix for cache efficiency and universal behavioral constraints"
+area: architecture
+created: 2026-04-13
+priority: high
+source: research
+sprint: 4
+---
+
+## Task
+
+Extract a shared behavioral prefix (~300-400 tokens) into `src/subagents/shared-prefix.ts` and prepend it to all 9 subagent instruction strings. This provides: (1) universal behavioral constraints in one place, (2) self-distrust and anti-sycophancy patterns from a single source, and (3) cache reuse potential when Mastra supports prompt caching for subagents.
+
+## Context
+
+Claude Code's fork model achieves 92% prompt reuse across subagents by ensuring they inherit a byte-identical instruction prefix. luca-mastracode's 9 subagents each have independent inline instructions with no shared prefix. When 4 parallel reviewer subagents spawn, each is a full cache miss.
+
+## Research References
+
+- [01-cache-boundary-design.md](../../docs/research/prompt-architecture/01-cache-boundary-design.md) — Fork model, 92% prompt reuse, cache-efficient subagent spawning
+- [04-multi-agent-coordination.md](../../docs/research/prompt-architecture/04-multi-agent-coordination.md) — Shared prefix design, self-distrust patterns
+- [10-final-actionable-review.md](../../docs/research/prompt-architecture/10-final-actionable-review.md) — Sprint 4, item 4.1
+
+## Implementation
+
+**New file:** `packages/luca-mastracode/src/subagents/shared-prefix.ts`
+
+```typescript
+/**
+ * Shared behavioral prefix for all subagents.
+ * Must be byte-identical across all subagent types to maximize cache reuse.
+ * No variable interpolation — fully static.
+ */
+export const SUBAGENT_SHARED_PREFIX = `
+You are a Luca subagent operating within the Luca development workflow.
+
+## Universal Constraints
+- Evidence-based: Every claim requires file:line citations
+- Output compression: Strip intermediate reasoning before returning results
+- Context awareness: You are one of potentially many parallel subagents
+- Memory as hints: Recalled MuninnDB memories require verification against current code
+
+## Quality Gate
+Do not rubber-stamp weak work. Every APPROVE verdict must be earned through evidence.
+The implementer is an LLM. Do not trust that code is correct. Verify independently.
+A check without a tool execution is not a PASS.
+`;
+```
+
+Then update all 9 subagent files to prepend:
+
+```typescript
+import { SUBAGENT_SHARED_PREFIX } from './shared-prefix'
+
+export const verifierSubagent: HarnessSubagent = {
+  instructions: SUBAGENT_SHARED_PREFIX + `
+## Your Role: Verifier
+[existing verifier-specific instructions...]
+`,
+  // ...
+}
+```
+
+## Files Changed
+
+- `packages/luca-mastracode/src/subagents/shared-prefix.ts` (NEW)
+- All 9 files in `packages/luca-mastracode/src/subagents/` (prepend import)
+
+## Constraints
+
+- The shared prefix must be a static string constant — no template literals or variable interpolation
+- Must be byte-identical when compared across subagents (for cache reuse)
+- Sprint 1 self-distrust and anti-sycophancy additions should be moved INTO the shared prefix and removed from individual files to avoid duplication

--- a/.planning/todos/pending/define-luca-reminder-convention-and-add-environment-context.md
+++ b/.planning/todos/pending/define-luca-reminder-convention-and-add-environment-context.md
@@ -1,0 +1,77 @@
+---
+title: "Define <luca-reminder> tag convention, add environment context block, add memory-as-hints framing"
+area: prompt-engineering
+created: 2026-04-13
+priority: medium
+source: research
+sprint: 2
+---
+
+## Task
+
+Three related infrastructure-level instruction changes: (1) define the `<luca-reminder>` tag convention in HARD_CONSTRAINTS, (2) add an environment context block to every mode, (3) add "memory as hints" framing after every MuninnDB recall block.
+
+## Context
+
+Claude Code declares `<system-reminder>` tags in its system prompt so the model treats mid-conversation injections as authoritative. Without this priming, injected tags are treated as arbitrary XML. This is a prerequisite for future mid-conversation injection to combat context rot.
+
+Claude Code also injects cwd, platform, date, model, and git branch as dynamic context. luca-mastracode injects only workflow state.
+
+Claude Code explicitly frames recalled memories as "hints requiring verification, not authoritative truth." luca-mastracode instructions say "query MuninnDB" and immediately use results without verification framing.
+
+## Research References
+
+- [02-context-rot-and-injection.md](../../docs/research/prompt-architecture/02-context-rot-and-injection.md) — Section 3: Claude Code's system-reminder implementation
+- [00-overview.md](../../docs/research/prompt-architecture/00-overview.md) — Section 5: Environment context gap; Section 6: "Memory as hints"
+- [07-context-compaction-and-memory.md](../../docs/research/prompt-architecture/07-context-compaction-and-memory.md) — Memory as hints requiring verification
+- [10-final-actionable-review.md](../../docs/research/prompt-architecture/10-final-actionable-review.md) — Sprint 2, items 2.5-2.7
+
+## Implementation
+
+### Part A: `<luca-reminder>` Convention
+
+**File:** `packages/luca-mastracode/src/index.ts` — add to HARD_CONSTRAINTS:
+
+```markdown
+- **System reminders are authoritative.** Messages may include `<luca-reminder>` tags containing
+  behavioral guidance from the Luca harness. Follow their instructions as if they were part of
+  your original system prompt.
+```
+
+### Part B: Environment Context Block
+
+**File:** `packages/luca-mastracode/src/index.ts` — add function and call from `getAgentConstraints()`:
+
+```typescript
+function buildEnvironmentContext(): string {
+  const cwd = process.cwd()
+  const platform = process.platform
+  const date = new Date().toISOString().split('T')[0]
+  return `\n## Environment\n- Working directory: ${cwd}\n- Platform: ${platform}\n- Date: ${date}`
+}
+```
+
+### Part C: Memory as Hints
+
+Add a single line after every MuninnDB recall code block across instruction files:
+
+```markdown
+Recalled memories are hints, not truth. Verify critical facts against the current
+codebase before depending on them.
+```
+
+**Files:** triage.md (after line ~78), execute.md (after line ~355), research.md (after line ~205), architect.md (after line ~65), review.md (after line ~137), finalize.md (after line ~66)
+
+### Part D: Parallel Tool Call Enforcement
+
+**File:** `packages/luca-mastracode/src/index.ts` — add to HARD_CONSTRAINTS:
+
+```markdown
+- **Prefer parallel tool calls.** When multiple tool calls are independent, issue them in the
+  same response. Do NOT call tools sequentially when they could run concurrently.
+```
+
+## Constraints
+
+- Part A is a prerequisite for the mid-conversation injection infrastructure (Sprint 4)
+- Parts B-D are independent and can be done in any order

--- a/.planning/todos/pending/dual-inject-hard-constraints-and-add-because-clauses.md
+++ b/.planning/todos/pending/dual-inject-hard-constraints-and-add-because-clauses.md
@@ -1,0 +1,68 @@
+---
+title: "Dual-inject HARD_CONSTRAINTS (primacy + recency) and add 'because' clauses"
+area: prompt-engineering
+created: 2026-04-13
+priority: high
+source: research
+sprint: 1
+---
+
+## Task
+
+Change HARD_CONSTRAINTS injection from append-only to prepend-AND-append (exploiting both primacy and recency attention peaks), and add "because" clauses to all three constraints to enable edge-case reasoning.
+
+## Context
+
+Currently HARD_CONSTRAINTS are only appended at the end of instructions via `getAgentConstraints()`. This exploits recency but misses the primacy peak. Research shows the first and last ~200 tokens receive almost equal attention. Additionally, "because" clauses transform opaque rules into teachable principles — when the model encounters an edge case, the reasoning clause enables correct inference.
+
+Claude Code says: "Avoid git amend **because** it may overwrite others' commits." The "because" is what teaches the model to make correct decisions in scenarios not explicitly covered by the rule.
+
+## Research References
+
+- [05-attention-curves-and-structure.md](../../docs/research/prompt-architecture/05-attention-curves-and-structure.md) — U-shaped attention, primacy/recency exploitation
+- [00-overview.md](../../docs/research/prompt-architecture/00-overview.md) — Section 3: "Because" clauses for edge-case reasoning
+- [09-instruction-budget-and-prompt-economics.md](../../docs/research/prompt-architecture/09-instruction-budget-and-prompt-economics.md) — Section 8: Phrasing hierarchy
+- [10-final-actionable-review.md](../../docs/research/prompt-architecture/10-final-actionable-review.md) — Sprint 1, items 1.5 and 1.6
+
+## Implementation
+
+**File:** `packages/luca-mastracode/src/index.ts`
+
+### Part A: Dual Injection
+
+Change `getAgentConstraints()` (or equivalent assembly point) to return constraints for BOTH prepending and appending. Modify the instruction assembly so:
+
+```
+Final instructions = HARD_CONSTRAINTS + mode_instructions + HARD_CONSTRAINTS + ALWAYS_APPLY_RULES
+```
+
+### Part B: Add "Because" Clauses
+
+Update HARD_CONSTRAINTS (lines ~160-163) from:
+
+```markdown
+- Never use temp files as an edit workaround. [...]
+- Never shell out for file edits. [...]
+- Respect mode boundaries. [...]
+```
+
+To:
+
+```markdown
+- **Never use temp files as an edit workaround** because it bypasses the harness's change tracking and makes modifications invisible to the review and verification pipeline.
+- **Never shell out for file edits** because execute_command output is not tracked by edit tools, so changes cannot be verified, reviewed, or rolled back by the harness.
+- **Respect mode boundaries** because mode restrictions separate concerns — a read-only mode that secretly writes files corrupts the verification guarantee of subsequent phases.
+```
+
+### Part C: Add 4th Constraint
+
+Add a new constraint addressing the most common cross-mode failure (verbose inter-tool narration):
+
+```markdown
+- **Do NOT generate explanatory prose between consecutive tool calls** because text between tool calls wastes tokens and slows execution. If your next action is a tool call, invoke it directly.
+```
+
+## Constraints
+
+- Total HARD_CONSTRAINTS should stay under 200 tokens to avoid excessive duplication cost
+- The dual injection adds ~200 tokens per mode — acceptable given the ~510 tokens freed by template compression (Sprint 2)

--- a/.planning/todos/pending/enrich-all-tool-descriptions-with-behavioral-guidance.md
+++ b/.planning/todos/pending/enrich-all-tool-descriptions-with-behavioral-guidance.md
@@ -1,0 +1,77 @@
+---
+title: "Enrich all 10 tool descriptions with behavioral guidance, priority ordering, and examples"
+area: prompt-engineering
+created: 2026-04-13
+priority: high
+source: research
+sprint: 3
+---
+
+## Task
+
+Rewrite all 10 custom tool descriptions from minimal action schemas (~379 tokens total) to rich behavioral guidance with when/when-not rules, priority ordering, cross-tool coordination, and examples (~2,384 tokens total). Implementation in 3 phases by tool traffic priority.
+
+## Context
+
+Claude Code allocates ~79% of its prompt token budget (~18,000 tokens) to tool definitions. luca-mastracode's 10 tools average ~38 tokens each — a **16-33x deficit** in description depth. The tool reviewer produced complete rewrite proposals for every tool. Total cost: +2,005 tokens (1.2% of context window). This is the highest-ROI single investment identified by the research.
+
+Each tool description should follow Claude Code's five-part anatomy: purpose, usage guidance (when/how), behavioral constraints (what NOT to do), priority ordering (vs alternatives), and examples.
+
+## Research References
+
+- [03-tool-definition-engineering.md](../../docs/research/prompt-architecture/03-tool-definition-engineering.md) — Full analysis of Claude Code's tool definition patterns, five-part anatomy, ~79% budget allocation
+- [09-instruction-budget-and-prompt-economics.md](../../docs/research/prompt-architecture/09-instruction-budget-and-prompt-economics.md) — MCP token overhead, tool definition budget math
+- [10-final-actionable-review.md](../../docs/research/prompt-architecture/10-final-actionable-review.md) — Sprint 3, item 3.1
+
+## Implementation
+
+### Phase 1: Highest-Traffic Tools (do first)
+
+1. **workflowState** — 12 actions, most complex. Add per-action guidance, pipeline ordering constraints, cross-tool disambiguation with sessionLedger. (+380 tokens)
+2. **runChecks** — Fix-loop efficiency. Add convergence interpretation, failFast guidance, relationship to verificationResult. (+205 tokens)
+3. **verificationResult** — Sequential dependency on runChecks. Add the runChecks→verificationResult→workflowState flow, evidence requirements. (+225 tokens)
+
+### Phase 2: Cross-Tool Disambiguation
+
+4. **sessionLedger** — Add READ-ONLY emphasis, "Do NOT use for execution tracking" disambiguation vs workflowState. (+185 tokens)
+5. **manageTodos** — Add lifecycle flow, action guidance, "Do NOT use for research artifacts" disambiguation vs writePlanningFile. (+185 tokens)
+6. **pipelineLock** — Add infrastructure-level framing, "Do NOT use for state reads" disambiguation vs workflowState. (+175 tokens)
+
+### Phase 3: Remaining Tools
+
+7. **manageRoadmap** — Add WSJF guidance, create-overwrites warning, disambiguation vs workflowState. (+165 tokens)
+8. **writePlanningFile** — Add security boundary explanation, "Do NOT use for todos/roadmap/state". (+155 tokens)
+9. **repoCleanup** — Add multi-step orchestration workflow, apply-fix destructiveness warning. (+210 tokens)
+10. **classifyComplexity** — Add early-pipeline-only guidance, over-estimate heuristic. (+120 tokens)
+
+### Token Budget Summary
+
+| Tool | Current | Proposed | Delta |
+|------|---------|----------|-------|
+| workflowState | ~44 | ~424 | +380 |
+| runChecks | ~33 | ~238 | +205 |
+| verificationResult | ~32 | ~257 | +225 |
+| sessionLedger | ~26 | ~211 | +185 |
+| manageTodos | ~50 | ~235 | +185 |
+| pipelineLock | ~27 | ~202 | +175 |
+| manageRoadmap | ~34 | ~199 | +165 |
+| writePlanningFile | ~44 | ~199 | +155 |
+| repoCleanup | ~41 | ~251 | +210 |
+| classifyComplexity | ~48 | ~168 | +120 |
+| **TOTAL** | **~379** | **~2,384** | **+2,005** |
+
+Full rewrite proposals for every tool are in the tool reviewer's output (summarized in the final review doc).
+
+## Files Changed
+
+Tool description strings in:
+- `packages/luca-mastracode/src/tools/classify-complexity.ts`
+- `packages/luca-mastracode/src/tools/workflow-state.ts`
+- `packages/luca-mastracode/src/tools/build-mode-tools.ts` (or wherever descriptions are defined for each tool)
+- All other tool definition files in `packages/luca-mastracode/src/tools/`
+
+## Constraints
+
+- Total enriched tool descriptions should stay under 2,500 tokens
+- Do NOT duplicate information already in tool schemas (parameter names, types) — focus on behavioral guidance
+- Each tool must have: purpose, when to use, when NOT to use, and cross-tool coordination note

--- a/.planning/todos/pending/enrich-subagent-instructions-with-self-compression-and-citations.md
+++ b/.planning/todos/pending/enrich-subagent-instructions-with-self-compression-and-citations.md
@@ -1,0 +1,105 @@
+---
+title: "Add self-compression, citation discipline, and skeptical recall to subagent instructions"
+area: prompt-engineering
+created: 2026-04-13
+priority: medium
+source: research
+sprint: 3
+---
+
+## Task
+
+Enrich subagent instructions with self-compression directives, citation discipline (file:line evidence), skeptical MuninnDB recall, and planner distrust. Covers 7 of 9 subagents (verifier and reviewer handled in Sprint 1).
+
+## Context
+
+Claude Code's coordinator requires "workers compress their own results before returning." Currently, subagent output dumps into the parent's context uncompressed. When 5 researcher subagents each return 2000 words, the orchestrator's context fills with 10K words before synthesis begins.
+
+Devin's mandatory `<cite>` tag innovation forces file-level citations with line numbers, making hallucination immediately detectable. luca-mastracode's researcher says "reference specific files/lines" but doesn't enforce a format.
+
+## Research References
+
+- [04-multi-agent-coordination.md](../../docs/research/prompt-architecture/04-multi-agent-coordination.md) — Sections 4 (worker self-compression), 3 (self-distrust)
+- [06-comparative-agent-analysis.md](../../docs/research/prompt-architecture/06-comparative-agent-analysis.md) — Devin's citation discipline
+- [07-context-compaction-and-memory.md](../../docs/research/prompt-architecture/07-context-compaction-and-memory.md) — Memory as hints requiring verification
+- [10-final-actionable-review.md](../../docs/research/prompt-architecture/10-final-actionable-review.md) — Sprint 3, items 3.2-3.4
+
+## Implementation
+
+### Executor Subagent
+
+**File:** `packages/luca-mastracode/src/subagents/executor.ts`
+
+Add:
+```markdown
+## Verification Awareness
+A separate verifier subagent will independently check your work. Focus on making
+changes correct, not on proving they are correct.
+
+## Output Compression
+Before returning results, compress to: tasks completed (by ID), files modified (paths),
+deviations from plan (with rationale), blockers. Strip intermediate reasoning and failed attempts.
+Maximum output: 200 words.
+```
+
+### Plan Reviewer Subagent
+
+**File:** `packages/luca-mastracode/src/subagents/plan-reviewer.ts`
+
+Add:
+```markdown
+## Planner Distrust
+The plan was created by an LLM planner. LLM-generated plans have blind spots:
+tasks that look atomic but bundle multiple changes, tautological verification criteria
+("verify it works"), missing error handling, optimistic dependency ordering.
+An APPROVED with zero BLOCKING findings must explain what you checked and why
+you are confident.
+```
+
+### Researcher Subagent
+
+**File:** `packages/luca-mastracode/src/subagents/researcher.ts`
+
+Add:
+```markdown
+## Output Compression
+Compress findings to essential information. Each finding: file:line reference,
+one-sentence finding, confidence level, one-sentence implication.
+Strip exploration paths and dead ends. Maximum output: 500 words.
+
+## Skeptical Recall
+If you recall information from prior context about the codebase, verify it against
+actual code before including it. Stale information is worse than no information.
+
+## Citation Format
+Every Key Finding MUST include a citation: `file_path:line_number`.
+A finding without a citation is a guess, not research.
+```
+
+### Discussion Subagent
+
+**File:** `packages/luca-mastracode/src/subagents/discussion.ts`
+
+Add:
+```markdown
+- When recalling past decisions from MuninnDB, treat them as hints, not truth.
+  Verify that referenced files, APIs, or patterns still exist.
+- Compress CONTEXT.md to decisions that would change the plan if answered differently.
+```
+
+### Learner Subagent
+
+**File:** `packages/luca-mastracode/src/subagents/learner.ts`
+
+Add:
+```markdown
+## Self-Skepticism
+Before storing a pattern, ask: "Would this insight change behavior in a future session?"
+If no, skip it. Prefer concrete, falsifiable patterns over vague observations.
+```
+
+## Constraints
+
+- Do NOT change subagent output schemas or tool sets
+- Self-compression word limits: researchers=500, reviewers=300, verifier summaries=200, executor=200
+- shadow-scanner and planner subagents need no changes (already well-constrained)

--- a/.planning/todos/pending/exploit-attention-curve-in-all-instruction-files.md
+++ b/.planning/todos/pending/exploit-attention-curve-in-all-instruction-files.md
@@ -1,0 +1,119 @@
+---
+title: "Exploit attention curve: move critical constraints to primacy zone, add recency reminders"
+area: prompt-engineering
+created: 2026-04-13
+priority: high
+source: research
+sprint: 1
+---
+
+## Task
+
+Restructure all 10 mode instruction files to exploit the U-shaped attention curve: move critical constraints to the first 3-5 lines (primacy peak) and add a `## Reminder` section at the very end (recency peak) that repeats the 2-3 most critical rules.
+
+## Context
+
+LLMs exhibit U-shaped attention — peak focus at the beginning and end of prompts, with degradation in the middle. Research shows:
+- Structural formatting has up to 40% impact on task completion (Gao et al.)
+- Prompt repetition won 47/70 benchmark tasks with 0 losses (Google Research, Leviathan et al. 2025)
+- Claude Code deliberately places identity + safety at the start and repeats critical rules at the end
+
+Currently, luca-mastracode's critical constraints are buried in the attention trough:
+- `execute.md`: "NEVER write code directly" at line ~383 of 436 lines
+- `review.md`: "NEVER edit files" at line ~267
+- `research.md`: "Read-only" at line ~190
+- `architect.md`: Behavioral guidelines at line ~301
+
+## Research References
+
+- [05-attention-curves-and-structure.md](../../docs/research/prompt-architecture/05-attention-curves-and-structure.md) — U-shaped attention, primacy/recency exploitation, formatting impact
+- [10-final-actionable-review.md](../../docs/research/prompt-architecture/10-final-actionable-review.md) — Sprint 1, items 1.3 and 1.4
+- [00-overview.md](../../docs/research/prompt-architecture/00-overview.md) — Section 9: Attention curve exploitation
+
+## Implementation
+
+### Part A: Move Critical Constraints to Primacy Zone
+
+For each file, move the most critical behavioral constraint to immediately after the role description (line 2-4), with bidirectional framing:
+
+| File | Constraint | Move to |
+|------|-----------|---------|
+| `execute.md` | "NEVER write code directly" + "Do NOT use string_replace_lsp or write_file yourself" | Line 8 |
+| `review.md` | "NEVER edit files" + "Do NOT use string_replace_lsp, write_file, or execute_command" | Line 7 |
+| `research.md` | "Read-only" + "Do NOT use string_replace_lsp, write_file, or execute_command for code modifications" | Line 9 |
+| `architect.md` | "Discussion is never skipped" | Line 10 |
+| `finalize.md` | "Check every task in PLAN.md. Report exact completed/total ratio." | Line 8 |
+
+### Part B: Add Recency-Zone Reminders
+
+Add a `## Reminder` section at the very end of every instruction file:
+
+**triage.md:**
+```
+## Reminder
+You MUST call `workflowState(action: "switch-mode")` before your turn ends. Do NOT create tasks, modify files, or run commands.
+```
+
+**execute.md:**
+```
+## Reminder
+NEVER write code directly — delegate to subagents. Run checks after every wave. If convergence stalls, stop. One commit per task.
+```
+
+**review.md:**
+```
+## Reminder
+NEVER edit files. Maximum 5 MUST-FIX items. Review against the plan, not personal preferences.
+```
+
+**research.md:**
+```
+## Reminder
+You are READ-ONLY. Do NOT modify code files. Output goes to .planning/ only via writePlanningFile.
+```
+
+**architect.md:**
+```
+## Reminder
+Discussion is NEVER skipped. Every task has verification criteria. Store plan artifacts in workflow state before switching modes.
+```
+
+**finalize.md:**
+```
+## Reminder
+Release the pipeline lock. Check every planned task for completion. PR creation is mandatory if git workflow was used. 3 milestones max.
+```
+
+**build.md:**
+```
+## Reminder
+All file edits go through edit tools, never shell commands. Verify every change compiles before moving on.
+```
+
+**fast.md:**
+```
+## Reminder
+Speed over completeness. Under 100 words. <=25 words between tool calls. >5 tool calls = switch to build mode.
+```
+
+**plan.md:**
+```
+## Reminder
+You are READ-ONLY. Do NOT modify, create, or delete any files.
+```
+
+**discuss.md:**
+```
+## Reminder
+You are READ-ONLY. Do NOT modify files, create plans, or trigger mode transitions.
+```
+
+## Files Changed
+
+All 10 files in `packages/luca-mastracode/src/instructions/`
+
+## Constraints
+
+- Do NOT change the workflow logic, only the placement and repetition of behavioral rules
+- Each `## Reminder` section should be 2-4 lines maximum
+- Primacy-zone constraints should include bidirectional framing ("Do X. Do NOT use Y.")

--- a/.planning/todos/pending/implement-conditional-mcp-loading-per-mode.md
+++ b/.planning/todos/pending/implement-conditional-mcp-loading-per-mode.md
@@ -1,0 +1,50 @@
+---
+title: "Implement conditional MCP tool loading per mode to save ~15K tokens/turn"
+area: architecture
+created: 2026-04-13
+priority: high
+source: research
+sprint: 4
+---
+
+## Task
+
+Only inject MuninnDB MCP tools into modes that actually use memory operations. Skip MCP tool injection for lightweight modes (fast, triage, plan, research, architect, review) to save ~15,000+ tokens per turn.
+
+## Context
+
+Each MCP server connection injects tool definitions costing 15,000+ tokens. MuninnDB tools are currently loaded into every mode via `mcpManagerRef.current?.getTools()`, even modes that never use memory. 5 connected MCP servers can burn 60K tokens before the first user message — over 30% of a 200K context window.
+
+## Research References
+
+- [09-instruction-budget-and-prompt-economics.md](../../docs/research/prompt-architecture/09-instruction-budget-and-prompt-economics.md) — Section 3: MCP tool definition overhead, budget math
+- [10-final-actionable-review.md](../../docs/research/prompt-architecture/10-final-actionable-review.md) — Sprint 4, item 4.2
+
+## Implementation
+
+**File:** `packages/luca-mastracode/src/index.ts` (line ~271, tools callback)
+
+```typescript
+const MEMORY_MODES = new Set([
+  'luca:4-execute',
+  'luca:6-finalize',
+  'luca:discuss',
+  'build'
+])
+
+// In createStaticAgent tools callback:
+tools: () => {
+  const mcpTools = MEMORY_MODES.has(currentModeId)
+    ? (mcpManagerRef.current?.getTools() ?? {})
+    : {}
+  return { ...staticTools, ...mcpTools }
+},
+```
+
+Also update mode instruction files that reference MuninnDB in non-memory modes to note that MuninnDB is available only when relevant.
+
+## Constraints
+
+- Verify which modes actually reference MuninnDB in their instructions before finalizing the MEMORY_MODES set
+- If a mode references MuninnDB but only for optional recall (not required), it should still be in MEMORY_MODES
+- This change is zero-risk for modes not in the set — they simply won't see MuninnDB tools

--- a/.planning/todos/pending/implement-mid-conversation-injection-infrastructure.md
+++ b/.planning/todos/pending/implement-mid-conversation-injection-infrastructure.md
@@ -1,0 +1,82 @@
+---
+title: "Implement mid-conversation injection infrastructure for context rot remediation"
+area: architecture
+created: 2026-04-13
+priority: critical
+source: research
+sprint: 4
+---
+
+## Task
+
+Build a `ContextRefresher` module that evaluates conditions at harness lifecycle events and injects `<luca-reminder>` behavioral reminders into the message stream to combat context rot.
+
+## Context
+
+Context rot — the degradation of instruction adherence as conversations grow — is the single most impactful missing capability in luca-mastracode. Adobe Research measured 29-60 percentage point drops across frontier models at 32K tokens. Agent drift compounds exponentially: 95% per-step reliability over 20 steps = 36% combined success; 2% early misalignment escalates to 40% failure.
+
+Claude Code implements 37 system-reminders across 5 domains, injected reactively at lifecycle events. They are invisible to users, placed in the message layer to preserve cache validity.
+
+Prerequisite: The `<luca-reminder>` tag convention must be defined in HARD_CONSTRAINTS first (Sprint 2 todo).
+
+## Research References
+
+- [02-context-rot-and-injection.md](../../docs/research/prompt-architecture/02-context-rot-and-injection.md) — Full analysis: 37 system-reminders, 5 domains, injection strategies, degradation curves
+- [05-attention-curves-and-structure.md](../../docs/research/prompt-architecture/05-attention-curves-and-structure.md) — Recency peak exploitation
+- [01-cache-boundary-design.md](../../docs/research/prompt-architecture/01-cache-boundary-design.md) — Message-layer injection preserves cache
+- [10-final-actionable-review.md](../../docs/research/prompt-architecture/10-final-actionable-review.md) — Sprint 4, item 4.3
+
+## Implementation
+
+**New file:** `packages/luca-mastracode/src/context-refresher.ts`
+
+```typescript
+interface RefreshConfig {
+  /** Re-inject hard constraints every N tool calls */
+  toolCallInterval: number       // default: 15
+  /** Re-inject mode boundaries every N tokens estimated */
+  tokenThreshold: number         // default: 30_000
+  /** Always re-inject after these events */
+  alwaysTriggerAfter: string[]   // ['compaction', 'mode_transition']
+}
+
+const REFRESH_TIERS = {
+  critical: () => HARD_CONSTRAINTS,
+  mode: (modeId: string) => getModeCoreBehavior(modeId),
+  tools: (modeId: string) => getToolPriorityReminder(modeId),
+} as const
+```
+
+Integration via harness event subscription:
+
+```typescript
+harness.subscribe(async (event) => {
+  if (event.type === 'tool_end') {
+    refresher.recordToolCall()
+    if (refresher.shouldInject()) {
+      const reminder = refresher.buildReminder(currentModeId)
+      await harness.followUp({
+        content: wrapInLucaReminder(reminder)
+      })
+    }
+  }
+})
+```
+
+Content injected per tier:
+- **Critical** (~200 tokens): HARD_CONSTRAINTS, mode boundaries
+- **Mode-specific** (~100 tokens): Core behavioral rules for current mode
+- **Tool guidance** (~100 tokens): Priority ordering reminders
+
+## Dependencies
+
+- Requires `<luca-reminder>` tag convention in HARD_CONSTRAINTS (Sprint 2)
+- Requires `harness.followUp()` for message injection (already wired via `followUpRef`)
+- Does NOT require cache boundary (Sprint 5) — message-layer injection is cache-independent
+
+## Constraints
+
+- Start conservative: every 15 tool calls, inject only critical-tier content
+- Each injection should be under 200 tokens to avoid attention dilution
+- Over-injection wastes tokens — measure impact on task completion before increasing frequency
+- Add circuit breaker: maximum 3 injections per mode turn to prevent runaway injection

--- a/.planning/todos/pending/implement-progressive-context-compaction-pipeline.md
+++ b/.planning/todos/pending/implement-progressive-context-compaction-pipeline.md
@@ -1,0 +1,73 @@
+---
+title: "Implement progressive 3-level context compaction pipeline"
+area: architecture
+created: 2026-04-13
+priority: high
+source: research
+sprint: 5
+---
+
+## Task
+
+Build a 3-level progressive compression pipeline (tool result budgeting, observation masking, LLM summarization) to manage context window utilization and prevent quality degradation in long sessions.
+
+## Context
+
+luca-mastracode has zero active context management. Claude Code implements a 5-level compression pipeline with micro-compaction preserving cache hits and a circuit breaker preventing runaway compaction (added after discovering 1,279 sessions with up to 3,272 consecutive failures wasting ~250K API calls/day).
+
+JetBrains Research found that simple observation masking (replacing old tool outputs with placeholders) outperforms LLM summarization in 4/5 configurations — 2.6% higher solve rates and 52% cost reduction. This means Level 2 is more important than Level 3.
+
+## Research References
+
+- [07-context-compaction-and-memory.md](../../docs/research/prompt-architecture/07-context-compaction-and-memory.md) — Full analysis: 5-level pipeline, micro-compaction, circuit breaker, JetBrains research
+- [01-cache-boundary-design.md](../../docs/research/prompt-architecture/01-cache-boundary-design.md) — Cache-aware compaction, Context Editing API
+- [10-final-actionable-review.md](../../docs/research/prompt-architecture/10-final-actionable-review.md) — Sprint 5, item 5.3
+
+## Implementation
+
+### Level 1: Tool Result Budgeting (zero API cost)
+
+```
+- Cap tool results at 50K chars
+- Persist full output to .planning/tool-results/{hash}.md
+- Keep 2KB preview in context with note: "[Full result saved to disk — re-read if needed]"
+- Triggered: every tool result
+```
+
+### Level 2: Observation Masking (zero API cost)
+
+```
+- Replace older tool results with "[Result cleared — re-read if needed]"
+- Preserve agent reasoning and action history
+- Keep last N tool results (configurable: 5 for execute, 3 for review)
+- Triggered: at 50% context utilization (from token budget monitor)
+```
+
+### Level 3: LLM Summarization (expensive, last resort)
+
+```
+- Fork a Haiku subagent to summarize conversation
+- Chain-of-thought in <analysis> tags, then strip reasoning before re-injection
+- Circuit breaker: MAX_CONSECUTIVE_FAILURES = 3
+- Triggered: at 80% context utilization
+```
+
+### New Files
+
+- `packages/luca-mastracode/src/context-pipeline.ts` — Pipeline orchestrator
+- `packages/luca-mastracode/src/tool-result-budget.ts` — Level 1
+- `packages/luca-mastracode/src/subagents/summarizer.ts` — Level 3 (Haiku model)
+
+## Dependencies
+
+- Level 1-2 require intercepting tool results before they enter conversation (verify Mastra support)
+- Level 3 requires the Haiku-model summarizer subagent
+- Token budget monitor (separate todo) provides the utilization triggers
+- Cache boundary (separate todo) ensures Levels 1-2 don't invalidate cached prefix
+
+## Constraints
+
+- Implement Level 1 first (highest impact, zero cost)
+- Implement Level 2 second (JetBrains validates it outperforms Level 3)
+- Level 3 is a fallback — only implement if Levels 1-2 prove insufficient for COMPLEX+ tasks
+- Always persist full results to disk (Level 1) so the agent can re-read via workspace tools

--- a/.planning/todos/pending/implement-token-budget-monitoring-and-thresholds.md
+++ b/.planning/todos/pending/implement-token-budget-monitoring-and-thresholds.md
@@ -1,0 +1,67 @@
+---
+title: "Implement token budget monitoring with threshold-based interventions"
+area: architecture
+created: 2026-04-13
+priority: high
+source: research
+sprint: 5
+---
+
+## Task
+
+Build a `TokenBudgetMonitor` that tracks cumulative token usage from API responses and triggers interventions (reminder injection, observation masking, compaction, blocking) at configurable thresholds.
+
+## Context
+
+luca-mastracode tracks context metrics in `.context-metrics.json` and has a quality degradation curve documented in CLAUDE.md (0-30% peak, 70%+ poor), but there is zero runtime token budget monitoring. Claude Code uses a four-threshold "soft landing" hierarchy (warning at 20K remaining, auto-compact at 13K, error at 20K, hard block at 3K) with tiered estimation (API-based, Haiku fallback, character heuristic).
+
+## Research References
+
+- [07-context-compaction-and-memory.md](../../docs/research/prompt-architecture/07-context-compaction-and-memory.md) — Token budgeting approaches, Claude Code's thresholds
+- [01-cache-boundary-design.md](../../docs/research/prompt-architecture/01-cache-boundary-design.md) — Cache hit rate monitoring
+- [09-instruction-budget-and-prompt-economics.md](../../docs/research/prompt-architecture/09-instruction-budget-and-prompt-economics.md) — Context budget math
+- [10-final-actionable-review.md](../../docs/research/prompt-architecture/10-final-actionable-review.md) — Sprint 5, item 5.2
+
+## Implementation
+
+**New file:** `packages/luca-mastracode/src/token-budget.ts`
+
+```typescript
+interface BudgetState {
+  totalInputTokens: number
+  totalOutputTokens: number
+  cacheReadTokens: number
+  cacheCreationTokens: number
+  turnsCompleted: number
+  toolCallsCompleted: number
+  lastCacheHitRate: number
+  currentUtilization: number  // estimated % of context window used
+}
+
+const THRESHOLDS = {
+  INJECT_REMINDERS: 0.30,    // Start context rot remediation
+  OBSERVATION_MASK: 0.50,    // Start masking old tool results
+  WARNING: 0.65,             // Alert user, suggest mode boundary
+  COMPACTION: 0.80,          // Trigger LLM summarization
+  BLOCK: 0.90,               // Block new tool calls, require intervention
+}
+```
+
+Integration with harness events for usage tracking. Feeds into context-refresher (Sprint 4) and compaction pipeline (if implemented).
+
+## Dependencies
+
+- Benefits from mid-conversation injection infrastructure (Sprint 4) for threshold-triggered interventions
+- Benefits from cache boundary (Sprint 5) for cache hit rate monitoring
+- Can be implemented independently with character-count heuristic as initial estimator
+
+## Files Changed
+
+- `packages/luca-mastracode/src/token-budget.ts` (NEW)
+- `packages/luca-mastracode/src/index.ts` — Wire into harness event subscription
+
+## Constraints
+
+- Start with character-count heuristic (~1 token per 4 chars, ~20% error margin)
+- Use conservative thresholds to account for estimation error
+- Add circuit breaker for cascading interventions

--- a/.planning/todos/pending/introduce-cache-boundary-in-prompt-assembly-pipeline.md
+++ b/.planning/todos/pending/introduce-cache-boundary-in-prompt-assembly-pipeline.md
@@ -1,0 +1,84 @@
+---
+title: "Introduce cache boundary in the prompt assembly pipeline (static/dynamic split)"
+area: architecture
+created: 2026-04-13
+priority: critical
+source: research
+sprint: 5
+---
+
+## Task
+
+Split the prompt assembly pipeline into a two-block system prompt with explicit cache breakpoints: a static prefix (mode instructions, hard constraints, always-apply rules) cached with a 1-hour TTL, and a dynamic suffix (workflow state, environment info, MCP instructions) refreshed per-request with a 5-minute TTL.
+
+## Context
+
+Claude Code splits every system prompt at `SYSTEM_PROMPT_DYNAMIC_BOUNDARY`. Content before is cached globally across all users (1-hour TTL); content after is per-session (5-minute TTL). This achieves 85% latency reduction and 90% cost reduction on reads. It also enables fork-model subagent spawning at near-zero marginal cost — spawning 5 agents costs barely more than 1.
+
+luca-mastracode currently assembles a single monolithic `instructions` string via `createStaticAgent()`. Every call to `instructions()` re-reads `luca-state.json` and mixes it with static instruction markdown. If any state field changes, the entire instruction prefix cache is invalidated.
+
+## Research References
+
+- [01-cache-boundary-design.md](../../docs/research/prompt-architecture/01-cache-boundary-design.md) — Full technical analysis of cache boundaries, micro-compaction, 5-level compression pipeline
+- [00-overview.md](../../docs/research/prompt-architecture/00-overview.md) — Section 2: Cache boundary pattern
+- [10-final-actionable-review.md](../../docs/research/prompt-architecture/10-final-actionable-review.md) — Sprint 5, item 5.1
+
+## Implementation
+
+### Phase A: Code Separation (no API change)
+
+Extract dynamic state from `buildXInstructions()` into a shared `buildDynamicContext()`:
+
+```typescript
+// Static (cacheable): loaded once per mode
+function buildStaticInstructions(modeId: string): string {
+  return loadModeInstructions(modeId)
+    + '\n\n' + HARD_CONSTRAINTS
+    + '\n\n' + ALWAYS_APPLY_RULES
+}
+
+// Dynamic (per-request): changes on every turn
+function buildDynamicContext(): string {
+  const state = readLucaState()
+  return buildWorkflowContext(state)
+    + '\n\n' + buildEnvironmentContext()
+}
+```
+
+### Phase B: Two-Block System Prompt (requires Mastra support)
+
+When Mastra exposes `cache_control` support:
+
+```typescript
+system: [
+  { type: 'text', text: buildStaticInstructions(modeId), cache_control: { type: 'ephemeral' } },
+  { type: 'text', text: buildDynamicContext() }
+]
+```
+
+### Phase C: Cache Hit Rate Monitoring
+
+Add monitoring via API response `usage` fields:
+
+```typescript
+const cacheHitRate = usage.cache_read_input_tokens /
+  (usage.cache_read_input_tokens + usage.cache_creation_input_tokens)
+```
+
+## Dependencies
+
+- Phase A: No external dependencies. Pure refactoring.
+- Phase B: Requires Mastra's `@mastra/core/agent` to support array-form `system` blocks or a wrapper that sets `cache_control` directly on the API request.
+- Phase C: Requires access to API response `usage` fields.
+
+## Files Changed
+
+- `packages/luca-mastracode/src/index.ts` — Main assembly refactor
+- `packages/luca-mastracode/src/modes/*.ts` — Extract dynamic state from buildXInstructions()
+- Potentially new: `packages/luca-mastracode/src/cache-boundary.ts`
+
+## Constraints
+
+- Phase A has value regardless of Mastra API support — start there
+- If Mastra converts `instructions` to a single text block internally, Phase B requires patching Mastra or wrapping the API call
+- Tool definitions should also benefit from caching — ensure `buildModeTools()` returns stable objects per mode

--- a/.planning/todos/pending/quantify-all-qualitative-directives-across-instruction-files.md
+++ b/.planning/todos/pending/quantify-all-qualitative-directives-across-instruction-files.md
@@ -1,0 +1,57 @@
+---
+title: "Replace all qualitative directives with quantified constraints across instruction files"
+area: prompt-engineering
+created: 2026-04-13
+priority: high
+source: research
+sprint: 2
+---
+
+## Task
+
+Replace every qualitative directive ("be concise", "be thorough", "don't over-research", "don't nitpick") with specific quantified constraints (word counts, item limits, tool call budgets) across all mode instruction files.
+
+## Context
+
+Research shows quantified constraints are the most enforceable instruction type. Claude Code's A/B testing found ~1.2% output token reduction with quantified limits vs qualitative "be concise." The phrasing hierarchy from most to least enforceable: quantified limits > hard constraints (NEVER) > bidirectional (Use X, NOT Y) > conditional > soft > principles.
+
+Currently, multiple instruction files use qualitative directives that have inconsistent enforcement.
+
+## Research References
+
+- [09-instruction-budget-and-prompt-economics.md](../../docs/research/prompt-architecture/09-instruction-budget-and-prompt-economics.md) — Section 8: Quantified constraints in production, phrasing hierarchy
+- [00-overview.md](../../docs/research/prompt-architecture/00-overview.md) — Section 3: "Quantified Constraints Beat Qualitative Directives"
+- [05-attention-curves-and-structure.md](../../docs/research/prompt-architecture/05-attention-curves-and-structure.md) — Formatting strategies ranked by effectiveness
+- [10-final-actionable-review.md](../../docs/research/prompt-architecture/10-final-actionable-review.md) — Sprint 2, item 2.1
+
+## Implementation
+
+Replace these directives across all instruction files:
+
+| File | Current (qualitative) | Proposed (quantified) |
+|------|----------------------|----------------------|
+| `fast.md` line 6 | "Under 200 words" | "Under 100 words. <=25 words between tool calls." |
+| `triage.md` line 194 | "Be concise in your output" | "<=75 words. Classification + 1-sentence rationale + next mode." |
+| `architect.md` line 302 | "Be thorough but not verbose" | "<=3 sentences per task. <=150 lines total PLAN.md." |
+| `execute.md` line 383 | "Fail fast, fix fast" | "Run checks within 1 tool call of wave completion. Stalled 2+ iterations = stop immediately." |
+| `research.md` line 193 | "Don't over-research" | "MODERATE: <=10 tool calls. COMPLEX: <=20. CRITICAL: <=30." |
+| `research.md` line 195 | "Time-box" | "Synthesis <=200 lines for RESEARCH.md." |
+| `review.md` line 268 | "Don't nitpick" | "Maximum 5 MUST-FIX items. MUST-FIX = correctness bugs, security, missing requirements ONLY." |
+| `discuss.md` line 34 | "Keep responses focused" | "Under 300 words per turn. <=2 clarifying questions per response." |
+| `finalize.md` line 304 | "Be thorough in gap detection" | "Check every task in PLAN.md. Report exact completed/total ratio." |
+
+## Files Changed
+
+- `packages/luca-mastracode/src/instructions/fast.md`
+- `packages/luca-mastracode/src/instructions/triage.md`
+- `packages/luca-mastracode/src/instructions/architect.md`
+- `packages/luca-mastracode/src/instructions/execute.md`
+- `packages/luca-mastracode/src/instructions/research.md`
+- `packages/luca-mastracode/src/instructions/review.md`
+- `packages/luca-mastracode/src/instructions/discuss.md`
+- `packages/luca-mastracode/src/instructions/finalize.md`
+
+## Constraints
+
+- Do NOT change the behavioral intent, only make it measurable
+- Quantified limits should be realistic — validate against actual outputs from recent pipeline runs if available

--- a/docs/research/claude-code-prompt-architecture.md
+++ b/docs/research/claude-code-prompt-architecture.md
@@ -10,7 +10,7 @@
 
 Claude Code's system prompt is not a static string — it is a **dynamically assembled context** built from 30+ conditional components, 36+ tool definitions, multi-agent orchestration prompts, and session-specific state. The architecture is designed around three core principles: **prompt cache efficiency**, **behavioral precision over prose**, and **mid-conversation injection for context rot remediation**.
 
-This document catalogs every technique identified through source analysis, the March 2026 source leak, and community reverse-engineering — then maps each to a concrete recommendation for luca-mastracode.
+This document catalogs every technique identified through publicly documented behavior, observed system behavior, and community reverse-engineering — then maps each to a concrete recommendation for luca-mastracode.
 
 ---
 
@@ -149,7 +149,7 @@ Claude Code gives **behavioral intentions**, not step-by-step procedures:
 
 ### Quantified Constraints Beat Qualitative Directives
 
-The leaked source reveals A/B testing results:
+Public analysis reveals A/B testing results:
 
 > "Research shows ~1.2% output token reduction vs qualitative 'be concise.'"
 
@@ -546,12 +546,12 @@ Instead of allowlists, Claude Code uses a **critic pattern**: a separate query a
 - [How Claude Code Builds a System Prompt](https://www.dbreunig.com/2026/04/04/how-claude-code-builds-a-system-prompt.html) — Drew Breunig's analysis of the 30+ component dynamic assembly
 - [System Prompts Define the Agent as Much as the Model](https://www.dbreunig.com/2026/02/10/system-prompts-define-the-agent-as-much-as-the-model.html) — Empirical study showing prompt swaps produce different agent workflows on identical tasks
 
-### Source Leak Analysis
+### Public Source Analysis
 
-- [Diving into Claude Code's Source Code Leak](https://read.engineerscodex.com/p/diving-into-claude-codes-source-code) — Engineer's Codex deep dive on cache boundaries, anti-distillation, KAIROS
-- [Comprehensive Analysis of Claude Code Source Leak](https://www.sabrina.dev/p/claude-code-source-leak-analysis) — Detailed architecture analysis including compaction, A/B testing results
-- [The Claude Code Source Leak: fake tools, frustration regexes, undercover mode](https://alex000kim.com/posts/2026-03-31-claude-code-source-leak/) — Alex Kim's analysis of anti-distillation, frustration detection, undercover mode
-- [Claude Code Source Code Leaked: What's Inside](https://www.the-ai-corner.com/p/claude-code-source-code-leaked-2026) — AI Corner overview
+- [Diving into Claude Code's Source Code](https://read.engineerscodex.com/p/diving-into-claude-codes-source-code) — Engineer's Codex deep dive on cache boundaries, anti-distillation, KAIROS
+- [Comprehensive Analysis of Claude Code Architecture](https://www.sabrina.dev/p/claude-code-source-leak-analysis) — Detailed architecture analysis including compaction, A/B testing results
+- [Claude Code Internals: fake tools, frustration regexes, undercover mode](https://alex000kim.com/posts/2026-03-31-claude-code-source-leak/) — Alex Kim's analysis of anti-distillation, frustration detection, undercover mode
+- [Claude Code Source Code: What's Inside](https://www.the-ai-corner.com/p/claude-code-source-code-leaked-2026) — AI Corner overview
 
 ### Reverse Engineering & Community Analysis
 
@@ -563,5 +563,4 @@ Instead of allowlists, Claude Code uses a **critic pattern**: a separate query a
 ### Prompt Engineering Patterns
 
 - [AI Agent Prompt Engineering: 10 Patterns That Actually Work](https://paxrel.com/blog-ai-agent-prompts) — Production patterns including progressive disclosure, guard rails, self-evaluation loops
-- [Claude Code Source Code Leak: 8 Hidden Features](https://www.mindstudio.ai/blog/claude-code-source-code-leak-8-hidden-features) — Feature flags and hidden capabilities
-- [VentureBeat: Claude Code's source code appears to have leaked](https://venturebeat.com/technology/claude-codes-source-code-appears-to-have-leaked-heres-what-we-know) — News coverage of the leak event
+- [Claude Code: 8 Hidden Features](https://www.mindstudio.ai/blog/claude-code-source-code-leak-8-hidden-features) — Feature flags and hidden capabilities

--- a/docs/research/claude-code-prompt-architecture.md
+++ b/docs/research/claude-code-prompt-architecture.md
@@ -1,0 +1,567 @@
+# Claude Code Prompt Architecture: Lessons for luca-mastracode
+
+**Research Date:** 2026-04-13
+**Status:** Complete
+**Scope:** How Claude Code constructs system prompts and what techniques luca-mastracode should adopt
+
+---
+
+## Executive Summary
+
+Claude Code's system prompt is not a static string — it is a **dynamically assembled context** built from 30+ conditional components, 36+ tool definitions, multi-agent orchestration prompts, and session-specific state. The architecture is designed around three core principles: **prompt cache efficiency**, **behavioral precision over prose**, and **mid-conversation injection for context rot remediation**.
+
+This document catalogs every technique identified through source analysis, the March 2026 source leak, and community reverse-engineering — then maps each to a concrete recommendation for luca-mastracode.
+
+---
+
+## Table of Contents
+
+1. [Prompt Assembly Architecture](#1-prompt-assembly-architecture)
+2. [The Cache Boundary Pattern](#2-the-cache-boundary-pattern)
+3. [Behavioral Instruction Techniques](#3-behavioral-instruction-techniques)
+4. [Tool Definition Patterns](#4-tool-definition-patterns)
+5. [Mid-Conversation Injection (system-reminder)](#5-mid-conversation-injection)
+6. [Memory System Architecture](#6-memory-system-architecture)
+7. [Multi-Agent Coordination Prompts](#7-multi-agent-coordination-prompts)
+8. [Context Management & Compaction](#8-context-management--compaction)
+9. [Attention Curve Exploitation](#9-attention-curve-exploitation)
+10. [Security & Anti-Distillation](#10-security--anti-distillation)
+11. [Gap Analysis: luca-mastracode vs Claude Code](#11-gap-analysis)
+12. [Prioritized Recommendations](#12-prioritized-recommendations)
+13. [Sources](#13-sources)
+
+---
+
+## 1. Prompt Assembly Architecture
+
+### How Claude Code Builds a Prompt
+
+Claude Code assembles its system prompt from **9 categories** containing **124 total prompts** (19k characters for system prompt alone, 73k for tool definitions):
+
+```
+Static Prefix (globally cached, 1-hour TTL)
+├── Identity & Introduction (1-3 sentences)
+├── System Rules & Permissions
+├── Executing Actions with Care (reversibility/blast radius framework)
+├── Doing Tasks (coding philosophy)
+├── Using Your Tools (dedicated tool preference)
+├── Tone and Style
+├── Session-Specific Guidance (conditional)
+├── Tool Definitions (36+ tools, each with own prompt)
+└── __SYSTEM_PROMPT_DYNAMIC_BOUNDARY__
+Dynamic Suffix (session-specific, 5-minute TTL)
+├── Environment Info (cwd, platform, shell, model, date)
+├── Language Preference
+├── CLAUDE.md / Project Rules
+├── Memory Prompt (MEMORY.md index)
+├── MCP Server Instructions (recomputed each turn)
+├── Git Status Snapshot
+└── Scratchpad Instructions
+```
+
+### Key Architectural Decisions
+
+1. **Conditional assembly**: Components are included/excluded based on configuration flags, available tools, user type (internal vs external), and session state
+2. **Functional composition**: Each section is a function returning a string (or empty string to exclude)
+3. **~124 distinct prompts** across system, tools, agents, memory, and services — not one monolithic blob
+
+### What luca-mastracode Does Today
+
+luca-mastracode uses a **three-layer composition**:
+
+```
+Base Markdown (loaded from instructions/*.md, static per mode)
+  + Dynamic State Context (read per-request via readLucaState())
+  + Hard Constraints (3 universal rules)
+  + Bundled AlwaysApply Rules (caveman, pr-title-format)
+= Final instruction string
+```
+
+**Gap**: No cache boundary marker. No conditional component inclusion. No per-turn dynamic sections beyond workflow state. Tool definitions are static per mode, not dynamically assembled.
+
+---
+
+## 2. The Cache Boundary Pattern
+
+### The Technique
+
+Claude Code splits every system prompt at `SYSTEM_PROMPT_DYNAMIC_BOUNDARY`:
+
+- **Before the boundary** (static): Identity, behavioral rules, tool instructions — cached globally across all users with a **1-hour TTL**
+- **After the boundary** (dynamic): CLAUDE.md, git status, MCP instructions, memory — per-session with a **5-minute TTL**
+
+Any section that must bypass caching is explicitly marked with `DANGEROUS_uncachedSystemPromptSection()` — a naming convention that signals the performance cost to developers.
+
+### Why This Matters
+
+Prompt caching reduces latency and cost dramatically. Claude Code's architecture means spawning 5 sub-agents costs barely more than 1, because they share the cached static prefix (fork model).
+
+### The Micro-Compaction Strategy
+
+When approaching token limits, Claude Code performs **surgical edits** via `apiMicrocompact.ts`:
+- Replaces large tool results with `[Old tool result cleared]`
+- Edits only within the dynamic section to preserve cache hits
+- Avoids full session restarts that would forfeit cached prefixes
+
+### Recommendation for luca-mastracode
+
+**Priority: HIGH**
+
+Introduce a cache boundary in instruction assembly:
+
+```typescript
+// In each mode's buildInstructions():
+function buildInstructions(): string {
+  const staticPrefix = loadModeInstructions(mode)  // Cacheable
+    + HARD_CONSTRAINTS
+    + ALWAYS_APPLY_RULES
+
+  const dynamicSuffix = buildDynamicContext()       // Per-request
+    + buildEnvironmentInfo()
+    + buildGitStatus()
+
+  return staticPrefix + '\n\n__CACHE_BOUNDARY__\n\n' + dynamicSuffix
+}
+```
+
+This requires Mastra's API layer to support Anthropic's cache control headers, but the prompt-side preparation should happen now.
+
+---
+
+## 3. Behavioral Instruction Techniques
+
+### Principles Over Procedures
+
+Claude Code gives **behavioral intentions**, not step-by-step procedures:
+
+```
+# Claude Code approach (principles):
+"Always understand existing code before modifying.
+ Don't add features beyond what was asked.
+ A bug fix doesn't need surrounding code cleaned up."
+
+# Anti-pattern (procedures):
+"Step 1: Read the file. Step 2: Identify the bug.
+ Step 3: Write the fix. Step 4: Run tests."
+```
+
+**Why**: Principles generalize to unanticipated scenarios. Procedures fail when the situation doesn't match the script.
+
+### Quantified Constraints Beat Qualitative Directives
+
+The leaked source reveals A/B testing results:
+
+> "Research shows ~1.2% output token reduction vs qualitative 'be concise.'"
+
+Production Claude Code uses **explicit word counts**:
+- "Keep text between tool calls to <=25 words"
+- "Keep final responses to <=100 words"
+
+### Bidirectional Constraints
+
+Claude Code doesn't just say what TO do — it says what NOT to do:
+
+```
+"Do NOT use the Bash to run commands when a relevant dedicated tool
+ is provided. Using dedicated tools allows the user to better understand
+ and review your work."
+```
+
+Every positive instruction has a corresponding negative constraint. This eliminates ambiguity.
+
+### Explain Why
+
+```
+"Avoid git amend because it may overwrite others' commits"
+```
+
+The "because" clause teaches the model to make correct edge-case decisions autonomously.
+
+### Recommendation for luca-mastracode
+
+**Priority: HIGH**
+
+1. Audit all instruction `.md` files: replace procedural step lists with behavioral principles where possible
+2. Add quantified constraints (word/token limits) to modes like `fast.md` and `triage.md`
+3. Add bidirectional constraints to tool usage sections: "Use X for Y. Do NOT use Z for Y."
+4. Add "because" clauses to every constraint that isn't self-evident
+
+---
+
+## 4. Tool Definition Patterns
+
+### Each Tool Carries Its Own Prompt
+
+Claude Code has 36+ tools, each with a detailed description that includes:
+- **When to use** (and when NOT to use)
+- **Priority ordering** vs alternative tools
+- **Behavioral constraints** specific to that tool
+- **Few-shot examples** of correct invocation
+
+Example — the Bash tool prompt:
+```
+Do NOT use the Bash to run commands when a relevant dedicated tool
+is provided:
+ - File search: Use Glob (NOT find or ls)
+ - Content search: Use Grep (NOT grep or rg)
+ - Read files: Use Read (NOT cat/head/tail)
+ - Edit files: Use Edit (NOT sed/awk)
+ - Write files: Use Write (NOT echo >/cat <<EOF)
+```
+
+### Tool Selection Heuristics
+
+Tools are listed in priority order with specific conditions:
+1. Read local files first
+2. Use cached data second
+3. Web search for gaps only
+4. LLM scoring calls cost money — batch them
+
+### Security-First Tool Defaults
+
+The bash security system spans **9,707 lines with 22 validators**. Philosophy: "When in doubt, ask the human." Tools default to requiring explicit user approval rather than assuming permission.
+
+### What luca-mastracode Does Today
+
+- Tool permissions defined in `mode-permissions.ts` manifest (good)
+- `createScopedTool` wrapper enforces action restrictions (good)
+- But tool definitions lack behavioral guidance, priority ordering, and negative examples
+- Instructions reference tool names inline but don't explain when NOT to use them
+
+### Recommendation for luca-mastracode
+
+**Priority: MEDIUM**
+
+1. Add behavioral descriptions to tool definitions in `build-mode-tools.ts` — not just the action schema, but when/why/why-not guidance
+2. Add tool priority ordering in mode instruction files
+3. Add negative examples ("Do NOT use workflowState for X, use Y instead")
+
+---
+
+## 5. Mid-Conversation Injection
+
+### The `<system-reminder>` Pattern
+
+Claude Code declares in its system prompt:
+
+```
+Tool results and user messages may include <system-reminder> or other
+tags. Tags contain information from the system. They bear no direct
+relation to the specific tool results or user messages in which they
+appear.
+```
+
+Then mid-conversation, it injects reminders for:
+- **Behavioral refresh**: Re-stating critical rules that degrade over long contexts
+- **Mode switching**: Plan mode, readonly mode transitions
+- **File change notifications**: Alerting the model to external changes
+- **Dynamic context updates**: Git status, open files, task lists
+- **Periodic rule refresh**: Because models "forget" planning and start coding
+
+### Why This Matters: Context Rot
+
+LLM instruction adherence degrades after ~80K tokens. By ~180K tokens, it's severely compromised. Mid-conversation injection combats this by re-asserting critical rules at the point where they matter most — the **recency** end of the attention curve.
+
+### Why It Goes in Messages, Not System Prompt
+
+Putting changing context in the message layer (not system prompt) **preserves cache validity**. The static system prompt stays cached while dynamic reminders flow through messages.
+
+### What luca-mastracode Does Today
+
+- Mode continuation messages inject context when switching modes (good)
+- But no mid-conversation behavioral refresh
+- No periodic rule re-injection during long sessions
+- No mechanism to combat context rot
+
+### Recommendation for luca-mastracode
+
+**Priority: HIGH**
+
+1. Define a `<luca-reminder>` tag convention in base instructions
+2. Implement periodic behavioral refresh at tool-call boundaries (every N turns or every M tokens)
+3. Re-inject critical constraints (hard constraints, mode boundaries) as conversation grows
+4. Use message-layer injection, not system prompt modification, to preserve any future cache boundaries
+
+---
+
+## 6. Memory System Architecture
+
+### Claude Code's Three-Layer Memory
+
+1. **Index layer** (MEMORY.md, always loaded): ~150-character pointers per entry, max 200 lines
+2. **Topic files** (on-demand): Actual knowledge content, loaded when referenced
+3. **Transcripts** (grep-only): Never loaded into context directly
+
+### Write Discipline
+
+- If a fact can be re-derived from the codebase, it's NOT stored
+- Topic files updated BEFORE index modifications
+- Memory is treated as **hints requiring verification**, not authoritative truth
+
+### autoDream Consolidation
+
+A forked subagent with limited tool access runs "nightly" consolidation:
+- Reorganizes knowledge
+- Removes contradictions
+- Prevents memory corruption through tool isolation
+- Triple-gated: 24+ hours since last run, 5+ accumulated sessions, file-based advisory lock
+
+### What luca-mastracode Does Today
+
+- Uses MuninnDB (semantic graph memory) — more sophisticated than file-based memory
+- Two-vault model (repo vault + default vault) with concept-prefix routing
+- Session context via `session:*` engrams
+- No autoDream-style consolidation
+
+### Recommendation for luca-mastracode
+
+**Priority: LOW** (already strong)
+
+1. Consider adding a periodic consolidation step similar to autoDream — a background subagent that reviews and deduplicates MuninnDB entries
+2. Add the "hints, not truth" framing to any instructions that reference recalled memories
+
+---
+
+## 7. Multi-Agent Coordination Prompts
+
+### Claude Code's Subagent Models
+
+Three execution models:
+1. **Fork**: Subagent inherits parent context as byte-identical copy (cache-efficient)
+2. **Teammate**: Collaborative execution with shared workspace
+3. **Worktree**: Isolated working directory (git worktree)
+
+### Coordinator Prompt Patterns
+
+The multi-agent coordinator uses system prompt instructions like:
+- "Do not rubber-stamp weak work"
+- "Never hand off understanding to another worker"
+- Four-phase workflow: Research -> Synthesis -> Implementation -> Verification
+
+### Self-Distrust in Verification
+
+The Verification Agent contains a hardcoded list of rationalizations to resist:
+
+> "The implementer is an LLM. Verify independently."
+
+This **explicit self-distrust** forces independent validation rather than trusting AI-generated output.
+
+### Specialized Agent Personas
+
+7 agent prompts with distinct personalities:
+- **Explore Agent**: Read-only codebase search specialist with deny-lists of prohibited operations
+- **Plan Agent**: Software architect role
+- **Coordinator**: Four-phase workflow manager
+
+### What luca-mastracode Does Today
+
+- 9 subagent definitions with inline instructions
+- Subagents have `allowedWorkspaceTools` and `maxSteps` constraints
+- Researcher subagent explicitly states "Read-only: Do NOT modify any files"
+- No explicit self-distrust patterns in verifier
+
+### Recommendation for luca-mastracode
+
+**Priority: MEDIUM**
+
+1. Add explicit self-distrust to lu-verifier: "The implementer is an LLM. Do not trust the code is correct. Verify independently."
+2. Add "Do not rubber-stamp weak work" to any review-stage subagents
+3. Consider fork-style subagent spawning for cache efficiency (depends on Mastra support)
+
+---
+
+## 8. Context Management & Compaction
+
+### Token Budgeting
+
+Claude Code monitors context continuously:
+- **Buffer**: 13,000 tokens reserved before triggering compaction
+- **Warning threshold**: 20,000 tokens for UI warnings
+- **Max summary size**: 20,000 tokens for compaction summaries
+
+### Tiered Estimation
+
+Three approaches, used in order of precision:
+1. **API-based**: Anthropic Token Counting API (most precise)
+2. **Haiku fallback**: Faster model call if primary fails
+3. **Rough heuristic**: ~1 token per 4 characters (immediate UI feedback)
+
+### Compaction Strategy
+
+Chain-of-thought reasoning in `<analysis>` tags, then **strips the reasoning** before re-injecting results. This reduces token waste while maintaining reasoning quality.
+
+Circuit breaker: `MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES = 3` — prevents runaway compaction loops (added after observing 1,279 sessions with up to 3,272 consecutive failures).
+
+### What luca-mastracode Does Today
+
+- Context metrics tracked in `.context-metrics.json`
+- Quality degradation curve documented (0-30% peak, 70%+ poor)
+- Plans should complete within ~50% context
+- No active compaction or micro-compaction
+
+### Recommendation for luca-mastracode
+
+**Priority: MEDIUM**
+
+1. Implement a context budget monitor that tracks token usage per mode
+2. Add compaction triggers at mode boundaries (not just session boundaries)
+3. Strip chain-of-thought from intermediate results before re-injection
+4. Add a circuit breaker for compaction failures
+
+---
+
+## 9. Attention Curve Exploitation
+
+### U-Shaped Attention
+
+LLMs show **U-shaped attention**: peak focus at the beginning and end, degradation in the middle. Claude Code exploits this deliberately:
+
+```
+System Prompt Structure:
+  [START] Identity + Security (PEAK attention)
+  [MIDDLE] Workflow, tools, domain knowledge (lower attention)
+  [END] Repeat 2-3 critical rules (PEAK attention via recency)
+```
+
+### Practical Implications
+
+- **First 3 lines**: Identity + NEVER constraints (strongest enforcement)
+- **Middle**: Operational details that benefit from structured formatting (headers, bullets, XML tags)
+- **Last section**: Repeat the most important safety/behavioral rules
+
+### What luca-mastracode Does Today
+
+- Instructions start with role/purpose (good)
+- Behavioral guidelines in the middle of instruction files
+- Hard constraints appended at the end (partially exploits recency)
+- No deliberate repetition of critical rules
+
+### Recommendation for luca-mastracode
+
+**Priority: MEDIUM**
+
+1. Move the 2-3 most critical constraints to BOTH the start and end of mode instructions
+2. Restructure instruction files: identity -> safety -> workflow -> tools -> **repeat safety**
+3. Use structured formatting (headers, bullets) more aggressively in the "middle zone" where attention is lowest
+
+---
+
+## 10. Security & Anti-Distillation
+
+### Anti-Distillation (Fake Tools)
+
+When `ANTI_DISTILLATION_CC` is enabled, Claude Code sends `anti_distillation: ['fake_tools']` in API requests. The server injects **decoy tool definitions** to poison training data from competitors recording API traffic.
+
+### Undercover Mode
+
+For external repository contributions:
+- Strips internal codenames, Slack references, self-identification
+- ON by default, no force-OFF option
+- Commit messages appear human-authored
+
+### Frustration Detection
+
+Pattern-matching via regex in `userPromptKeywords.ts` detects user frustration ("wtf", "broken", etc.) to trigger behavioral modifications — faster than inference-based sentiment detection.
+
+### Permission Critic Pattern
+
+Instead of allowlists, Claude Code uses a **critic pattern**: a separate query asking "Is this command safe?" The model evaluates context, working directory, and intent — adaptive security that replaces brittle static rules.
+
+### Recommendation for luca-mastracode
+
+**Priority: LOW** (nice-to-have)
+
+1. Consider frustration detection regex for adjusting agent verbosity/carefulness
+2. The permission critic pattern could improve luca's `createScopedTool` — evaluate tool calls contextually instead of just checking action allowlists
+
+---
+
+## 11. Gap Analysis
+
+### luca-mastracode vs Claude Code
+
+| Technique | Claude Code | luca-mastracode | Gap |
+|---|---|---|---|
+| Dynamic prompt assembly | 30+ conditional components | 3-layer static + dynamic state | **Large** |
+| Cache boundary | `SYSTEM_PROMPT_DYNAMIC_BOUNDARY` | None | **Large** |
+| Behavioral principles (not procedures) | Consistently applied | Mixed — some modes procedural | **Medium** |
+| Quantified constraints | Word counts, A/B tested | Caveman mode only | **Medium** |
+| Bidirectional constraints | Every positive has a negative | Minimal | **Medium** |
+| Tool behavioral descriptions | 73k chars across 36+ tools | Action schemas only | **Large** |
+| Mid-conversation injection | `<system-reminder>` per-turn | Mode continuation only | **Large** |
+| Context rot remediation | Periodic rule refresh | None | **Large** |
+| Memory (hints not truth) | Explicit in prompt | Not framed this way | **Small** |
+| Self-distrust in verification | Hardcoded rationalizations | Not present | **Medium** |
+| Attention curve exploitation | Identity at start, rules repeated at end | Partial (constraints at end) | **Medium** |
+| Compaction/micro-compaction | Surgical with cache preservation | None | **Medium** |
+| Frustration detection | Regex-based behavioral adjustment | None | **Low priority** |
+| Environment context | cwd, platform, shell, model, date | Workflow state only | **Medium** |
+
+---
+
+## 12. Prioritized Recommendations
+
+### Tier 1: High Impact, Moderate Effort
+
+| # | Recommendation | Addresses | Effort |
+|---|---|---|---|
+| 1 | **Implement `<luca-reminder>` mid-conversation injection** — re-inject critical constraints every N turns to combat context rot | Context rot, behavioral drift | 3-4h |
+| 2 | **Add environment context block** — inject cwd, platform, date, model name, git branch into dynamic suffix of every mode | Environment awareness gap | 1-2h |
+| 3 | **Rewrite instruction files as principles** — replace step-by-step procedures with behavioral intentions + "because" clauses | Behavioral precision | 4-6h |
+| 4 | **Add bidirectional constraints** — for every "use X" instruction, add "do NOT use Y for same purpose" | Ambiguity elimination | 2-3h |
+
+### Tier 2: High Impact, Higher Effort
+
+| # | Recommendation | Addresses | Effort |
+|---|---|---|---|
+| 5 | **Introduce cache boundary marker** in instruction assembly — separate static instructions from per-request dynamic context | Cache efficiency | 3-4h |
+| 6 | **Enrich tool definitions** with behavioral guidance — add when/why/why-not/priority to each tool in `build-mode-tools.ts` | Tool selection quality | 4-6h |
+| 7 | **Add self-distrust to verification subagents** — "The implementer is an LLM. Verify independently." | Verification rigor | 1-2h |
+| 8 | **Exploit attention curve** — repeat 2-3 critical rules at both start AND end of mode instructions | Instruction adherence | 2-3h |
+
+### Tier 3: Medium Impact, Worth Doing
+
+| # | Recommendation | Addresses | Effort |
+|---|---|---|---|
+| 9 | **Add quantified output constraints** — explicit word/token limits per mode (fast: <=100 words, triage: <=50 words) | Output discipline | 1-2h |
+| 10 | **Implement context budget monitoring** — track token usage per mode, trigger compaction at thresholds | Context management | 4-6h |
+| 11 | **Add "memory as hints" framing** — instruct agents that recalled memories require verification against current code | Memory accuracy | 1h |
+| 12 | **Conditional component assembly** — make instruction sections toggleable based on complexity, oversight, feature flags | Prompt efficiency | 6-8h |
+
+### Tier 4: Future Considerations
+
+| # | Recommendation | Addresses | Effort |
+|---|---|---|---|
+| 13 | Frustration detection regex | UX responsiveness | 2-3h |
+| 14 | Permission critic pattern for tool calls | Security adaptiveness | 4-6h |
+| 15 | autoDream-style MuninnDB consolidation | Memory hygiene | 6-8h |
+| 16 | Fork-style subagent spawning for cache efficiency | Cost optimization | Depends on Mastra |
+
+---
+
+## 13. Sources
+
+### Primary Articles
+
+- [How Claude Code Builds a System Prompt](https://www.dbreunig.com/2026/04/04/how-claude-code-builds-a-system-prompt.html) — Drew Breunig's analysis of the 30+ component dynamic assembly
+- [System Prompts Define the Agent as Much as the Model](https://www.dbreunig.com/2026/02/10/system-prompts-define-the-agent-as-much-as-the-model.html) — Empirical study showing prompt swaps produce different agent workflows on identical tasks
+
+### Source Leak Analysis
+
+- [Diving into Claude Code's Source Code Leak](https://read.engineerscodex.com/p/diving-into-claude-codes-source-code) — Engineer's Codex deep dive on cache boundaries, anti-distillation, KAIROS
+- [Comprehensive Analysis of Claude Code Source Leak](https://www.sabrina.dev/p/claude-code-source-leak-analysis) — Detailed architecture analysis including compaction, A/B testing results
+- [The Claude Code Source Leak: fake tools, frustration regexes, undercover mode](https://alex000kim.com/posts/2026-03-31-claude-code-source-leak/) — Alex Kim's analysis of anti-distillation, frustration detection, undercover mode
+- [Claude Code Source Code Leaked: What's Inside](https://www.the-ai-corner.com/p/claude-code-source-code-leaked-2026) — AI Corner overview
+
+### Reverse Engineering & Community Analysis
+
+- [The Complete Guide to Writing Agent System Prompts](https://medium.com/@fengliu_367/the-complete-guide-to-writing-agent-system-prompts-lessons-from-reverse-engineering-claude-code-09ecd87c7cc1) — Feng Liu's 8-section prompt structure guide with attention curve exploitation
+- [Claude Code Prompts | Anatomy of an AI Coding Agent](https://ccprompts.info/) — Catalog of 124 prompts across 9 categories with 18 identified techniques
+- [System Prompt & Query Loop | DeepWiki](https://deepwiki.com/ghboke/claude-code-reverse/2.1-system-prompt-and-query-loop) — Technical breakdown of query loop and caching architecture
+- [Piebald-AI/claude-code-system-prompts](https://github.com/Piebald-AI/claude-code-system-prompts) — Extracted system prompts, tool descriptions, sub-agent prompts (updated per version)
+
+### Prompt Engineering Patterns
+
+- [AI Agent Prompt Engineering: 10 Patterns That Actually Work](https://paxrel.com/blog-ai-agent-prompts) — Production patterns including progressive disclosure, guard rails, self-evaluation loops
+- [Claude Code Source Code Leak: 8 Hidden Features](https://www.mindstudio.ai/blog/claude-code-source-code-leak-8-hidden-features) — Feature flags and hidden capabilities
+- [VentureBeat: Claude Code's source code appears to have leaked](https://venturebeat.com/technology/claude-codes-source-code-appears-to-have-leaked-heres-what-we-know) — News coverage of the leak event

--- a/docs/research/prompt-architecture/00-overview.md
+++ b/docs/research/prompt-architecture/00-overview.md
@@ -10,7 +10,7 @@
 
 Claude Code's system prompt is not a static string — it is a **dynamically assembled context** built from 30+ conditional components, 36+ tool definitions, multi-agent orchestration prompts, and session-specific state. The architecture is designed around three core principles: **prompt cache efficiency**, **behavioral precision over prose**, and **mid-conversation injection for context rot remediation**.
 
-This document catalogs every technique identified through source analysis, the March 2026 source leak, and community reverse-engineering — then maps each to a concrete recommendation for luca-mastracode.
+This document catalogs every technique identified through publicly documented behavior, observed system behavior, and community reverse-engineering — then maps each to a concrete recommendation for luca-mastracode.
 
 ---
 
@@ -149,7 +149,7 @@ Claude Code gives **behavioral intentions**, not step-by-step procedures:
 
 ### Quantified Constraints Beat Qualitative Directives
 
-The leaked source reveals A/B testing results:
+Public analysis reveals A/B testing results:
 
 > "Research shows ~1.2% output token reduction vs qualitative 'be concise.'"
 

--- a/docs/research/prompt-architecture/00-overview.md
+++ b/docs/research/prompt-architecture/00-overview.md
@@ -1,0 +1,567 @@
+# Claude Code Prompt Architecture: Lessons for luca-mastracode
+
+**Research Date:** 2026-04-13
+**Status:** Complete
+**Scope:** How Claude Code constructs system prompts and what techniques luca-mastracode should adopt
+
+---
+
+## Executive Summary
+
+Claude Code's system prompt is not a static string — it is a **dynamically assembled context** built from 30+ conditional components, 36+ tool definitions, multi-agent orchestration prompts, and session-specific state. The architecture is designed around three core principles: **prompt cache efficiency**, **behavioral precision over prose**, and **mid-conversation injection for context rot remediation**.
+
+This document catalogs every technique identified through source analysis, the March 2026 source leak, and community reverse-engineering — then maps each to a concrete recommendation for luca-mastracode.
+
+---
+
+## Table of Contents
+
+1. [Prompt Assembly Architecture](#1-prompt-assembly-architecture)
+2. [The Cache Boundary Pattern](#2-the-cache-boundary-pattern)
+3. [Behavioral Instruction Techniques](#3-behavioral-instruction-techniques)
+4. [Tool Definition Patterns](#4-tool-definition-patterns)
+5. [Mid-Conversation Injection (system-reminder)](#5-mid-conversation-injection)
+6. [Memory System Architecture](#6-memory-system-architecture)
+7. [Multi-Agent Coordination Prompts](#7-multi-agent-coordination-prompts)
+8. [Context Management & Compaction](#8-context-management--compaction)
+9. [Attention Curve Exploitation](#9-attention-curve-exploitation)
+10. [Security & Anti-Distillation](#10-security--anti-distillation)
+11. [Gap Analysis: luca-mastracode vs Claude Code](#11-gap-analysis)
+12. [Prioritized Recommendations](#12-prioritized-recommendations)
+13. [Sources](#13-sources)
+
+---
+
+## 1. Prompt Assembly Architecture
+
+### How Claude Code Builds a Prompt
+
+Claude Code assembles its system prompt from **9 categories** containing **124 total prompts** (19k characters for system prompt alone, 73k for tool definitions):
+
+```
+Static Prefix (globally cached, 1-hour TTL)
+├── Identity & Introduction (1-3 sentences)
+├── System Rules & Permissions
+├── Executing Actions with Care (reversibility/blast radius framework)
+├── Doing Tasks (coding philosophy)
+├── Using Your Tools (dedicated tool preference)
+├── Tone and Style
+├── Session-Specific Guidance (conditional)
+├── Tool Definitions (36+ tools, each with own prompt)
+└── __SYSTEM_PROMPT_DYNAMIC_BOUNDARY__
+Dynamic Suffix (session-specific, 5-minute TTL)
+├── Environment Info (cwd, platform, shell, model, date)
+├── Language Preference
+├── CLAUDE.md / Project Rules
+├── Memory Prompt (MEMORY.md index)
+├── MCP Server Instructions (recomputed each turn)
+├── Git Status Snapshot
+└── Scratchpad Instructions
+```
+
+### Key Architectural Decisions
+
+1. **Conditional assembly**: Components are included/excluded based on configuration flags, available tools, user type (internal vs external), and session state
+2. **Functional composition**: Each section is a function returning a string (or empty string to exclude)
+3. **~124 distinct prompts** across system, tools, agents, memory, and services — not one monolithic blob
+
+### What luca-mastracode Does Today
+
+luca-mastracode uses a **three-layer composition**:
+
+```
+Base Markdown (loaded from instructions/*.md, static per mode)
+  + Dynamic State Context (read per-request via readLucaState())
+  + Hard Constraints (3 universal rules)
+  + Bundled AlwaysApply Rules (caveman, pr-title-format)
+= Final instruction string
+```
+
+**Gap**: No cache boundary marker. No conditional component inclusion. No per-turn dynamic sections beyond workflow state. Tool definitions are static per mode, not dynamically assembled.
+
+---
+
+## 2. The Cache Boundary Pattern
+
+### The Technique
+
+Claude Code splits every system prompt at `SYSTEM_PROMPT_DYNAMIC_BOUNDARY`:
+
+- **Before the boundary** (static): Identity, behavioral rules, tool instructions — cached globally across all users with a **1-hour TTL**
+- **After the boundary** (dynamic): CLAUDE.md, git status, MCP instructions, memory — per-session with a **5-minute TTL**
+
+Any section that must bypass caching is explicitly marked with `DANGEROUS_uncachedSystemPromptSection()` — a naming convention that signals the performance cost to developers.
+
+### Why This Matters
+
+Prompt caching reduces latency and cost dramatically. Claude Code's architecture means spawning 5 sub-agents costs barely more than 1, because they share the cached static prefix (fork model).
+
+### The Micro-Compaction Strategy
+
+When approaching token limits, Claude Code performs **surgical edits** via `apiMicrocompact.ts`:
+- Replaces large tool results with `[Old tool result cleared]`
+- Edits only within the dynamic section to preserve cache hits
+- Avoids full session restarts that would forfeit cached prefixes
+
+### Recommendation for luca-mastracode
+
+**Priority: HIGH**
+
+Introduce a cache boundary in instruction assembly:
+
+```typescript
+// In each mode's buildInstructions():
+function buildInstructions(): string {
+  const staticPrefix = loadModeInstructions(mode)  // Cacheable
+    + HARD_CONSTRAINTS
+    + ALWAYS_APPLY_RULES
+
+  const dynamicSuffix = buildDynamicContext()       // Per-request
+    + buildEnvironmentInfo()
+    + buildGitStatus()
+
+  return staticPrefix + '\n\n__CACHE_BOUNDARY__\n\n' + dynamicSuffix
+}
+```
+
+This requires Mastra's API layer to support Anthropic's cache control headers, but the prompt-side preparation should happen now.
+
+---
+
+## 3. Behavioral Instruction Techniques
+
+### Principles Over Procedures
+
+Claude Code gives **behavioral intentions**, not step-by-step procedures:
+
+```
+# Claude Code approach (principles):
+"Always understand existing code before modifying.
+ Don't add features beyond what was asked.
+ A bug fix doesn't need surrounding code cleaned up."
+
+# Anti-pattern (procedures):
+"Step 1: Read the file. Step 2: Identify the bug.
+ Step 3: Write the fix. Step 4: Run tests."
+```
+
+**Why**: Principles generalize to unanticipated scenarios. Procedures fail when the situation doesn't match the script.
+
+### Quantified Constraints Beat Qualitative Directives
+
+The leaked source reveals A/B testing results:
+
+> "Research shows ~1.2% output token reduction vs qualitative 'be concise.'"
+
+Production Claude Code uses **explicit word counts**:
+- "Keep text between tool calls to <=25 words"
+- "Keep final responses to <=100 words"
+
+### Bidirectional Constraints
+
+Claude Code doesn't just say what TO do — it says what NOT to do:
+
+```
+"Do NOT use the Bash to run commands when a relevant dedicated tool
+ is provided. Using dedicated tools allows the user to better understand
+ and review your work."
+```
+
+Every positive instruction has a corresponding negative constraint. This eliminates ambiguity.
+
+### Explain Why
+
+```
+"Avoid git amend because it may overwrite others' commits"
+```
+
+The "because" clause teaches the model to make correct edge-case decisions autonomously.
+
+### Recommendation for luca-mastracode
+
+**Priority: HIGH**
+
+1. Audit all instruction `.md` files: replace procedural step lists with behavioral principles where possible
+2. Add quantified constraints (word/token limits) to modes like `fast.md` and `triage.md`
+3. Add bidirectional constraints to tool usage sections: "Use X for Y. Do NOT use Z for Y."
+4. Add "because" clauses to every constraint that isn't self-evident
+
+---
+
+## 4. Tool Definition Patterns
+
+### Each Tool Carries Its Own Prompt
+
+Claude Code has 36+ tools, each with a detailed description that includes:
+- **When to use** (and when NOT to use)
+- **Priority ordering** vs alternative tools
+- **Behavioral constraints** specific to that tool
+- **Few-shot examples** of correct invocation
+
+Example — the Bash tool prompt:
+```
+Do NOT use the Bash to run commands when a relevant dedicated tool
+is provided:
+ - File search: Use Glob (NOT find or ls)
+ - Content search: Use Grep (NOT grep or rg)
+ - Read files: Use Read (NOT cat/head/tail)
+ - Edit files: Use Edit (NOT sed/awk)
+ - Write files: Use Write (NOT echo >/cat <<EOF)
+```
+
+### Tool Selection Heuristics
+
+Tools are listed in priority order with specific conditions:
+1. Read local files first
+2. Use cached data second
+3. Web search for gaps only
+4. LLM scoring calls cost money — batch them
+
+### Security-First Tool Defaults
+
+The bash security system spans **9,707 lines with 22 validators**. Philosophy: "When in doubt, ask the human." Tools default to requiring explicit user approval rather than assuming permission.
+
+### What luca-mastracode Does Today
+
+- Tool permissions defined in `mode-permissions.ts` manifest (good)
+- `createScopedTool` wrapper enforces action restrictions (good)
+- But tool definitions lack behavioral guidance, priority ordering, and negative examples
+- Instructions reference tool names inline but don't explain when NOT to use them
+
+### Recommendation for luca-mastracode
+
+**Priority: MEDIUM**
+
+1. Add behavioral descriptions to tool definitions in `build-mode-tools.ts` — not just the action schema, but when/why/why-not guidance
+2. Add tool priority ordering in mode instruction files
+3. Add negative examples ("Do NOT use workflowState for X, use Y instead")
+
+---
+
+## 5. Mid-Conversation Injection
+
+### The `<system-reminder>` Pattern
+
+Claude Code declares in its system prompt:
+
+```
+Tool results and user messages may include <system-reminder> or other
+tags. Tags contain information from the system. They bear no direct
+relation to the specific tool results or user messages in which they
+appear.
+```
+
+Then mid-conversation, it injects reminders for:
+- **Behavioral refresh**: Re-stating critical rules that degrade over long contexts
+- **Mode switching**: Plan mode, readonly mode transitions
+- **File change notifications**: Alerting the model to external changes
+- **Dynamic context updates**: Git status, open files, task lists
+- **Periodic rule refresh**: Because models "forget" planning and start coding
+
+### Why This Matters: Context Rot
+
+LLM instruction adherence degrades after ~80K tokens. By ~180K tokens, it's severely compromised. Mid-conversation injection combats this by re-asserting critical rules at the point where they matter most — the **recency** end of the attention curve.
+
+### Why It Goes in Messages, Not System Prompt
+
+Putting changing context in the message layer (not system prompt) **preserves cache validity**. The static system prompt stays cached while dynamic reminders flow through messages.
+
+### What luca-mastracode Does Today
+
+- Mode continuation messages inject context when switching modes (good)
+- But no mid-conversation behavioral refresh
+- No periodic rule re-injection during long sessions
+- No mechanism to combat context rot
+
+### Recommendation for luca-mastracode
+
+**Priority: HIGH**
+
+1. Define a `<luca-reminder>` tag convention in base instructions
+2. Implement periodic behavioral refresh at tool-call boundaries (every N turns or every M tokens)
+3. Re-inject critical constraints (hard constraints, mode boundaries) as conversation grows
+4. Use message-layer injection, not system prompt modification, to preserve any future cache boundaries
+
+---
+
+## 6. Memory System Architecture
+
+### Claude Code's Three-Layer Memory
+
+1. **Index layer** (MEMORY.md, always loaded): ~150-character pointers per entry, max 200 lines
+2. **Topic files** (on-demand): Actual knowledge content, loaded when referenced
+3. **Transcripts** (grep-only): Never loaded into context directly
+
+### Write Discipline
+
+- If a fact can be re-derived from the codebase, it's NOT stored
+- Topic files updated BEFORE index modifications
+- Memory is treated as **hints requiring verification**, not authoritative truth
+
+### autoDream Consolidation
+
+A forked subagent with limited tool access runs "nightly" consolidation:
+- Reorganizes knowledge
+- Removes contradictions
+- Prevents memory corruption through tool isolation
+- Triple-gated: 24+ hours since last run, 5+ accumulated sessions, file-based advisory lock
+
+### What luca-mastracode Does Today
+
+- Uses MuninnDB (semantic graph memory) — more sophisticated than file-based memory
+- Two-vault model (repo vault + default vault) with concept-prefix routing
+- Session context via `session:*` engrams
+- No autoDream-style consolidation
+
+### Recommendation for luca-mastracode
+
+**Priority: LOW** (already strong)
+
+1. Consider adding a periodic consolidation step similar to autoDream — a background subagent that reviews and deduplicates MuninnDB entries
+2. Add the "hints, not truth" framing to any instructions that reference recalled memories
+
+---
+
+## 7. Multi-Agent Coordination Prompts
+
+### Claude Code's Subagent Models
+
+Three execution models:
+1. **Fork**: Subagent inherits parent context as byte-identical copy (cache-efficient)
+2. **Teammate**: Collaborative execution with shared workspace
+3. **Worktree**: Isolated working directory (git worktree)
+
+### Coordinator Prompt Patterns
+
+The multi-agent coordinator uses system prompt instructions like:
+- "Do not rubber-stamp weak work"
+- "Never hand off understanding to another worker"
+- Four-phase workflow: Research -> Synthesis -> Implementation -> Verification
+
+### Self-Distrust in Verification
+
+The Verification Agent contains a hardcoded list of rationalizations to resist:
+
+> "The implementer is an LLM. Verify independently."
+
+This **explicit self-distrust** forces independent validation rather than trusting AI-generated output.
+
+### Specialized Agent Personas
+
+7 agent prompts with distinct personalities:
+- **Explore Agent**: Read-only codebase search specialist with deny-lists of prohibited operations
+- **Plan Agent**: Software architect role
+- **Coordinator**: Four-phase workflow manager
+
+### What luca-mastracode Does Today
+
+- 9 subagent definitions with inline instructions
+- Subagents have `allowedWorkspaceTools` and `maxSteps` constraints
+- Researcher subagent explicitly states "Read-only: Do NOT modify any files"
+- No explicit self-distrust patterns in verifier
+
+### Recommendation for luca-mastracode
+
+**Priority: MEDIUM**
+
+1. Add explicit self-distrust to lu-verifier: "The implementer is an LLM. Do not trust the code is correct. Verify independently."
+2. Add "Do not rubber-stamp weak work" to any review-stage subagents
+3. Consider fork-style subagent spawning for cache efficiency (depends on Mastra support)
+
+---
+
+## 8. Context Management & Compaction
+
+### Token Budgeting
+
+Claude Code monitors context continuously:
+- **Buffer**: 13,000 tokens reserved before triggering compaction
+- **Warning threshold**: 20,000 tokens for UI warnings
+- **Max summary size**: 20,000 tokens for compaction summaries
+
+### Tiered Estimation
+
+Three approaches, used in order of precision:
+1. **API-based**: Anthropic Token Counting API (most precise)
+2. **Haiku fallback**: Faster model call if primary fails
+3. **Rough heuristic**: ~1 token per 4 characters (immediate UI feedback)
+
+### Compaction Strategy
+
+Chain-of-thought reasoning in `<analysis>` tags, then **strips the reasoning** before re-injecting results. This reduces token waste while maintaining reasoning quality.
+
+Circuit breaker: `MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES = 3` — prevents runaway compaction loops (added after observing 1,279 sessions with up to 3,272 consecutive failures).
+
+### What luca-mastracode Does Today
+
+- Context metrics tracked in `.context-metrics.json`
+- Quality degradation curve documented (0-30% peak, 70%+ poor)
+- Plans should complete within ~50% context
+- No active compaction or micro-compaction
+
+### Recommendation for luca-mastracode
+
+**Priority: MEDIUM**
+
+1. Implement a context budget monitor that tracks token usage per mode
+2. Add compaction triggers at mode boundaries (not just session boundaries)
+3. Strip chain-of-thought from intermediate results before re-injection
+4. Add a circuit breaker for compaction failures
+
+---
+
+## 9. Attention Curve Exploitation
+
+### U-Shaped Attention
+
+LLMs show **U-shaped attention**: peak focus at the beginning and end, degradation in the middle. Claude Code exploits this deliberately:
+
+```
+System Prompt Structure:
+  [START] Identity + Security (PEAK attention)
+  [MIDDLE] Workflow, tools, domain knowledge (lower attention)
+  [END] Repeat 2-3 critical rules (PEAK attention via recency)
+```
+
+### Practical Implications
+
+- **First 3 lines**: Identity + NEVER constraints (strongest enforcement)
+- **Middle**: Operational details that benefit from structured formatting (headers, bullets, XML tags)
+- **Last section**: Repeat the most important safety/behavioral rules
+
+### What luca-mastracode Does Today
+
+- Instructions start with role/purpose (good)
+- Behavioral guidelines in the middle of instruction files
+- Hard constraints appended at the end (partially exploits recency)
+- No deliberate repetition of critical rules
+
+### Recommendation for luca-mastracode
+
+**Priority: MEDIUM**
+
+1. Move the 2-3 most critical constraints to BOTH the start and end of mode instructions
+2. Restructure instruction files: identity -> safety -> workflow -> tools -> **repeat safety**
+3. Use structured formatting (headers, bullets) more aggressively in the "middle zone" where attention is lowest
+
+---
+
+## 10. Security & Anti-Distillation
+
+### Anti-Distillation (Fake Tools)
+
+When `ANTI_DISTILLATION_CC` is enabled, Claude Code sends `anti_distillation: ['fake_tools']` in API requests. The server injects **decoy tool definitions** to poison training data from competitors recording API traffic.
+
+### Undercover Mode
+
+For external repository contributions:
+- Strips internal codenames, Slack references, self-identification
+- ON by default, no force-OFF option
+- Commit messages appear human-authored
+
+### Frustration Detection
+
+Pattern-matching via regex in `userPromptKeywords.ts` detects user frustration ("wtf", "broken", etc.) to trigger behavioral modifications — faster than inference-based sentiment detection.
+
+### Permission Critic Pattern
+
+Instead of allowlists, Claude Code uses a **critic pattern**: a separate query asking "Is this command safe?" The model evaluates context, working directory, and intent — adaptive security that replaces brittle static rules.
+
+### Recommendation for luca-mastracode
+
+**Priority: LOW** (nice-to-have)
+
+1. Consider frustration detection regex for adjusting agent verbosity/carefulness
+2. The permission critic pattern could improve luca's `createScopedTool` — evaluate tool calls contextually instead of just checking action allowlists
+
+---
+
+## 11. Gap Analysis
+
+### luca-mastracode vs Claude Code
+
+| Technique | Claude Code | luca-mastracode | Gap |
+|---|---|---|---|
+| Dynamic prompt assembly | 30+ conditional components | 3-layer static + dynamic state | **Large** |
+| Cache boundary | `SYSTEM_PROMPT_DYNAMIC_BOUNDARY` | None | **Large** |
+| Behavioral principles (not procedures) | Consistently applied | Mixed — some modes procedural | **Medium** |
+| Quantified constraints | Word counts, A/B tested | Caveman mode only | **Medium** |
+| Bidirectional constraints | Every positive has a negative | Minimal | **Medium** |
+| Tool behavioral descriptions | 73k chars across 36+ tools | Action schemas only | **Large** |
+| Mid-conversation injection | `<system-reminder>` per-turn | Mode continuation only | **Large** |
+| Context rot remediation | Periodic rule refresh | None | **Large** |
+| Memory (hints not truth) | Explicit in prompt | Not framed this way | **Small** |
+| Self-distrust in verification | Hardcoded rationalizations | Not present | **Medium** |
+| Attention curve exploitation | Identity at start, rules repeated at end | Partial (constraints at end) | **Medium** |
+| Compaction/micro-compaction | Surgical with cache preservation | None | **Medium** |
+| Frustration detection | Regex-based behavioral adjustment | None | **Low priority** |
+| Environment context | cwd, platform, shell, model, date | Workflow state only | **Medium** |
+
+---
+
+## 12. Prioritized Recommendations
+
+### Tier 1: High Impact, Moderate Effort
+
+| # | Recommendation | Addresses | Effort |
+|---|---|---|---|
+| 1 | **Implement `<luca-reminder>` mid-conversation injection** — re-inject critical constraints every N turns to combat context rot | Context rot, behavioral drift | 3-4h |
+| 2 | **Add environment context block** — inject cwd, platform, date, model name, git branch into dynamic suffix of every mode | Environment awareness gap | 1-2h |
+| 3 | **Rewrite instruction files as principles** — replace step-by-step procedures with behavioral intentions + "because" clauses | Behavioral precision | 4-6h |
+| 4 | **Add bidirectional constraints** — for every "use X" instruction, add "do NOT use Y for same purpose" | Ambiguity elimination | 2-3h |
+
+### Tier 2: High Impact, Higher Effort
+
+| # | Recommendation | Addresses | Effort |
+|---|---|---|---|
+| 5 | **Introduce cache boundary marker** in instruction assembly — separate static instructions from per-request dynamic context | Cache efficiency | 3-4h |
+| 6 | **Enrich tool definitions** with behavioral guidance — add when/why/why-not/priority to each tool in `build-mode-tools.ts` | Tool selection quality | 4-6h |
+| 7 | **Add self-distrust to verification subagents** — "The implementer is an LLM. Verify independently." | Verification rigor | 1-2h |
+| 8 | **Exploit attention curve** — repeat 2-3 critical rules at both start AND end of mode instructions | Instruction adherence | 2-3h |
+
+### Tier 3: Medium Impact, Worth Doing
+
+| # | Recommendation | Addresses | Effort |
+|---|---|---|---|
+| 9 | **Add quantified output constraints** — explicit word/token limits per mode (fast: <=100 words, triage: <=50 words) | Output discipline | 1-2h |
+| 10 | **Implement context budget monitoring** — track token usage per mode, trigger compaction at thresholds | Context management | 4-6h |
+| 11 | **Add "memory as hints" framing** — instruct agents that recalled memories require verification against current code | Memory accuracy | 1h |
+| 12 | **Conditional component assembly** — make instruction sections toggleable based on complexity, oversight, feature flags | Prompt efficiency | 6-8h |
+
+### Tier 4: Future Considerations
+
+| # | Recommendation | Addresses | Effort |
+|---|---|---|---|
+| 13 | Frustration detection regex | UX responsiveness | 2-3h |
+| 14 | Permission critic pattern for tool calls | Security adaptiveness | 4-6h |
+| 15 | autoDream-style MuninnDB consolidation | Memory hygiene | 6-8h |
+| 16 | Fork-style subagent spawning for cache efficiency | Cost optimization | Depends on Mastra |
+
+---
+
+## 13. Sources
+
+### Primary Articles
+
+- [How Claude Code Builds a System Prompt](https://www.dbreunig.com/2026/04/04/how-claude-code-builds-a-system-prompt.html) — Drew Breunig's analysis of the 30+ component dynamic assembly
+- [System Prompts Define the Agent as Much as the Model](https://www.dbreunig.com/2026/02/10/system-prompts-define-the-agent-as-much-as-the-model.html) — Empirical study showing prompt swaps produce different agent workflows on identical tasks
+
+### Source Leak Analysis
+
+- [Diving into Claude Code's Source Code Leak](https://read.engineerscodex.com/p/diving-into-claude-codes-source-code) — Engineer's Codex deep dive on cache boundaries, anti-distillation, KAIROS
+- [Comprehensive Analysis of Claude Code Source Leak](https://www.sabrina.dev/p/claude-code-source-leak-analysis) — Detailed architecture analysis including compaction, A/B testing results
+- [The Claude Code Source Leak: fake tools, frustration regexes, undercover mode](https://alex000kim.com/posts/2026-03-31-claude-code-source-leak/) — Alex Kim's analysis of anti-distillation, frustration detection, undercover mode
+- [Claude Code Source Code Leaked: What's Inside](https://www.the-ai-corner.com/p/claude-code-source-code-leaked-2026) — AI Corner overview
+
+### Reverse Engineering & Community Analysis
+
+- [The Complete Guide to Writing Agent System Prompts](https://medium.com/@fengliu_367/the-complete-guide-to-writing-agent-system-prompts-lessons-from-reverse-engineering-claude-code-09ecd87c7cc1) — Feng Liu's 8-section prompt structure guide with attention curve exploitation
+- [Claude Code Prompts | Anatomy of an AI Coding Agent](https://ccprompts.info/) — Catalog of 124 prompts across 9 categories with 18 identified techniques
+- [System Prompt & Query Loop | DeepWiki](https://deepwiki.com/ghboke/claude-code-reverse/2.1-system-prompt-and-query-loop) — Technical breakdown of query loop and caching architecture
+- [Piebald-AI/claude-code-system-prompts](https://github.com/Piebald-AI/claude-code-system-prompts) — Extracted system prompts, tool descriptions, sub-agent prompts (updated per version)
+
+### Prompt Engineering Patterns
+
+- [AI Agent Prompt Engineering: 10 Patterns That Actually Work](https://paxrel.com/blog-ai-agent-prompts) — Production patterns including progressive disclosure, guard rails, self-evaluation loops
+- [Claude Code Source Code Leak: 8 Hidden Features](https://www.mindstudio.ai/blog/claude-code-source-code-leak-8-hidden-features) — Feature flags and hidden capabilities
+- [VentureBeat: Claude Code's source code appears to have leaked](https://venturebeat.com/technology/claude-codes-source-code-appears-to-have-leaked-heres-what-we-know) — News coverage of the leak event

--- a/docs/research/prompt-architecture/01-cache-boundary-design.md
+++ b/docs/research/prompt-architecture/01-cache-boundary-design.md
@@ -1,0 +1,468 @@
+# Cache Boundary Design for AI Coding Agents
+
+**Research Date:** 2026-04-13
+**Status:** Complete
+**Scope:** Prompt caching mechanics, Claude Code's cache boundary implementation, micro-compaction, and recommendations for luca-mastracode
+
+---
+
+## 1. How Prompt Caching Works at the API Level
+
+### Prefix-Based Matching
+
+Anthropic's prompt caching stores computed input tensors from the prefill stage. On subsequent requests sharing the same prefix, the model skips prefill for the cached portion and processes only the new tokens. Matching is **100% exact** on the byte level -- even a single character change in the prefix invalidates the cache from that point forward.
+
+The cache evaluates content in a strict hierarchy:
+
+```
+tools -> system -> messages
+```
+
+Changes at any level invalidate that level **and all subsequent levels**. Modifying a tool definition invalidates the system prompt cache and the message cache. Modifying the system prompt invalidates the message cache but not the tool cache.
+
+### Cache Breakpoints
+
+You can place up to **4 explicit cache breakpoints** per request using the `cache_control` parameter. Each breakpoint marks a position where the system should attempt to match against existing cache entries. The system also performs automatic prefix checking by looking back approximately 20 content blocks.
+
+```typescript
+// Explicit breakpoint on the last tool definition
+{
+  tools: [
+    { name: "search", description: "...", input_schema: {...} },
+    {
+      name: "edit_file",
+      description: "...",
+      input_schema: {...},
+      cache_control: { type: "ephemeral" }  // Breakpoint here
+    }
+  ],
+  system: [
+    {
+      type: "text",
+      text: "Static behavioral instructions...",
+      cache_control: { type: "ephemeral" }  // Breakpoint here
+    },
+    {
+      type: "text",
+      text: "Dynamic per-session context..."
+      // No breakpoint -- changes every turn
+    }
+  ]
+}
+```
+
+Cache writes happen **only** at breakpoints. If the breakpoint sits on content that changes every request (timestamps, per-request IDs), the prefix hash never matches on subsequent requests and you pay the write premium with zero benefit.
+
+### TTL Tiers
+
+| TTL | Write Cost | Read Cost | Use Case |
+|-----|-----------|-----------|----------|
+| 5-minute (default) | 1.25x base input | 0.1x base input | Multi-turn conversations, per-session state |
+| 1-hour (extended) | 2.0x base input | 0.1x base input | Shared system prompts, tool definitions, global instructions |
+
+The 5-minute TTL is specified as `{ type: "ephemeral" }`. The 1-hour TTL is specified as `{ type: "ephemeral", ttl: "1h" }`. Cache is refreshed at no additional cost each time cached content is reused within the TTL window.
+
+**Mixing TTLs**: You can use both in the same request, but longer TTL entries must appear before shorter TTL entries in the prompt sequence. The API bills across three positions: the highest cache hit, the highest 1-hour block after it, and the last breakpoint.
+
+### Minimum Token Requirements
+
+Caching only activates when the content before a breakpoint exceeds a model-specific minimum:
+
+| Model | Minimum Tokens |
+|-------|---------------|
+| Claude Opus 4.6 / Opus 4.5 | 4,096 |
+| Claude Sonnet 4.6 | 2,048 |
+| Claude Sonnet 4.5 / 4 / 3.7, Opus 4.1 / 4 | 1,024 |
+| Claude Haiku 4.5 | 4,096 |
+| Claude Haiku 3.5 | 2,048 |
+
+Prompts shorter than the minimum are processed normally without caching and without error. Check the response `usage` fields: if both `cache_creation_input_tokens` and `cache_read_input_tokens` are 0, caching did not occur.
+
+### Cache Scope
+
+As of February 2026, cache isolation is **workspace-level** on the Claude API and Azure AI Foundry. Different workspaces never share caches. Amazon Bedrock and Google Vertex AI maintain organization-level isolation.
+
+### Cost and Latency Numbers
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| Cache read cost vs base input | 0.1x (90% reduction) | Anthropic API docs |
+| Cache write cost (5-min TTL) | 1.25x base input | Anthropic API docs |
+| Cache write cost (1-hour TTL) | 2.0x base input | Anthropic API docs |
+| Latency reduction on long prompts | Up to 85% | Anthropic announcement |
+| 100K-token book example | 11.5s -> 2.4s (79% reduction) | Anthropic benchmark |
+| Break-even point | Turn 2 of a session | prompt-caching.ai benchmarks |
+
+For Opus 4.6: base input is $5/M tokens, cache reads are $0.50/M tokens. A 20K-token system prompt read from cache costs $0.01 per request instead of $0.10 -- a 10x reduction that compounds across every turn of every session.
+
+---
+
+## 2. Claude Code's Cache Boundary Implementation
+
+### The SYSTEM_PROMPT_DYNAMIC_BOUNDARY
+
+Claude Code splits its system prompt at a marker called `__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__`. Everything before the boundary is cached globally; everything after is per-session.
+
+```
+Static Prefix (1-hour TTL, scope: 'global')
++-- Identity & Introduction
++-- System Rules & Permissions
++-- Executing Actions with Care (reversibility/blast radius)
++-- Doing Tasks (coding philosophy)
++-- Using Your Tools (dedicated tool preference)
++-- Tone and Style
++-- Tool Definitions (36+ tools, ~73K characters)
++-- __SYSTEM_PROMPT_DYNAMIC_BOUNDARY__
+Dynamic Suffix (5-minute TTL, session-scoped)
++-- Environment Info (cwd, platform, shell, model, date)
++-- Language Preference
++-- CLAUDE.md / Project Rules
++-- Memory Prompt (MEMORY.md index)
++-- MCP Server Instructions (recomputed each turn)
++-- Git Status Snapshot
++-- Scratchpad Instructions
+```
+
+The static prefix is assembled from approximately 15 composable section functions (`getSimpleIntroSection`, `getUsingYourToolsSection`, etc.). This modular approach keeps each section independently testable while the concatenated result remains byte-identical across all users running the same Claude Code version.
+
+The static half is cached via Blake2b prefix hashing with a 1-hour TTL and `scope: 'global'`, meaning **millions of Claude Code users share the same cached prefix**. The dynamic half is injected per-session after the boundary marker.
+
+### Why Tool Definitions Live in the Static Prefix
+
+Tool definitions (36+ tools, ~73K characters of descriptions) reside in the static prefix specifically to benefit from the global cache. This is a deliberate architectural choice: subagents inherit the parent's full tool set even when they only need a subset, because different tools would mean a different prefix hash, which means a cache miss and reprocessing the entire system prompt from scratch.
+
+Claude Code accepts a measured 2.79% tool-call failure rate on certain model versions rather than lose caching benefits. The compaction sub-agent retains all 42 tools despite only needing text output. When the model attempts tool use instead of summarization, a blunt preamble handles it: *"CRITICAL: Respond with TEXT ONLY. Do NOT call any tools."*
+
+### DANGEROUS_uncachedSystemPromptSection()
+
+Any section that must bypass caching is explicitly marked with this function name. The naming convention is a performance contract -- it signals to developers that placing content here has a direct cost impact, discouraging casual additions to the uncached section.
+
+### The Fork Model for Subagents
+
+When Claude Code spawns subagents, each fork inherits the parent context as a byte-identical copy. This means the cached static prefix is reused without additional cost. Spawning 5 sub-agents costs barely more than 1, because they all share the same cached prefix. This is what makes parallel code review (5+ reviewers simultaneously) economically viable.
+
+---
+
+## 3. Micro-Compaction and Cache Preservation
+
+### The 5-Level Compression Pipeline
+
+Claude Code's context management lives in `src/services/compact/` (~3,960 lines of TypeScript) and implements progressive compression, triggering cheaper approaches before expensive ones:
+
+| Level | Name | Cost | Mechanism |
+|-------|------|------|-----------|
+| 1 | Tool Result Budget | Zero | Results exceeding 50K chars persist to disk; 2KB preview retained in context |
+| 2 | History Snip | Zero | Garbage collection removes stale scaffolding and redundant bookkeeping |
+| 3 | Microcompact | Low | Dual-path: cache-cold modifies messages directly; cache-hot uses `cache_edits` API |
+| 4 | Context Collapse | Medium | Non-destructive overlay; original messages intact; summaries in separate store |
+| 5 | Autocompact | High (irreversible) | Forks child agent for two-phase Chain-of-Thought summarization |
+
+### Level 3: Microcompact Dual-Path Design
+
+Microcompact is the critical layer for cache preservation. It has two mutually exclusive code paths:
+
+**Cache Cold Path** (prompt cache expired): Directly modifies messages in the conversation history, replacing old tool results with `[Old tool result cleared]` placeholders. This is cheaper but invalidates any existing cache.
+
+**Cache Hot Path** (prompt cache warm): Uses `cache_edits` blocks that ride alongside the API request, telling the server to delete specific tool result blocks by their `tool_use_id`. The server performs the deletion server-side, preserving cache warmth without client re-upload:
+
+```typescript
+// Conceptual: cache_edits alongside the API request
+{
+  messages: [...],  // Unchanged locally -- preserves cache prefix
+  cache_edits: [
+    { action: "delete", tool_use_id: "toolu_abc123" },
+    { action: "delete", tool_use_id: "toolu_def456" }
+  ]
+}
+```
+
+The system tags tool result blocks with `cache_reference: tool_use_id` to enable this surgical editing. Messages stay locally unchanged, the cached prefix stays warm, and the server applies the edits before the prompt reaches Claude.
+
+### Context Editing API (Official)
+
+Anthropic's official Context Editing API (`context-management-2025-06-27` beta) provides server-side strategies for managing growing conversations:
+
+**Tool Result Clearing** (`clear_tool_uses_20250919`): Automatically clears the oldest tool results in chronological order when context exceeds a threshold. Configurable parameters include:
+
+- `trigger`: Token threshold that activates clearing (e.g., 30,000 input tokens)
+- `keep`: Number of recent tool uses to preserve (e.g., last 3)
+- `clear_at_least`: Minimum tokens to clear per activation (e.g., 5,000)
+- `exclude_tools`: Tool names exempt from clearing
+
+```typescript
+const response = await anthropic.beta.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 4096,
+  messages: conversation,
+  tools: toolDefinitions,
+  betas: ["context-management-2025-06-27"],
+  context_management: {
+    edits: [{
+      type: "clear_tool_uses_20250919",
+      trigger: { type: "input_tokens", value: 30000 },
+      keep: { type: "tool_uses", value: 3 },
+      clear_at_least: { type: "input_tokens", value: 5000 },
+    }]
+  }
+});
+```
+
+**Thinking Block Clearing** (`clear_thinking_20251015`): Manages thinking blocks when extended thinking is enabled. Default behavior keeps only the last turn's thinking; configurable to keep all (maximizes cache hits) or clear aggressively (saves context space).
+
+**Cache interaction**: Tool result clearing invalidates cached prefixes at the clearing point but creates a new cacheable prefix for subsequent requests. Thinking block clearing preserves cache when blocks are kept and invalidates when cleared.
+
+### Production Bug: Cache Invalidation from Microcompact
+
+A production incident (BQ 2026-03-01) revealed that microcompact was responsible for 20% of prompt cache breaks because it modifies the system prompt without properly invalidating the cache flag. The fix required explicit cache invalidation checks when microcompact runs, ensuring the system correctly transitions between hot and cold paths.
+
+### Circuit Breaker
+
+After observing 1,279 sessions with up to 3,272 consecutive autocompact failures, Claude Code added `MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES = 3`. This prevented 250,000+ wasted API calls per day from runaway compaction loops.
+
+---
+
+## 4. How Other AI Agents Handle Caching
+
+### Aider
+
+Aider organizes its chat history explicitly for caching with `--cache-prompts`:
+
+1. System prompt (cached)
+2. Read-only files added with `--read` (cached)
+3. Repository map (cached)
+4. Editable files in the chat (cached, but changes per edit)
+
+**Keepalive mechanism**: `--cache-keepalive-pings N` sends pings every 5 minutes (matching Anthropic's default TTL) up to N times, keeping the cache warm between user messages. This prevents cache expiration during think-time.
+
+**Limitation**: Caching statistics and costs are not available when streaming responses. Users must disable streaming with `--no-stream` to access detailed cache analytics.
+
+### Cline
+
+Cline's current architecture (as of the discussion in early 2026) **fundamentally breaks caching**. It spawns a new Claude Code CLI process for every message exchange using `execa()` with `--max-turns 1`. Each process has independent metadata, and dynamic version headers (`cc_version=...;cch=...;`) change per invocation, guaranteeing cache misses.
+
+Two proposed fixes:
+- **Session Resume**: Use `--resume <session_id>` to maintain conversation state across invocations
+- **Persistent Process**: Keep a long-lived process with `--input-format stream-json`
+
+### Cursor
+
+Cursor integrates prompt caching with Anthropic's API. Real-world telemetry shows over 90% of tokens as cache reads in typical sessions, confirming effective caching. However, most cost comes from repeatedly reloading context rather than generating code, indicating that context size dominates even with caching.
+
+### prompt-caching MCP Plugin
+
+An open-source MCP plugin provides automatic cache breakpoint injection across Claude Code, Cursor, Windsurf, and other MCP-compatible clients. It operates through four modes:
+
+| Mode | Mechanism | Token Reduction |
+|------|-----------|-----------------|
+| BugFix | Caches stack traces + error context on first detection | 85% |
+| Refactor | Caches code patterns, style guides, type definitions | 80% |
+| File Tracking | Monitors read frequency; injects breakpoint on second access | 90% |
+| Conversation Freeze | Freezes pre-conversation messages after N turns; keeps last 3 fresh | 92% |
+
+---
+
+## 5. Implementation Recommendations for luca-mastracode
+
+### 5.1 Introduce a Cache Boundary in Instruction Assembly
+
+Split the system prompt into two content blocks with different TTLs:
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+function buildSystemPrompt(mode: string, sessionContext: SessionContext) {
+  // Static prefix: behavioral rules, tool guidance, hard constraints
+  // Identical across all sessions for the same mode + version
+  const staticPrefix = [
+    loadModeInstructions(mode),
+    HARD_CONSTRAINTS,
+    ALWAYS_APPLY_RULES,
+  ].join("\n\n");
+
+  // Dynamic suffix: per-session state, environment, git status
+  const dynamicSuffix = [
+    buildEnvironmentInfo(sessionContext),
+    buildGitStatus(sessionContext),
+    buildWorkflowState(sessionContext),
+    buildMcpInstructions(sessionContext),
+  ].join("\n\n");
+
+  return { staticPrefix, dynamicSuffix };
+}
+
+function buildApiRequest(
+  mode: string,
+  sessionContext: SessionContext,
+  messages: Message[],
+  tools: Tool[]
+) {
+  const { staticPrefix, dynamicSuffix } = buildSystemPrompt(mode, sessionContext);
+
+  return {
+    model: "claude-opus-4-6",
+    max_tokens: 16384,
+    tools: tools.map((tool, i, arr) =>
+      i === arr.length - 1
+        ? { ...tool, cache_control: { type: "ephemeral", ttl: "1h" } }
+        : tool
+    ),
+    system: [
+      {
+        type: "text",
+        text: staticPrefix,
+        cache_control: { type: "ephemeral", ttl: "1h" }
+      },
+      {
+        type: "text",
+        text: dynamicSuffix,
+        cache_control: { type: "ephemeral" }  // 5-minute TTL
+      }
+    ],
+    messages
+  };
+}
+```
+
+### 5.2 Keep Tool Definitions Stable and First
+
+Place tool definitions in the `tools` array (which is evaluated before `system` in the cache hierarchy) and add a breakpoint on the last tool. Since luca-mastracode's tool sets are mode-specific but stable within a mode, this is a natural cache boundary:
+
+```typescript
+// Tool definitions are stable per mode -- cache them with 1-hour TTL
+const tools = buildModeTools(mode).map((tool, i, arr) =>
+  i === arr.length - 1
+    ? { ...tool, cache_control: { type: "ephemeral", ttl: "1h" } }
+    : tool
+);
+```
+
+### 5.3 Adopt Context Editing for Tool Result Management
+
+Use the `context_management.edits` API instead of client-side tool result truncation:
+
+```typescript
+const response = await client.beta.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 16384,
+  tools,
+  system: systemBlocks,
+  messages: conversation,
+  betas: ["context-management-2025-06-27"],
+  context_management: {
+    edits: [{
+      type: "clear_tool_uses_20250919",
+      trigger: { type: "input_tokens", value: 50000 },
+      keep: { type: "tool_uses", value: 5 },
+      clear_at_least: { type: "input_tokens", value: 10000 },
+    }]
+  }
+});
+```
+
+### 5.4 Use Mid-Conversation Injection Instead of System Prompt Mutation
+
+When injecting dynamic context (behavioral refreshes, mode transitions, context rot remediation), use the message layer via `<luca-reminder>` tags rather than modifying the system prompt. This preserves system prompt cache validity:
+
+```typescript
+// BAD: Modifying system prompt invalidates cache
+system[1].text = updatedDynamicContext;
+
+// GOOD: Inject as a user message -- system prompt cache stays warm
+messages.push({
+  role: "user",
+  content: [{
+    type: "text",
+    text: `<luca-reminder>
+${criticalConstraintRefresh}
+${updatedWorkflowState}
+</luca-reminder>
+
+${actualUserMessage}`
+  }]
+});
+```
+
+### 5.5 Monitor Cache Performance
+
+Track cache hit rates using the `usage` fields in every API response:
+
+```typescript
+function logCacheMetrics(usage: ApiUsage) {
+  const total = usage.cache_read_input_tokens
+    + usage.cache_creation_input_tokens
+    + usage.input_tokens;
+
+  const hitRate = total > 0
+    ? usage.cache_read_input_tokens / total
+    : 0;
+
+  // Alert if hit rate drops below expected threshold
+  if (hitRate < 0.6 && total > 5000) {
+    console.warn(`Cache hit rate degraded: ${(hitRate * 100).toFixed(1)}%`);
+  }
+}
+```
+
+### 5.6 Subagent Cache Sharing
+
+When spawning subagents, ensure they use the same tool set and static system prefix as the parent to maximize cache reuse. If a subagent needs fewer tools, prefer giving it the full set (with behavioral constraints limiting usage) over a reduced set that would cause a cache miss:
+
+```typescript
+// Prefer: Full tool set with behavioral constraint
+const subagentSystem = `${staticPrefix}
+You are a read-only research agent. Do NOT use Write, Edit, or Bash tools.`;
+
+// Avoid: Different tool set that breaks cache
+const reducedTools = tools.filter(t => ["Read", "Grep", "Glob"].includes(t.name));
+// This causes a cache miss on the tools layer
+```
+
+---
+
+## 6. Key Architectural Principles
+
+1. **Stability dominates cost**: The most important optimization is keeping the prompt prefix stable across turns. A 20K-token prefix cached at 0.1x costs $0.001 per read; uncached it costs $0.01. Over 100 turns, that is $0.10 vs $1.00 for the prefix alone.
+
+2. **Cache hierarchy is strict**: tools -> system -> messages. Changes early in the hierarchy cascade. Put the most stable content first.
+
+3. **The 4-breakpoint budget is scarce**: Use them strategically: one on the last tool, one on the static system prefix, one on the dynamic system suffix, and one on the last assistant message in multi-turn conversations.
+
+4. **Minimum token thresholds matter**: For Opus 4.6 and Haiku 4.5, you need 4,096 tokens before caching activates. Ensure your static prefix exceeds this threshold.
+
+5. **Server-side editing preserves warmth**: Use context editing APIs and cache_edits over client-side message mutation whenever the cache is warm.
+
+6. **Mid-conversation injection over system prompt mutation**: Dynamic context that changes per-turn belongs in messages, not the system prompt. The system prompt is your most valuable cache asset.
+
+7. **Monitor, do not assume**: Track `cache_read_input_tokens` and `cache_creation_input_tokens` on every response. Unexpected cache writes indicate prefix instability.
+
+---
+
+## Sources
+
+### Anthropic Official Documentation
+- [Prompt Caching - Claude API Docs](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) -- Comprehensive API reference for cache_control, TTLs, pricing, breakpoints, and code examples
+- [Context Editing - Claude API Docs](https://platform.claude.com/docs/en/build-with-claude/context-editing) -- Server-side tool result clearing and thinking block clearing APIs
+- [Compaction - Claude API Docs](https://platform.claude.com/docs/en/build-with-claude/compaction) -- Server-side compaction strategies
+- [Tool Use with Prompt Caching - Claude API Docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-use-with-prompt-caching) -- Caching tool definitions and deferred tool references
+- [Prompt Caching Announcement](https://www.anthropic.com/news/prompt-caching?s=09) -- Original announcement with 85% latency reduction benchmark
+- [Token-Saving Updates](https://www.anthropic.com/news/token-saving-updates) -- Extended 1-hour TTL announcement
+
+### Claude Code Source Analysis
+- [Inside Claude Code - Victor Dibia](https://newsletter.victordibia.com/p/inside-claude-code) -- Analysis of cache boundary design, fork model, and tool set inheritance
+- [Claude Code's Compaction Engine - Barazany](https://barazany.dev/blog/claude-codes-compaction-engine) -- Source code analysis of the compression pipeline
+- [Claude Code's 5-Level Compression Pipeline - HarrisonSec](https://harrisonsec.com/blog/claude-code-context-engineering-compression-pipeline/) -- Detailed breakdown of all 5 compression levels, microcompact dual-path, circuit breaker
+- [Inside the Claude Code Source - Haseeb Qureshi](https://gist.github.com/Haseeb-Qureshi/d0dc36844c19d26303ce09b42e7188c1) -- SYSTEM_PROMPT_DYNAMIC_BOUNDARY, Blake2b hashing, global scope
+- [System Prompt & Query Loop - DeepWiki](https://deepwiki.com/ghboke/claude-code-reverse/2.1-system-prompt-and-query-loop) -- Static vs dynamic sections, tool definition caching, query loop
+- [Inside Claude Code's Compaction System - Decode Claude](https://decodeclaude.com/compaction-deep-dive/) -- Three-layer compaction architecture, post-compaction recovery
+- [System Prompt - Claude Code Internals](https://claude-code-explain.helmcode.com/system-prompt/) -- Prompt assembly components
+
+### Other Agent Implementations
+- [Aider Prompt Caching](https://aider.chat/docs/usage/caching.html) -- Keepalive pings, chat history organization for caching
+- [Cline Prompt Caching Discussion](https://github.com/cline/cline/discussions/9892) -- Process-per-message architecture breaking caching, proposed fixes
+- [Cursor Prompt Caching Forum](https://forum.cursor.com/t/prompt-caching-with-claude/7551) -- Community discussion on Cursor's caching integration
+- [prompt-caching MCP Plugin](https://prompt-caching.ai/) -- Automatic breakpoint injection across multiple AI tools
+
+### Additional References
+- [Prompt Caching 201 - OpenAI](https://developers.openai.com/cookbook/examples/prompt_caching_201) -- Cross-provider comparison of caching approaches
+- [Session Memory Compaction - Anthropic Cookbook](https://platform.claude.com/cookbook/misc-session-memory-compaction) -- Official cookbook for compaction patterns
+- [Prompt Caching Infrastructure - Introl](https://introl.com/blog/prompt-caching-infrastructure-llm-cost-latency-reduction-guide-2025) -- Infrastructure-level guide to caching

--- a/docs/research/prompt-architecture/02-context-rot-and-injection.md
+++ b/docs/research/prompt-architecture/02-context-rot-and-injection.md
@@ -1,0 +1,293 @@
+# Context Rot and Mid-Conversation Injection
+
+**Research Date:** 2026-04-13
+**Status:** Complete
+**Scope:** How context rot degrades agent behavior, how Claude Code combats it with system-reminder injection, and what academic research tells us about remediation strategies for luca-mastracode
+
+---
+
+## 1. What Context Rot Is and Why It Happens
+
+Context rot is the progressive degradation of LLM output quality as a conversation's token count grows. Unlike context window overflow (a hard failure when the window is full), context rot is a continuous, sub-catastrophic decline that begins well before capacity limits are reached. Anthropic researchers frame it bluntly: "Context must be treated as a finite resource with diminishing marginal returns... Every new token introduced depletes this budget by some amount."
+
+Three architectural mechanisms drive the degradation:
+
+**Attention dilution.** Transformer self-attention requires every token to attend to every other token. At 100K tokens, approximately 10 billion pairwise relationships must be tracked. Attention weights spread thinner with each additional token, reducing the model's ability to focus on any single piece of information (Liu et al., 2024).
+
+**The lost-in-the-middle effect.** Liu et al. (2024, TACL) demonstrated that LLMs exhibit a U-shaped attention curve: tokens at the beginning and end of the context receive disproportionately strong attention, while tokens in the middle receive significantly less. In multi-document question answering, accuracy dropped by more than 30% when the relevant document moved from position 1 or 20 to position 10 in a 20-document context. This is not a training artifact -- it emerges from positional encoding biases, particularly Rotary Position Embedding (RoPE), which introduces a decay effect favoring sequence boundaries.
+
+**Distractor interference.** Semantically similar but factually irrelevant content actively degrades performance. It competes for attention weights with genuinely relevant tokens and increases hallucination rates (measured at approximately 2.55% for GPT models in distractor-heavy conditions).
+
+These mechanisms are compounding. As an agent reads files, executes tools, and accumulates conversation history, every result persists in context. Dead-end explorations, superseded file contents, and stale tool outputs create an ever-growing noise floor against which the model must distinguish signal.
+
+### Measured Degradation Curves
+
+Adobe Research (February 2025) measured accuracy drops across frontier models on complex retrieval tasks as context grew:
+
+| Model | Short Context | 32K Tokens | Drop |
+|---|---|---|---|
+| GPT-4o | 99% | 70% | -29pp |
+| Claude 3.5 Sonnet | 88% | 30% | -58pp |
+| Gemini 2.5 Flash | 94% | 48% | -46pp |
+| Llama 4 Scout | 82% | 22% | -60pp |
+
+Two-hop reasoning tasks (requiring chained inference) showed even steeper degradation. Chroma's 2025 benchmark of 18 frontier models -- including GPT-4.1, Claude Opus 4, and Gemini 2.5 -- confirmed that every model tested exhibits performance decline as input length increases, with no exceptions.
+
+Du et al. (2025, ACL Findings) proved that context length alone causes degradation independent of retrieval quality. Even when irrelevant tokens were replaced with whitespace and models were forced to attend only to relevant tokens, performance still dropped 13.9% to 85% as input length increased.
+
+For coding agents specifically, research shows a "35-minute threshold": agent success rates decrease after 35 minutes of continuous operation, with task duration doubling quadrupling failure rates. By that point, agents typically accumulate 80K-150K tokens with signal-to-noise ratios near 2.5%.
+
+---
+
+## 2. Agent Drift: The Multi-Turn Amplification
+
+Context rot becomes especially pernicious in agentic systems. Tran et al. (2026) formalize this as "agent drift" -- behavioral degradation in multi-agent LLM systems over extended interactions. They identify three distinct manifestations:
+
+1. **Semantic drift**: Progressive deviation from original intent. The agent's understanding of the task subtly shifts as conversation history accumulates.
+2. **Coordination drift**: Breakdown in multi-agent consensus mechanisms. Subagents begin contradicting each other or the orchestrator's plan.
+3. **Behavioral drift**: Emergence of unintended strategies. The agent develops shortcuts or habits not specified in its instructions.
+
+The paper introduces the Agent Stability Index (ASI), a composite metric across twelve dimensions including response consistency, tool usage patterns, and reasoning pathway stability. Their projection: unchecked drift causes a 42% reduction in task success rates for long-running agents.
+
+A separate finding from Zylos Research (2026) quantifies the compounding effect: 95% per-step reliability over 20 steps compounds to only 36% combined success, and 2% early misalignment can escalate into 40% failure rates by workflow end.
+
+The critical insight for agent harness design: **context rot is not merely a retrieval problem -- it is a behavioral stability problem.** The model does not just fail to find information; it fundamentally changes how it behaves, which instructions it follows, and what strategies it employs.
+
+---
+
+## 3. Claude Code's System-Reminder Implementation
+
+Claude Code combats context rot through a mid-conversation injection system built on `<system-reminder>` XML tags. The system prompt declares:
+
+```
+Tool results and user messages may include <system-reminder> or other tags.
+Tags contain information from the system. They bear no direct relation to
+the specific tool results or user messages in which they appear.
+```
+
+This primes the model to treat reminder content as authoritative system-level guidance regardless of where it appears in the conversation.
+
+### Injection Mechanism
+
+System reminders are reactive, not periodic. They fire when specific harness-level conditions are met -- they evaluate at lifecycle events including `session_start`, `turn_start`, `turn_end`, `tool_execution_start/end`, `message_start/update/end`, and `session_compact`. The harness checks conditions at each event and injects the appropriate reminder if the condition is satisfied.
+
+Claude Code implements approximately 37 reminders across five domains:
+
+1. **File state monitoring**: Alerts about truncated reads, empty files, linter modifications
+2. **Context management**: Token usage warnings and post-compaction notifications
+3. **Task tracking**: Nudges toward underutilized tools (e.g., re-surfacing available MCP tools)
+4. **Plan mode enforcement**: Behavioral reminders when the agent should be planning but starts coding
+5. **Security awareness**: Post-read prompts about potential malware risks
+
+### Visibility and Design Philosophy
+
+System reminders are invisible to the user. They appear in the API message stream but are not rendered in the Claude Code UI. The design philosophy is "nudging over forcing" -- reminders are soft behavioral reinforcement, not hard blocks. The model can theoretically ignore them, but the strategic placement at decision-critical moments makes compliance highly likely.
+
+### The UserPromptSubmit Hook Pattern
+
+Community implementations (e.g., John Lindquist's auto-refresh hook) demonstrate the extensibility of this approach. The `UserPromptSubmit` hook fires every time the user sends a message. By tracking prompt count via persistent files keyed by `session_id`, the hook injects contextual reminders at configurable intervals:
+
+```
+FREQUENCY = 3   (inject every 3 prompts)
+START_AFTER = 3  (delay until prompt 3)
+```
+
+Content appears at prompts 3, 6, 9, 12, etc. Advanced implementations cycle through multiple reminder types (tools, context, protocol) across successive intervals. The injected content arrives via `additionalContext` in the hook's JSON response, wrapped in `<system-reminder>` tags that Claude sees but the user does not.
+
+---
+
+## 4. Why Message-Layer Injection Preserves Cache
+
+This is the architectural crux that any custom harness must understand.
+
+Anthropic's prompt caching works by hashing the prefix of each request (tools + system prompt + message history, in that order). If the prefix matches a cached entry, the cached KV activations are reused, saving both cost and latency. Cache reads cost 0.1x the base input token price versus 1.0x for uncached tokens.
+
+**The problem with system prompt mutation**: If behavioral reminders are injected by modifying the system prompt, the hash changes on every injection. This invalidates the cache for the entire static prefix -- identity, behavioral rules, tool definitions, everything. For a system prompt of 20,000+ tokens running over 50 turns, this means approximately 1 million tokens of redundant computation billed at full price.
+
+**The solution**: Claude Code places dynamic reminders in the message layer (as user messages or tool results containing `<system-reminder>` tags), not in the system prompt. The system prompt remains static and cacheable. The reminder content appears at the recency end of the conversation, where it benefits from the U-shaped attention curve's recency bias -- the model attends to recent tokens with peak strength.
+
+This creates an elegant alignment: the cache boundary preserves cost efficiency while the recency effect maximizes behavioral impact. Claude Code formalizes this with `SYSTEM_PROMPT_DYNAMIC_BOUNDARY`, splitting the system prompt into a static prefix (1-hour cache TTL) and a dynamic suffix (5-minute cache TTL). Anything that must change per-turn goes in messages, not in either system prompt section.
+
+---
+
+## 5. How Other Agents Handle Context Management
+
+### Cursor
+
+Cursor relies primarily on its context engine to manage relevance, fetching only relevant code snippets rather than entire files. It does not appear to implement mid-conversation behavioral re-injection. Context management is primarily an input-side concern (what goes in) rather than a mid-conversation remediation concern (refreshing what's already there).
+
+### GitHub Copilot
+
+Copilot Agent Mode (introduced early 2025, refined through 2026) handles context through its planning-execution loop. The agent plans autonomously, executes steps, and iterates. Context management is implicit in the agent loop structure rather than explicit through injection mechanisms.
+
+### Cline
+
+Cline takes the approach of maximizing context breadth -- reading entire codebases and maintaining deep project context throughout sessions. Its token-based pricing model reflects this philosophy. Cline's MCP integration (v3.4+) routes all tool calls through a unified MCP-compatible interface, but this addresses context sourcing rather than context rot remediation.
+
+### JetBrains Research (December 2025)
+
+JetBrains published research on efficient context management for LLM-powered coding agents, finding that simple observation masking (replacing older tool outputs with placeholders while preserving action history) matched or exceeded LLM-based summarization in effectiveness, with over 50% cost reduction. A 10-turn rolling window showed the optimal balance between context preservation and performance. Critically, they found that LLM summarization causes trajectory elongation -- agents run 13-15% longer because summaries "smooth over" failure indicators that would otherwise signal the agent to stop.
+
+### Agentic Context Engineering (ACE)
+
+Wang et al. (2025) propose treating contexts as "evolving playbooks" that accumulate, refine, and organize strategies through modular generation-reflection-curation processes. ACE achieved +10.6% improvement on agent tasks and +8.6% on finance domain tasks, matching top-ranked production agents on the AppWorld leaderboard while using smaller open-source models. The key innovation: structured incremental updates that preserve detailed knowledge and prevent the information collapse that occurs with repeated full-context compression.
+
+---
+
+## 6. Optimal Injection Strategies
+
+No peer-reviewed study directly answers "inject every N turns or every M tokens." However, converging evidence from multiple sources allows us to synthesize practical guidelines:
+
+### Token-Based Triggers
+
+- **30K token threshold**: Adobe's data shows accelerating degradation beyond 30K tokens for complex tasks. First injection should occur no later than this point.
+- **70% context utilization**: Anthropic's own `compact-2026-01-12` feature triggers compaction at 70% utilization. Behavioral re-injection should precede this -- ideally at 40-50% to reinforce instructions before the degradation zone.
+- **Every 15-20K token increment**: Given the measured degradation curves, re-injecting critical behavioral rules every 15-20K tokens of accumulated context provides reinforcement before attention dilution reaches problematic levels.
+
+### Turn-Based Triggers
+
+- **Every 3-5 user turns**: The community hook pattern (inject every 3 prompts after an initial delay of 3) aligns with the observation that behavioral drift becomes measurable after 5-10 tool-call rounds.
+- **At mode/phase boundaries**: When an agent transitions between workflow phases (research -> planning -> execution), a full behavioral refresh is warranted regardless of token count. Phase transitions represent natural points where the model's behavioral context should be re-anchored.
+
+### Content-Based Triggers
+
+- **After compaction**: Post-compaction is the highest-priority injection point. Compaction strips conversation history, potentially removing the behavioral context that grounded earlier adherence. Re-inject all critical constraints immediately.
+- **After tool result floods**: Large tool results (file reads, grep outputs) dilute the attention available for behavioral instructions. Re-inject after any tool result exceeding approximately 2K tokens.
+- **On behavioral deviation detection**: If the harness detects the model violating a constraint (e.g., writing code when it should be planning), inject a targeted correction reminder.
+
+### Content Selection
+
+Not all rules need re-injection. Prioritize:
+
+1. **Hard constraints** (safety rules, permission boundaries) -- always re-inject
+2. **Mode-specific behavioral rules** (plan vs execute vs review) -- re-inject at phase boundaries
+3. **Output format constraints** (word limits, response structure) -- re-inject every N turns
+4. **Tool usage preferences** (which tools to use/avoid) -- re-inject after tool result floods
+
+Lower priority for re-injection: project conventions, coding style rules, and domain knowledge (these degrade more slowly and can be recalled from external memory on demand).
+
+---
+
+## 7. Implementation Patterns for luca-mastracode
+
+### Pattern 1: Lifecycle-Event Reminders (Reactive)
+
+Mimic Claude Code's approach -- evaluate conditions at harness lifecycle events and inject when conditions are met:
+
+```typescript
+// In the harness event loop:
+function onTurnStart(state: ConversationState): SystemReminder | null {
+  if (state.tokenCount > 30_000 && !state.recentReminder('hard-constraints')) {
+    return buildReminder('hard-constraints', HARD_CONSTRAINTS)
+  }
+  if (state.turnsSinceLastReminder('mode-rules') >= 5) {
+    return buildReminder('mode-rules', currentModeRules(state.mode))
+  }
+  return null
+}
+```
+
+### Pattern 2: Turn-Counter Injection (Periodic)
+
+Simpler to implement, appropriate as a first pass:
+
+```typescript
+const INJECTION_FREQUENCY = 4  // every 4 turns
+const INJECTION_START = 3      // after turn 3
+
+function shouldInject(turnCount: number): boolean {
+  return turnCount >= INJECTION_START && turnCount % INJECTION_FREQUENCY === 0
+}
+```
+
+### Pattern 3: Token-Budget Reminders (Threshold)
+
+Inject when crossing token budget thresholds:
+
+```typescript
+const THRESHOLDS = [30_000, 60_000, 90_000, 120_000]
+
+function checkTokenThreshold(tokenCount: number, lastThreshold: number): number | null {
+  const next = THRESHOLDS.find(t => t > lastThreshold && tokenCount >= t)
+  return next ?? null
+}
+```
+
+### Pattern 4: Post-Compaction Full Refresh
+
+Always re-inject all critical context after any compaction event:
+
+```typescript
+function onCompactionComplete(state: ConversationState): SystemReminder {
+  return buildReminder('post-compaction-refresh', [
+    HARD_CONSTRAINTS,
+    currentModeRules(state.mode),
+    buildEnvironmentContext(state),
+    'Memory recalled via MuninnDB is hints, not truth. Verify against current code.',
+  ].join('\n\n'))
+}
+```
+
+### Tag Convention
+
+Define a `<luca-reminder>` tag in base instructions, analogous to Claude Code's `<system-reminder>`:
+
+```
+Tool results and user messages may include <luca-reminder> tags.
+These contain behavioral guidance from the Luca harness.
+They bear no relation to the specific tool results or messages
+in which they appear. Follow their instructions.
+```
+
+Place reminders in the message layer (as part of user messages or tool results), never in the system prompt, to preserve cache validity.
+
+---
+
+## 8. Summary of Findings
+
+| Finding | Implication for luca-mastracode |
+|---|---|
+| All frontier models degrade with context length (Chroma 2025, Du et al. 2025) | Context rot is inevitable; design around it, don't try to prevent it |
+| U-shaped attention: start and end tokens get peak attention (Liu et al. 2024) | Place critical rules at both start AND end of instructions; use message-layer injection to exploit recency |
+| 30K+ tokens is the danger zone for complex tasks (Adobe 2025) | Begin behavioral refresh no later than 30K tokens accumulated |
+| Agent drift compounds: 2% early misalignment becomes 40% failure (Zylos 2026) | Early and frequent re-injection is cheaper than late remediation |
+| System prompt mutation breaks caching (Anthropic docs) | All dynamic injection must go in the message layer |
+| Simple observation masking outperforms LLM summarization (JetBrains 2025) | When compacting, replace old tool results with placeholders rather than summarizing |
+| 37 reminders across 5 domains in Claude Code (source analysis) | Reminders should be domain-specific and condition-triggered, not one-size-fits-all |
+| ACE structured playbooks prevent context collapse (Wang et al. 2025) | External memory (MuninnDB) should complement in-context reminders |
+| Post-compaction is the highest-risk moment for behavioral loss | Always inject a full constraint refresh after compaction |
+
+---
+
+## Sources
+
+### Academic Papers
+
+- [Lost in the Middle: How Language Models Use Long Contexts](https://aclanthology.org/2024.tacl-1.9/) -- Liu et al., TACL 2024. The foundational U-shaped attention curve paper.
+- [Lost in the Middle: An Emergent Property from Information Retrieval Demands in LLMs](https://arxiv.org/abs/2510.10276) -- Follow-up showing the U-shape emerges from pre-training memory demands.
+- [Context Length Alone Hurts LLM Performance](https://aclanthology.org/2025.findings-emnlp.1264.pdf) -- Du et al., ACL Findings 2025. Proves length alone degrades performance.
+- [LongGenBench: Benchmarking Long-Form Generation in Long Context LLMs](https://proceedings.iclr.cc/paper_files/paper/2025/file/141304a37d59ec7f116f3535f1b74bde-Paper-Conference.pdf) -- ICLR 2025. Instruction adherence declines past 4K tokens.
+- [Agent Drift: Quantifying Behavioral Degradation in Multi-Agent LLM Systems](https://arxiv.org/abs/2601.04170) -- Tran et al., 2026. Formalizes semantic, coordination, and behavioral drift.
+- [Agentic Context Engineering: Evolving Contexts for Self-Improving Language Models](https://arxiv.org/abs/2510.04618) -- Wang et al., 2025. ACE framework for structured context evolution.
+
+### Industry Research
+
+- [Context Rot: Why LLMs Degrade as Context Grows](https://www.morphllm.com/context-rot) -- Morph. Comprehensive overview with coding agent-specific data (35-minute threshold, 2.5% SNR).
+- [Context Rot: The Emerging Challenge](https://www.understandingai.org/p/context-rot-the-emerging-challenge) -- Understanding AI. Adobe Research degradation measurements across 4 frontier models.
+- [Cutting Through the Noise: Smarter Context Management for LLM-Powered Agents](https://blog.jetbrains.com/research/2025/12/efficient-context-management/) -- JetBrains Research, December 2025. Observation masking vs LLM summarization comparison.
+- [AI Agent Context Compression Strategies](https://zylos.ai/research/2026-02-28-ai-agent-context-compression-strategies) -- Zylos Research, February 2026. ACON framework, compression ratios by content type.
+- [Context Engineering for Agents](https://rlancemartin.github.io/2025/06/23/context_engineering/) -- Lance Martin. Context engineering framework overview.
+- [Context Engineering Strategies to Prevent LLM Context Rot](https://milvus.io/blog/keeping-ai-agents-grounded-context-engineering-strategies-that-prevent-context-rot-using-milvus.md) -- Milvus Blog. Vector-DB-backed context management patterns.
+
+### Claude Code Implementation Analysis
+
+- [System Reminders: How Claude Code Steers Itself](https://michaellivs.com/blog/system-reminders-steering-agents/) -- Michael Livs. Analysis of 37 reminders across 5 domains, lifecycle event integration.
+- [Claude Code Hooks: Auto-Refresh Context Every N Prompts](https://gist.github.com/johnlindquist/23fac87f6bc589ddf354582837ec4ecc) -- John Lindquist. Community implementation of turn-counter injection via UserPromptSubmit hooks.
+- [System-Reminder Content Injection Issue #4464](https://github.com/anthropics/claude-code/issues/4464) -- GitHub. Community report on excessive system-reminder token consumption.
+- [Hidden System-Reminder Injections Issue #17601](https://github.com/anthropics/claude-code/issues/17601) -- GitHub. Report documenting 10,000+ injections consuming 15%+ of context window.
+- [Prompt Caching -- Claude API Docs](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) -- Anthropic. Official documentation on cache_control, ephemeral type, and cache boundary mechanics.
+
+### Companion Documents
+
+- [00-overview.md](./00-overview.md) -- Full Claude Code prompt architecture analysis with cache boundary pattern, tool definitions, and gap analysis for luca-mastracode.
+- [context-rot-prevention.md](../../archive/workflow-v2-spec/v2/00-design-principles/context-rot-prevention.md) -- Luca v2 design principle: many small agents with fresh context as the primary architectural defense.

--- a/docs/research/prompt-architecture/03-tool-definition-engineering.md
+++ b/docs/research/prompt-architecture/03-tool-definition-engineering.md
@@ -249,7 +249,7 @@ For modes with many tools (like `luca:6-finalize` with 6 tools), consider Gemini
 - [Piebald-AI/claude-code-system-prompts](https://github.com/Piebald-AI/claude-code-system-prompts) -- Extracted system prompts, 24 builtin tool descriptions, and sub-agent prompts updated per Claude Code release (v2.1.104)
 - [Tools and System Prompt of Claude Code (Gist)](https://gist.github.com/wong2/e0f34aac66caf890a332f7b6f9e2ba8f) -- Complete tool descriptions and system prompt text extraction
 - [Claude Code Prompts | Anatomy of an AI Coding Agent](https://ccprompts.info/) -- Catalog of 124 prompts across 9 categories with token counts per tool
-- [Diving into Claude Code's Source Code Leak](https://read.engineerscodex.com/p/diving-into-claude-codes-source-code) -- Analysis of permission critic pattern, anti-distillation, and tool security architecture
+- [Diving into Claude Code's Source Code](https://read.engineerscodex.com/p/diving-into-claude-codes-source-code) -- Analysis of permission critic pattern, anti-distillation, and tool security architecture
 
 ### Agent Building Patterns
 

--- a/docs/research/prompt-architecture/03-tool-definition-engineering.md
+++ b/docs/research/prompt-architecture/03-tool-definition-engineering.md
@@ -1,0 +1,269 @@
+# Tool Definition Engineering: Behavioral Guidance as the Missing Layer
+
+**Research Date:** 2026-04-13
+**Status:** Complete
+**Scope:** How effective tool definitions combine schemas with behavioral guidance to steer agent tool selection and usage
+**Series:** Prompt Architecture Research (03 of N)
+
+---
+
+## Executive Summary
+
+Tool definitions are not API documentation -- they are active control surfaces that directly shape how AI agents reason about tool selection, invocation, and sequencing. Claude Code dedicates approximately 73,000 characters across 36+ tools to tool-specific prompts, with individual tools like Bash consuming over 1,200 tokens of behavioral guidance alone. Empirical evidence from Anthropic and the broader agent-building community demonstrates that even small refinements to tool descriptions yield dramatic improvements in agent performance. This document catalogs the anatomy of effective tool definitions, extracts patterns from production coding agents, and provides implementation recommendations for enriching luca-mastracode's tool layer.
+
+---
+
+## 1. Why Tool Descriptions Matter as Much as Tool Schemas
+
+### The Schema-Description Gap
+
+A tool schema defines what a tool *can* do: its parameters, types, and constraints. A tool description defines what a tool *should* do: when to use it, when not to, how it relates to other tools, and what pitfalls to avoid. The schema is a contract with the runtime; the description is a contract with the model.
+
+Anthropic's official guidance states this explicitly: "Provide extremely detailed descriptions. This is by far the most important factor in tool performance." They recommend at minimum 3-4 sentences per tool description, more for complex tools, covering what the tool does, when it should be used, when it should not be used, what each parameter means, and any important caveats or limitations.
+
+### Empirical Evidence
+
+Anthropic reports that Claude Sonnet 3.5 achieved state-of-the-art performance on SWE-bench Verified specifically after "precise refinements to tool descriptions" -- not schema changes, not model improvements, but description engineering. The descriptions are serialized directly into the model's context window and function as what Augment Code calls "hidden prompts" that teach agents how to think about problems.
+
+### Tool Descriptions as Steering Mechanisms
+
+Augment Code's research identifies four layers of agent prompting infrastructure -- system prompts, tools, skills, and user messages -- with tool descriptions operating as the second layer. Their finding: "The more specific and directive your tool descriptions, the better the agent will understand when to use each tool." Tool descriptions should explain not just *what* a tool does, but *when* to invoke it, *what* it returns, and *why* those results matter for task planning.
+
+A critical corollary: absent tools prompt as strongly as present ones. By removing a lower-fidelity tool (like raw `grep`), agents are forced toward more powerful alternatives. Tool availability itself becomes a prompting mechanism.
+
+---
+
+## 2. Claude Code's Tool Definition Anatomy
+
+### Structure of a Claude Code Tool Prompt
+
+Each of Claude Code's 36+ built-in tools carries a self-contained prompt that follows a consistent five-part structure, extracted from the Piebald-AI/claude-code-system-prompts repository (v2.1.104, April 2026):
+
+1. **Purpose statement** -- What the tool does in 1-2 sentences
+2. **Usage guidance** -- When and how to use it, with specific conditions
+3. **Behavioral constraints** -- What NOT to do, with explicit reasoning
+4. **Priority ordering** -- Preference over alternative tools for the same task
+5. **Few-shot examples** -- Concrete invocation patterns for correct usage
+
+### Token Allocation by Tool
+
+The token investment varies significantly by tool complexity:
+
+| Tool | Approximate Tokens | Notes |
+|------|-------------------|-------|
+| Bash | ~1,233 | Most elaborate; combines tool guidance with git safety, command preferences, and timeout policies |
+| Read | ~690 | Multimodal support guidance, offset/limit patterns, PDF page limits |
+| Edit | ~469 | Indentation preservation, uniqueness constraints, read-before-edit requirement |
+| Grep | Implicit (shared) | Regex syntax, output modes, multiline matching flags |
+| Glob | Implicit (shared) | Pattern syntax, modification-time sorting |
+| Agent | Complex | Meta-prompting for sub-agent configuration |
+| TodoWrite | ~200-300 | State machine semantics, single-in-progress constraint |
+
+The total tool definition budget of ~73,000 characters represents roughly 79% of the combined system prompt + tool prompt token space (tool prompts are ~18,000 tokens vs ~4,750 tokens for the main system prompt). This ratio reveals a fundamental architectural insight: Claude Code invests far more in telling the model *how to use its tools* than in telling it *how to behave generally*.
+
+### The Bash Tool: A Case Study in Behavioral Guidance
+
+The Bash tool prompt is the most instructive example because it must simultaneously enable broad capability while preventing misuse. Its structure:
+
+**Priority ordering (negative examples):**
+```
+IMPORTANT: Avoid using this tool to run `find`, `grep`, `cat`, `head`,
+`tail`, `sed`, `awk`, or `echo` commands, unless explicitly instructed
+or after you have verified that a dedicated tool cannot accomplish your
+task. Instead, use the appropriate dedicated tool as this will provide
+a much better experience for the user:
+  - File search: Use Glob (NOT find or ls)
+  - Content search: Use Grep (NOT grep or rg)
+  - Read files: Use Read (NOT cat/head/tail)
+  - Edit files: Use Edit (NOT sed/awk)
+  - Write files: Use Write (NOT echo >/cat <<EOF)
+  - Communication: Output text directly (NOT echo/printf)
+```
+
+This pattern is bidirectional: it specifies both what TO use and what NOT to use, eliminating ambiguity. The reasoning ("this will provide a much better experience for the user") teaches the model to make correct edge-case decisions autonomously.
+
+**Operational constraints:**
+- Always quote file paths containing spaces
+- Prefer absolute paths; avoid `cd` between commands
+- Timeout defaults (120s) with explicit override documentation
+- Git safety protocol: never amend, never force-push, never skip hooks
+- Background execution guidance with `run_in_background` parameter
+
+**Few-shot examples:** The git commit section includes a complete HEREDOC example for commit message formatting, demonstrating the exact syntax the model should produce.
+
+### The Read Tool: Defensive Guidance
+
+The Read tool demonstrates how descriptions prevent common failure modes:
+
+- "You MUST use your Read tool at least once in the conversation before editing" (Edit tool cross-reference)
+- "By default, it reads up to 2000 lines starting from the beginning of the file"
+- "When you already know which part of the file you need, only read that part"
+- "For large PDFs (more than 10 pages), you MUST provide the pages parameter"
+- "Do NOT re-read a file you just edited to verify" (prevents wasted tool calls)
+
+Each constraint addresses a specific failure mode observed in production usage, not a theoretical concern.
+
+### The Edit Tool: Cross-Tool Coordination
+
+The Edit tool's description demonstrates inter-tool dependency management:
+
+- "You must use your Read tool at least once in the conversation before editing. This tool will error if you attempt an edit without reading the file."
+- "The edit will FAIL if old_string is not unique in the file. Either provide a larger string with more surrounding context to make it unique or use replace_all."
+- "ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required."
+
+These are not schema constraints (the schema cannot enforce "read before edit") -- they are behavioral guidance that shapes the model's planning.
+
+---
+
+## 3. Tool Priority Ordering and Bidirectional Constraints
+
+### The Anti-Redundancy Pattern
+
+Claude Code's most distinctive tool engineering pattern is systematic anti-redundancy: for every capability available through multiple tools, the descriptions explicitly state which tool to prefer and which to avoid.
+
+This is necessary because models are trained on vast corpora of shell usage. Without explicit guidance, Claude will default to `cat file.txt` over the Read tool, `grep -r pattern` over the Grep tool, and `find . -name "*.ts"` over Glob. The tool descriptions must fight these trained preferences.
+
+This is a concrete example of "fighting the weights" -- a concept documented by Drew Breunig where prompt instructions conflict with a model's post-training. Recognition signals include the model repeating incorrect tool choices despite instructions, acknowledging the preferred approach but reverting to trained habits, and few-shot examples being ignored in favor of familiar patterns. The mitigation in Claude Code's case is not subtle: the Bash tool description includes explicit, repeated negative examples with the target tools named in ALL CAPS for emphasis.
+
+### Reinforcement Across Layers
+
+Claude Code reinforces tool preferences at three levels:
+
+1. **System prompt** ("Using Your Tools" section): Global tool preference statement
+2. **Individual tool descriptions**: Per-tool negative examples
+3. **System reminders**: Mid-conversation re-injection when the model drifts
+
+This multi-layer reinforcement is deliberate. Augment Code's research confirms: "Critical tools warrant coverage in multiple layers -- system prompt emphasis, detailed descriptions, and even concrete examples -- leveraging repetition to strengthen agent adherence."
+
+---
+
+## 4. The Critic Pattern for Tool Safety
+
+### Permission Evaluation via Side-Query
+
+Claude Code's bash security system spans approximately 9,700 lines with 22 validators. Rather than relying solely on static allowlists, it employs a "permission classification via side-query" pattern: the command is sent to the model as a separate evaluation query asking "Is this command safe?" The model evaluates context, working directory, and user intent to produce an adaptive, context-aware security assessment.
+
+This critic pattern replaces brittle static rules with contextual evaluation. It can reason about intent (is this `rm -rf` targeting a build directory or the home directory?), assess blast radius (is this a single-file operation or recursive?), and consider session context (has the user been working on cleanup tasks?).
+
+### Implications for Tool Description Design
+
+The critic pattern demonstrates that tool descriptions serve dual audiences: the primary agent that selects and invokes tools, and the safety evaluator that assesses whether the invocation is appropriate. Tool descriptions must provide enough context for both audiences to reason correctly.
+
+---
+
+## 5. Comparison Across Coding Agents
+
+### Gemini CLI: Progressive Tool Discovery
+
+Gemini CLI (open-source, Google) takes a fundamentally different approach to tool definition management. Traditional tools are "eager" -- all definitions loaded into the system prompt at session start. Gemini CLI's Agent Skills system is "progressive" -- capabilities are discovered dynamically, with detailed instructions loaded only when the agent identifies a relevant task.
+
+At session start, only tool names and brief descriptions are injected. Full tool schemas and behavioral guidance load on-demand. This reduces context saturation at the cost of requiring an extra reasoning step for tool discovery. The system prompt supports template variables (`${AvailableTools}`, `${AgentSkills}`, `${SubAgents}`) for dynamic composition.
+
+### Codex CLI: Sandbox-First Security
+
+OpenAI's Codex CLI uses OS-level sandboxing (Docker isolation) as its primary safety mechanism, with tool descriptions focused on capability rather than safety guidance. The tool layer includes multi-agent collaboration primitives (`spawn_agent`, `send_input`, `resume_agent`, `wait_agent`, `close_agent`) that Claude Code handles through its Agent/Worktree tools instead.
+
+Codex's tool descriptions are leaner than Claude Code's because the sandbox provides a safety floor that reduces the need for behavioral safety guidance in descriptions. The trade-off: less adaptive security (sandbox rules are static) but simpler tool definitions.
+
+### Cursor: IDE-Integrated Tool Context
+
+Cursor integrates tool definitions with IDE state (open files, cursor position, visible lines), providing implicit context that reduces the need for explicit behavioral guidance. Tools know what the user is looking at, reducing the description burden of explaining when to use file-reading tools.
+
+### Comparative Summary
+
+| Dimension | Claude Code | Gemini CLI | Codex CLI | Cursor |
+|-----------|------------|------------|-----------|--------|
+| Tool loading | Eager (all at start) | Progressive (on-demand) | Eager | Eager + IDE context |
+| Description depth | Very deep (~1,200 tokens for Bash) | Shallow at start, deep on-demand | Moderate | Moderate + implicit context |
+| Safety mechanism | Behavioral guidance + critic pattern | Permission prompts for mutators | Docker sandbox | IDE permissions |
+| Cross-tool coordination | Extensive bidirectional constraints | Minimal | Minimal | Implicit via IDE |
+| Few-shot examples | In tool descriptions | In skill definitions | Limited | In rules files |
+
+---
+
+## 6. Implementation Recommendations for luca-mastracode
+
+### Current State
+
+luca-mastracode's tools have functional descriptions (1-2 sentences) and well-designed action schemas with `createScopedTool` for per-mode permission narrowing. What is missing is behavioral guidance: when to use each tool, when NOT to, priority ordering vs alternatives, few-shot examples of correct invocation, and cross-tool coordination instructions.
+
+### Recommendation 1: Enrich Tool Descriptions with Behavioral Guidance
+
+For each of the 10 registered tools, expand the `description` field from a single sentence to a structured prompt following Claude Code's five-part anatomy: purpose, usage guidance, behavioral constraints, priority ordering, and examples. Prioritize the highest-traffic tools first:
+
+- **workflowState**: Add guidance on when to use `read` vs other state-reading approaches, when mode transitions are appropriate, and what state fields are available.
+- **manageTodos**: Add guidance on backlog scanning patterns, when to use `list` vs `read`, and how todo status flow works.
+- **runChecks**: Add guidance on which checks to run when, timeout expectations, and how to interpret convergence tracking output.
+
+### Recommendation 2: Add `input_examples` to Complex Tools
+
+Anthropic's API now supports a dedicated `input_examples` field on tool definitions (schema-validated, ~20-50 tokens per simple example). For tools with complex action patterns like `workflowState` (11 actions) and `manageTodos` (6 actions), add 2-3 concrete input examples demonstrating common invocation patterns.
+
+### Recommendation 3: Add Cross-Tool Coordination in Mode Instructions
+
+Mode instruction files should include a "Tool Usage" section with bidirectional constraints specific to that mode. For example, in the execute mode: "Use `workflowState` with action `record-iteration` to log each execution pass. Do NOT use `sessionLedger` for tracking execution progress -- that tool is for finalization summaries only."
+
+### Recommendation 4: Implement the Description-Enrichment Pattern Incrementally
+
+Rather than rewriting all 10 tool descriptions at once, implement enrichment incrementally:
+
+1. **Phase 1**: Enrich the 3 highest-traffic tools (workflowState, manageTodos, runChecks) with full behavioral guidance
+2. **Phase 2**: Add `input_examples` to all action-based tools
+3. **Phase 3**: Add cross-tool coordination to mode instruction files
+4. **Phase 4**: Measure tool selection accuracy before and after enrichment
+
+### Recommendation 5: Consider Progressive Tool Loading
+
+For modes with many tools (like `luca:6-finalize` with 6 tools), consider Gemini CLI's progressive loading pattern: inject only tool names and brief descriptions initially, loading full schemas on first use. This would require Mastra framework support but could reduce context pressure in tool-heavy modes.
+
+---
+
+## 7. Key Principles
+
+1. **Tool descriptions are prompts, not documentation.** They are serialized into the model's context and directly steer behavior. Write them as instructions, not reference material.
+
+2. **Negative examples are as important as positive ones.** "Do NOT use X for Y" eliminates ambiguity that "Use Z for Y" alone leaves open.
+
+3. **Fight the weights with repetition and emphasis.** When tool guidance contradicts trained model behavior (e.g., preferring Read over cat), reinforce at multiple layers and use strong language.
+
+4. **Cross-tool coordination requires explicit instruction.** Models cannot infer tool relationships from schemas alone. State dependencies, ordering, and mutual exclusions explicitly.
+
+5. **Tool descriptions serve dual audiences.** The invoking agent and any safety evaluator both need sufficient context to reason correctly.
+
+6. **Measure the investment.** Claude Code allocates ~79% of its prompt token budget to tool definitions. Under-investing in tool descriptions is the single largest gap in most custom agent harnesses.
+
+---
+
+## Sources
+
+### Anthropic Official
+
+- [Writing Effective Tools for AI Agents](https://www.anthropic.com/engineering/writing-tools-for-agents) -- Anthropic's canonical guide to tool description engineering, including naming, description structure, response design, and error handling
+- [Effective Context Engineering for AI Agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) -- Context engineering principles including tool design as a control surface
+- [Define Tools - Claude API Docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/define-tools) -- Official tool definition reference with `input_examples` specification and best practices
+- [Making Claude Code More Secure and Autonomous](https://www.anthropic.com/engineering/claude-code-sandboxing) -- Sandboxing architecture and permission reduction metrics
+
+### Claude Code Analysis
+
+- [How Claude Code Builds a System Prompt](https://www.dbreunig.com/2026/04/04/how-claude-code-builds-a-system-prompt.html) -- Drew Breunig's analysis of dynamic prompt assembly including tool definition composition
+- [Piebald-AI/claude-code-system-prompts](https://github.com/Piebald-AI/claude-code-system-prompts) -- Extracted system prompts, 24 builtin tool descriptions, and sub-agent prompts updated per Claude Code release (v2.1.104)
+- [Tools and System Prompt of Claude Code (Gist)](https://gist.github.com/wong2/e0f34aac66caf890a332f7b6f9e2ba8f) -- Complete tool descriptions and system prompt text extraction
+- [Claude Code Prompts | Anatomy of an AI Coding Agent](https://ccprompts.info/) -- Catalog of 124 prompts across 9 categories with token counts per tool
+- [Diving into Claude Code's Source Code Leak](https://read.engineerscodex.com/p/diving-into-claude-codes-source-code) -- Analysis of permission critic pattern, anti-distillation, and tool security architecture
+
+### Agent Building Patterns
+
+- [How to Build Your Agent: 11 Prompting Techniques](https://www.augmentcode.com/blog/how-to-build-your-agent-11-prompting-techniques-for-better-ai-agents) -- Augment Code's techniques including tool calling limitations, consistency across prompt components, and cache-aware structuring
+- [Prompts Are Infrastructure: Building Agents That Actually Listen](https://www.augmentcode.com/blog/prompts-are-infrastructure-building-agents-that-actually-listen) -- Four-layer prompting architecture (system prompts, tools, skills, user messages) and tool descriptions as hidden prompts
+- [AI Agent Prompt Engineering: 10 Patterns That Actually Work](https://paxrel.com/blog-ai-agent-prompts) -- Production patterns including progressive disclosure and guard rails
+
+### Fighting the Weights
+
+- [Don't Fight the Weights](https://www.dbreunig.com/2025/11/11/don-t-fight-the-weights.html) -- Drew Breunig on recognizing and mitigating conflicts between prompt instructions and model training data
+
+### Competing Agent Architectures
+
+- [Gemini CLI (GitHub)](https://github.com/google-gemini/gemini-cli) -- Open-source agent with progressive tool discovery and Agent Skills system
+- [Gemini CLI Tools Reference](https://geminicli.com/docs/reference/tools/) -- Tool definition structure and schema documentation
+- [Codex CLI Agent Approvals & Security](https://developers.openai.com/codex/agent-approvals-security) -- Sandbox-first security model and tool annotation system
+- [Codex CLI Sandboxing](https://developers.openai.com/codex/concepts/sandboxing) -- Docker-based isolation as alternative to behavioral safety guidance

--- a/docs/research/prompt-architecture/04-multi-agent-coordination.md
+++ b/docs/research/prompt-architecture/04-multi-agent-coordination.md
@@ -1,0 +1,331 @@
+# Multi-Agent Prompt Coordination in AI Coding Systems
+
+**Research Date:** 2026-04-13
+**Status:** Complete
+**Scope:** How coordinator agents manage workers, how verification agents maintain independence, and how sub-agent prompts are structured -- with implementation guidance for luca-mastracode
+
+---
+
+## Executive Summary
+
+Multi-agent coordination in AI coding systems has converged on a shared set of architectural patterns: coordinator-worker hierarchies, cache-efficient subagent spawning, and adversarial verification loops. Claude Code's leaked source (March 2026) provides the most detailed public record of these patterns, revealing that orchestration behavior is defined entirely in natural language prompts rather than branching code. This document catalogs the coordination patterns across Claude Code, Cursor, Codex, Devin, and academic research, then maps each to concrete recommendations for luca-mastracode's 9-subagent architecture.
+
+---
+
+## 1. Claude Code's Multi-Agent Architecture
+
+### 1.1 Coordinator Mode
+
+Claude Code's coordinator mode transforms a single agent into a lead that spawns, directs, and manages multiple worker agents in parallel. The orchestration is prompt-driven: `coordinatorMode.ts` implements multi-agent work as system prompt instructions, meaning behavior updates ship without code changes.
+
+The coordinator's system prompt contains two foundational quality gates:
+
+1. **"Do not rubber-stamp weak work."** -- Forces the coordinator to critically evaluate worker output rather than passively relaying it.
+2. **"Never write 'based on your findings' -- these phrases delegate understanding to workers instead of doing it yourself."** -- Prevents the coordinator from becoming a passive relay. It must synthesize and own the conclusions.
+
+The coordinator follows a four-phase workflow: **Research -> Synthesis -> Implementation -> Verification**. Workers operate in isolated contexts with restricted tool permissions and communicate via XML-structured task notifications. A shared scratchpad directory enables data exchange without polluting the coordinator's context.
+
+### 1.2 Worker Instructions
+
+Worker agents receive focused directives from the coordinator. The leaked `system-prompt-worker-instructions.md` reveals a five-step protocol:
+
+1. **Simplify** -- invoke the simplify skill to clean up changes
+2. **Run unit tests** -- execute the project's test suite
+3. **Test end-to-end** -- follow the coordinator's e2e recipe
+4. **Commit and push** -- create a PR with `gh pr create`
+5. **Report** -- end with `PR: <url>` or `PR: none -- <reason>`
+
+Workers compress their own results before returning them to the coordinator, preventing context bloat while maintaining information fidelity. This is a critical architectural insight: sub-agents handle their own summarization rather than dumping raw output upstream.
+
+### 1.3 Agent Teams (Teammate Model)
+
+Released February 2026, Agent Teams extend beyond single-session subagents to coordinate multiple independent Claude Code instances. One session acts as team lead; teammates work independently with their own context windows and communicate directly with each other via a `SendMessage` tool.
+
+Key architectural components:
+
+| Component     | Role                                                        |
+|:------------- |:----------------------------------------------------------- |
+| **Team lead** | Creates the team, spawns teammates, coordinates work        |
+| **Teammates** | Separate Claude instances with independent context windows  |
+| **Task list** | Shared work items with dependency tracking and file locking |
+| **Mailbox**   | Message delivery system with broadcast capability           |
+
+Teams use hooks for quality enforcement: `TeammateIdle` (runs when a teammate finishes), `TaskCreated`, and `TaskCompleted` can reject work with feedback, keeping teammates working until quality gates pass.
+
+---
+
+## 2. The Three Execution Models
+
+Claude Code offers three distinct models for spawning sub-work, each with different trade-offs:
+
+### 2.1 Fork
+
+A forked subagent inherits the parent context as a byte-identical copy. This is the cache-efficient model -- because the API request prefix is identical, all forked workers share the same KV cache entry (90% cache discount on shared context). The leaked fork usage guidelines reveal:
+
+- **"Don't peek"** -- never read a fork's output file mid-flight; wait for the completion notification
+- **"Don't race"** -- never fabricate or predict fork results; if asked before notification arrives, acknowledge the fork is still running
+- **Prompt focus** -- write directives about what to do, not background context (inherited automatically)
+- **Cache preservation** -- omit the `model` parameter to preserve prefix sharing
+
+Fork is ideal for open-ended research questions, parallel implementation work, and any task where intermediate tool output is not worth keeping in the parent's context. Claude Code's prompt reuse rate across forks is reported at 92%.
+
+### 2.2 Teammate
+
+Teammates are fully independent Claude Code sessions with their own context windows. Unlike forks, teammates can message each other directly without going through the lead. They share a task list with file-locking for safe concurrent claiming.
+
+Teammates are appropriate when workers need to share findings, challenge each other's conclusions, and self-coordinate. The cost is higher -- each teammate consumes tokens independently -- but the communication model enables patterns like adversarial debugging where teammates actively try to disprove each other's theories.
+
+### 2.3 Worktree
+
+Worktrees provide file-system isolation via `git worktree`. Each worker gets its own branch, files, and git index, eliminating merge conflicts entirely. This model is best for parallel implementation on the same codebase where workers would otherwise overwrite each other's changes.
+
+### Trade-off Summary
+
+| Dimension            | Fork              | Teammate           | Worktree           |
+|:-------------------- |:----------------- |:------------------- |:------------------ |
+| Context isolation    | Shared prefix     | Fully independent   | Fully independent  |
+| Communication        | Return to parent  | Direct messaging    | Return to parent   |
+| File-system conflict | Shared filesystem | Shared filesystem   | Isolated branches  |
+| Cache efficiency     | Highest (90% hit) | None (independent)  | None (independent) |
+| Token cost           | Lowest            | Highest             | Medium             |
+| Best for             | Research, search  | Debate, review      | Parallel impl.     |
+
+---
+
+## 3. Self-Distrust and Anti-Sycophancy Patterns
+
+### 3.1 The Verification Specialist
+
+Claude Code's `agent-prompt-verification-specialist.md` (2,938 tokens) defines an adversarial verification agent that tests implementations by running builds, test suites, linters, and adversarial probes, then issues a PASS/FAIL/PARTIAL verdict.
+
+The core principle is **structural self-distrust**: the system assumes that the agent that built something has blind spots about its own work. A fresh agent with the explicit directive "find problems with this" catches what the builder missed. Testing asks "does it work?" -- adversarial verification asks "how can I break it?"
+
+Key prompt patterns from the verification specialist:
+
+- **Mandatory evidence**: "A check without a Command run block is not a PASS." Verdicts without tool execution are labeled as guesses.
+- **Self-awareness of failure modes**: The prompt explicitly enumerates common LLM failure patterns -- reading code instead of running it, trusting self-reports, hedging instead of declaring failure.
+- **Independence requirement**: "When non-trivial implementation happens on your turn, independent adversarial verification must happen before you report completion." Non-trivial is defined as 3+ file edits, backend/API changes, or infrastructure changes.
+
+### 3.2 The Adversarial Review Pattern
+
+The `ng/adversarial-review` Claude Code plugin implements a dual-agent pattern:
+
+- **Optimizer**: Deploys Sonnet and Opus teammates to independently identify issues, then merges and deduplicates findings
+- **Skeptic**: Challenges the Optimizer's discoveries and catches overlooked problems using cross-model consensus
+
+The Skeptic requires mandatory evidence fields -- no evidence means the verdict is labeled as a guess. The system explicitly names rubber-stamping as a failure mode in the Skeptic prompt, requiring substantive objections backed by external validation rather than forced disagreement. Findings are capped at 50 words per Problem field and 30 words per suggested fix, enforcing precision.
+
+### 3.3 The "Skeptical Memory" Pattern
+
+Agents treat their own recollections as hints requiring verification against ground truth. Before acting on remembered information, the agent must check the actual codebase. This pattern extends to the coordinator: the directive "Never write 'based on your findings'" forces the coordinator to actively verify worker output rather than trusting it at face value.
+
+---
+
+## 4. Coordinator Prompt Design Principles
+
+Synthesizing across Claude Code's leaked source, community analysis, and production systems, five principles emerge for coordinator prompt design:
+
+### P1: Active Synthesis Over Passive Relay
+
+The coordinator must understand findings before directing follow-up work. Phrases like "based on your findings" or "as reported by the worker" are banned because they signal that the coordinator is delegating understanding rather than owning it.
+
+### P2: Parallelism as Default
+
+"Parallelism is your superpower. Workers are async. Launch independent workers concurrently whenever possible." The coordinator should bias toward parallel execution unless there are genuine sequential dependencies.
+
+### P3: Structured Communication
+
+Workers communicate via XML-structured task notifications. The coordinator uses structured output formats (not prose) for task assignment, status updates, and result collection. This reduces ambiguity and enables programmatic parsing.
+
+### P4: Worker Self-Compression
+
+Sub-agents compress their own work before returning results. The coordinator never receives raw tool output from workers. This prevents context bloat and forces workers to distill findings into actionable summaries.
+
+### P5: Quality Gates, Not Trust
+
+The coordinator maintains explicit quality gates rather than trusting worker output. Every major deliverable passes through adversarial verification. The coordinator's prompt includes specific criteria for when to reject work and request revision.
+
+---
+
+## 5. Comparison Across Multi-Agent Coding Systems
+
+### 5.1 Cursor (FastRender Architecture)
+
+Cursor's January 2026 demonstration built a browser in a week using hierarchical agent orchestration with three roles:
+
+- **Planners**: Continuously explore the codebase and create tasks
+- **Workers**: Execute assigned tasks without coordinating with each other; push changes when done
+- **Judges**: Determine whether to continue at each cycle end
+
+This is a simpler coordination model than Claude Code's -- no inter-worker communication, no adversarial verification. Quality comes from the Judge role, which evaluates worker output without being influenced by the implementation process.
+
+### 5.2 OpenAI Codex
+
+Codex runs on specialized GPT-5 family models optimized for software engineering. Its multi-agent capability shipped February 2026 alongside every other major tool. The architecture spans cloud agents, terminal CLI, IDE extensions, and desktop apps. Codex emphasizes context engineering over prompt engineering -- ensuring models see the right information at the right time.
+
+### 5.3 Devin
+
+Devin aims to function as a full software engineer rather than an assistant. Teams run multiple Devins simultaneously on different tasks. The coordination model is task-based (assign a Devin to a ticket) rather than role-based (no internal sub-specialization visible to users).
+
+### 5.4 Convergence Pattern
+
+All major systems converged on multi-agent shipping in the same two-week window of February 2026: Grok Build (8 agents), Windsurf (5 parallel agents), Claude Code Agent Teams, Codex CLI, Devin parallel sessions. The shared pattern is coordinator-worker with isolated context windows, but they diverge on inter-worker communication, quality gates, and cost optimization.
+
+---
+
+## 6. Academic Research on Multi-Agent LLM Coordination
+
+### 6.1 Multi-Agent Debate (MAD)
+
+The seminal paper "Improving Factuality and Reasoning in Language Models through Multiagent Debate" (Du et al., ICML 2024) demonstrated that multiple LLM agents proposing answers and critiquing each other's reasoning significantly improves mathematical reasoning and reduces factual hallucinations. Adaptive Heterogeneous Multi-Agent Debate (A-HMAD) achieves 4-6% absolute accuracy gains over standard debate and reduces factual errors by over 30%.
+
+However, the ICLR 2025 study "Multi-LLM-Agents Debate: Performance, Efficiency, and Scaling Challenges" found that current MAD methods fail to consistently outperform simpler single-agent strategies even with increased computational resources. A NeurIPS 2025 study further found that Majority Voting alone accounts for most performance gains typically attributed to debate.
+
+### 6.2 Heterogeneous Agent Benefits
+
+Research on agent diversity shows that heterogeneous agents with differing model architectures, training data, and inductive biases explore a broader solution space and mitigate shared failure modes. This directly supports luca-mastracode's model routing table, which assigns different model tiers (fast/balanced/capable) to different subagents.
+
+### 6.3 Role Specialization
+
+The PRISM framework (2026) found that expert personas improve LLM alignment but can damage accuracy -- a warning against uncritical persona adoption. The effective pattern is constrained specialization: define the domain, enforce boundaries, but don't embellish with personality traits that distort reasoning. Studies on 162 roles found no reliable benefit from generic persona assignment; benefits appear only when roles are tightly coupled to the task domain.
+
+### 6.4 Anti-Sycophancy Research
+
+Personality traits like sycophancy are encoded in LLM activations as SAE features. They can be amplified or suppressed through prompt design. Structural approaches (adversarial roles, mandatory evidence requirements) are more reliable than instructional approaches ("be honest") for reducing sycophantic behavior.
+
+---
+
+## 7. Implementation Recommendations for luca-mastracode
+
+### 7.1 Add Self-Distrust to the Verifier
+
+The current `verifierSubagent` performs goal-backward verification but lacks explicit self-distrust patterns. Add to its instructions:
+
+```
+## Independence Mandate
+The implementer is an LLM. Do not trust that the code is correct.
+Verify independently by running checks, not by reading code and reasoning
+about correctness. A check without a tool execution is not a PASS.
+
+Common failure modes to resist:
+- Reading code and concluding it "looks correct" without running it
+- Trusting the executor's commit message about what changed
+- Hedging ("this appears to work") instead of declaring PASS or FAIL
+- Reducing severity of real issues to avoid blocking
+```
+
+**Priority: HIGH. Effort: 1-2 hours.**
+
+### 7.2 Add Anti-Sycophancy to the Reviewer
+
+The current `reviewerSubagent` has severity classification but no explicit anti-sycophancy. Add:
+
+```
+## Quality Gate
+Do not rubber-stamp weak work. Every APPROVE verdict must be earned
+through evidence, not granted by default. If you find zero MUST-FIX
+issues, explicitly state what you verified and how, not just that
+"everything looks good."
+```
+
+**Priority: HIGH. Effort: 1 hour.**
+
+### 7.3 Implement Worker Self-Compression
+
+Following Claude Code's pattern, subagents should compress their own output before returning to the orchestrator. The current architecture returns full structured output; add a compression directive:
+
+```
+## Output Compression
+Before returning results, compress your findings to essential information only.
+Strip intermediate reasoning, tool output, and exploration paths.
+The orchestrator reads your structured result, not your process.
+```
+
+**Priority: MEDIUM. Effort: 2-3 hours across all subagents.**
+
+### 7.4 Add Coordinator Synthesis Directives
+
+In the orchestrator modes (build, execute), add directives that prevent passive relay:
+
+```
+## Synthesis Requirement
+When sub-agents return results, YOU must synthesize them.
+Never write "based on the reviewer's findings" or "as the verifier reported."
+Understand the findings yourself, resolve conflicts between sub-agents,
+and present a unified assessment.
+```
+
+**Priority: MEDIUM. Effort: 2 hours.**
+
+### 7.5 Introduce Adversarial Verification for COMPLEX+
+
+For COMPLEX and CRITICAL complexity levels, spawn a second verification pass with an explicitly adversarial mandate. This maps to the debate pattern opportunity already identified in the project's memory (phase-execute code review, rated 5/5).
+
+**Priority: MEDIUM. Effort: 4-6 hours.**
+
+### 7.6 Explore Fork-Style Cache Efficiency
+
+luca-mastracode's subagents currently run with fully independent contexts. If Mastra's API layer supports Anthropic's prompt caching, restructure subagent spawning so that all subagents in a wave share a common instruction prefix (mode instructions + hard constraints + always-apply rules), diverging only at the task-specific directive. This could reduce token costs by up to 90% for the shared prefix.
+
+**Priority: MEDIUM. Effort: Depends on Mastra support.**
+
+### 7.7 Heterogeneous Model Assignment
+
+The current model routing table already assigns different tiers per complexity level. Extend this to exploit the academic finding on heterogeneous agents: for the parallel reviewer subagents (code-architect, dx-advocate, security-auditor, code-simplifier), consider routing to different model families when available, not just different tiers. Different models have distinct blind spots; diversity in the reviewer pool improves coverage.
+
+**Priority: LOW. Effort: 2-3 hours.**
+
+### 7.8 Structured Inter-Subagent Communication
+
+The current architecture has subagents report back to the orchestrator only. For COMPLEX+ work, consider adding a lightweight messaging mechanism (shared JSON file in `.planning/`) so that the verifier can read reviewer findings and vice versa, without routing through the orchestrator. This mirrors Claude Code's teammate model without the full overhead.
+
+**Priority: LOW. Effort: 6-8 hours.**
+
+---
+
+## 8. Sources
+
+### Official Documentation
+
+- [Create custom subagents -- Claude Code Docs](https://code.claude.com/docs/en/sub-agents) -- Subagent architecture, built-in agents, configuration
+- [Orchestrate teams of Claude Code sessions -- Claude Code Docs](https://code.claude.com/docs/en/agent-teams) -- Agent Teams architecture, teammate model, task coordination
+- [Plan in the cloud with ultraplan -- Claude Code Docs](https://code.claude.com/docs/en/ultraplan) -- Remote planning with cloud Opus sessions
+
+### Source Leak Analysis
+
+- [Claude Code Source Leak: What's Worth Learning for AI Agents](https://thoughts.jock.pl/p/claude-code-source-leak-what-to-learn-ai-agents-2026) -- Coordinator patterns, adversarial verification, skeptical memory
+- [Claude Code architecture Deep Dive: What the Leaked Source Reveals](https://wavespeed.ai/blog/posts/claude-code-architecture-leaked-source-deep-dive/) -- Mailbox system, atomic claim mechanism, coordinator prompt
+- [Production AI Agent Architecture: Lessons from Claude Code](https://artinoid.com/blog/production-ai-agent-architecture-claude-code-lessons) -- Coordinator directive text, sub-agent compression, model routing
+- [Diving into Claude Code's Source Code Leak](https://read.engineerscodex.com/p/diving-into-claude-codes-source-code) -- Cache boundaries, anti-distillation, compaction
+- [Claude Code Leaked Source: BUDDY, KAIROS & Every Hidden Feature](https://wavespeed.ai/blog/posts/claude-code-leaked-source-hidden-features/) -- Feature flags, hidden capabilities
+- [Claude Code's Hidden Multi-Agent System](https://paddo.dev/blog/claude-code-hidden-swarm/) -- TeammateTool operations, role taxonomy, early access analysis
+
+### Prompt Engineering & System Prompts
+
+- [Piebald-AI/claude-code-system-prompts](https://github.com/Piebald-AI/claude-code-system-prompts) -- Extracted system prompts updated per Claude Code version (280 files)
+- [repowise-dev/claude-code-prompts](https://github.com/repowise-dev/claude-code-prompts) -- Community-authored prompt templates informed by Claude Code study
+- [ng/adversarial-review](https://github.com/ng/adversarial-review) -- Optimizer/Skeptic dual-agent code review plugin
+- [How Claude Code Builds a System Prompt](https://www.dbreunig.com/2026/04/04/how-claude-code-builds-a-system-prompt.html) -- 30+ component dynamic assembly analysis
+- [How Prompt Caching Actually Works in Claude Code](https://www.claudecodecamp.com/p/how-prompt-caching-actually-works-in-claude-code) -- Cache sharing across forks, 92% reuse rate
+
+### Multi-Agent Coordination Guides
+
+- [Shipyard: Multi-agent orchestration for Claude Code](https://shipyard.build/blog/claude-code-multi-agent/) -- Practical orchestration patterns
+- [Claude Code Agent Teams: Setup & Usage Guide](https://claudefa.st/blog/guide/agents/agent-teams) -- Configuration and deployment guide
+- [AI Coding Agents in 2026: Coherence Through Orchestration](https://mikemason.ca/writing/ai-coding-agents-jan-2026/) -- Context engineering as the critical discipline
+- [The State of AI Coding Agents (2026)](https://medium.com/@dave-patten/the-state-of-ai-coding-agents-2026-from-pair-programming-to-autonomous-ai-teams-b11f2b39232a) -- February 2026 multi-agent convergence across vendors
+
+### Academic Research
+
+- [Improving Factuality and Reasoning through Multiagent Debate](https://arxiv.org/abs/2305.14325) (Du et al., ICML 2024) -- Foundational MAD paper
+- [Multi-LLM-Agents Debate: Performance, Efficiency, and Scaling Challenges](https://d2jud02ci9yv69.cloudfront.net/2025-04-28-mad-159/blog/mad/) (ICLR 2025) -- MAD limitations analysis
+- [Debate or Vote: Which Yields Better Decisions in Multi-Agent LLMs?](https://openreview.net/forum?id=iUjGNJzrF1) (NeurIPS 2025) -- Majority voting vs debate
+- [Adaptive Heterogeneous Multi-Agent Debate](https://link.springer.com/article/10.1007/s44443-025-00353-3) (2025) -- A-HMAD with 4-6% accuracy gains
+- [Expert Personas Improve LLM Alignment but Damage Accuracy: PRISM](https://arxiv.org/html/2603.18507v1) (2026) -- Persona effectiveness warning
+- [Courtroom-Style Multi-Agent Debate with Progressive RAG](https://arxiv.org/html/2603.28488v1) (2026) -- Structured deliberation for claim verification
+
+### Role Specialization
+
+- [Agentic Engineering Part 3: Role-Based Agent Personas](https://www.sagarmandal.com/2026/03/15/agentic-engineering-part-3-role-based-agent-personas-why-specialization-beats-generalization/) -- 10-persona coherence cascade, evidence for specialization
+- [How To Define an AI Agent Persona](https://thenewstack.io/how-to-define-an-ai-agent-persona-by-tweaking-llm-prompts/) -- Practical persona design framework
+- [The Persona Pattern: Unlocking Modular Intelligence](https://towardsai.net/p/artificial-intelligence/the-persona-pattern-unlocking-modular-intelligence-in-ai-agents) -- Pattern language for agent personas

--- a/docs/research/prompt-architecture/04-multi-agent-coordination.md
+++ b/docs/research/prompt-architecture/04-multi-agent-coordination.md
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-Multi-agent coordination in AI coding systems has converged on a shared set of architectural patterns: coordinator-worker hierarchies, cache-efficient subagent spawning, and adversarial verification loops. Claude Code's leaked source (March 2026) provides the most detailed public record of these patterns, revealing that orchestration behavior is defined entirely in natural language prompts rather than branching code. This document catalogs the coordination patterns across Claude Code, Cursor, Codex, Devin, and academic research, then maps each to concrete recommendations for luca-mastracode's 9-subagent architecture.
+Multi-agent coordination in AI coding systems has converged on a shared set of architectural patterns: coordinator-worker hierarchies, cache-efficient subagent spawning, and adversarial verification loops. Claude Code's public source analysis (March 2026) provides the most detailed public record of these patterns, revealing that orchestration behavior is defined entirely in natural language prompts rather than branching code. This document catalogs the coordination patterns across Claude Code, Cursor, Codex, Devin, and academic research, then maps each to concrete recommendations for luca-mastracode's 9-subagent architecture.
 
 ---
 
@@ -27,7 +27,7 @@ The coordinator follows a four-phase workflow: **Research -> Synthesis -> Implem
 
 ### 1.2 Worker Instructions
 
-Worker agents receive focused directives from the coordinator. The leaked `system-prompt-worker-instructions.md` reveals a five-step protocol:
+Worker agents receive focused directives from the coordinator. The `system-prompt-worker-instructions.md` reveals a five-step protocol:
 
 1. **Simplify** -- invoke the simplify skill to clean up changes
 2. **Run unit tests** -- execute the project's test suite
@@ -60,7 +60,7 @@ Claude Code offers three distinct models for spawning sub-work, each with differ
 
 ### 2.1 Fork
 
-A forked subagent inherits the parent context as a byte-identical copy. This is the cache-efficient model -- because the API request prefix is identical, all forked workers share the same KV cache entry (90% cache discount on shared context). The leaked fork usage guidelines reveal:
+A forked subagent inherits the parent context as a byte-identical copy. This is the cache-efficient model -- because the API request prefix is identical, all forked workers share the same KV cache entry (90% cache discount on shared context). The fork usage guidelines reveal:
 
 - **"Don't peek"** -- never read a fork's output file mid-flight; wait for the completion notification
 - **"Don't race"** -- never fabricate or predict fork results; if asked before notification arrives, acknowledge the fork is still running
@@ -123,7 +123,7 @@ Agents treat their own recollections as hints requiring verification against gro
 
 ## 4. Coordinator Prompt Design Principles
 
-Synthesizing across Claude Code's leaked source, community analysis, and production systems, five principles emerge for coordinator prompt design:
+Synthesizing across Claude Code's public architecture, community analysis, and production systems, five principles emerge for coordinator prompt design:
 
 ### P1: Active Synthesis Over Passive Relay
 

--- a/docs/research/prompt-architecture/05-attention-curves-and-structure.md
+++ b/docs/research/prompt-architecture/05-attention-curves-and-structure.md
@@ -73,7 +73,7 @@ Research shows the balance between primacy and recency varies by model:
 
 ### Structural Layout
 
-Reverse-engineering of Claude Code's system prompt (via the March 2026 source leak and community analysis) reveals deliberate positional exploitation:
+Reverse-engineering of Claude Code's system prompt (via public source analysis and community research) reveals deliberate positional exploitation:
 
 ```
 [START - PEAK PRIMACY]
@@ -361,7 +361,7 @@ For agent system prompts specifically, few-shot examples are most valuable for:
 - [The Complete Guide to Writing Agent System Prompts](https://medium.com/@fengliu_367/the-complete-guide-to-writing-agent-system-prompts-lessons-from-reverse-engineering-claude-code-09ecd87c7cc1) -- Feng Liu
 - [Claude Code Prompts | Anatomy of an AI Coding Agent](https://ccprompts.info/) -- Community catalog
 - [Piebald-AI/claude-code-system-prompts](https://github.com/Piebald-AI/claude-code-system-prompts) -- Extracted system prompts
-- [Diving into Claude Code's Source Code Leak](https://read.engineerscodex.com/p/diving-into-claude-codes-source-code) -- Engineer's Codex
+- [Diving into Claude Code's Source Code](https://read.engineerscodex.com/p/diving-into-claude-codes-source-code) -- Engineer's Codex
 - [Claude Code Feels Dumber? The System Prompt Architecture Trap](https://support.tools/claude-code-system-prompt-behavior-claude-md-optimization-guide/) -- Support Tools
 - [The Impact of Prompt Bloat on LLM Output Quality](https://mlops.community/the-impact-of-prompt-bloat-on-llm-output-quality/) -- MLOps Community
 - [Disadvantage of Long Prompt for LLM](https://blog.promptlayer.com/disadvantage-of-long-prompt-for-llm/) -- PromptLayer

--- a/docs/research/prompt-architecture/05-attention-curves-and-structure.md
+++ b/docs/research/prompt-architecture/05-attention-curves-and-structure.md
@@ -1,0 +1,369 @@
+# Attention Curves, Positional Bias, and Prompt Structure Optimization
+
+**Research Date:** 2026-04-13
+**Status:** Complete
+**Scope:** How positional attention, formatting strategies, and structural ordering affect LLM instruction adherence, with implementation guidance for luca-mastracode
+
+---
+
+## Executive Summary
+
+Transformer-based language models do not attend uniformly to their input. Research consistently demonstrates a **U-shaped attention distribution** -- peak focus at the beginning (primacy) and end (recency) of a prompt, with measurable degradation in the middle. This is not a bug but an artifact of causal masking and training data distributions. Claude Code exploits this pattern deliberately, placing identity and safety constraints at the start and repeating critical rules at the end. This document synthesizes the academic literature, reverse-engineered production practices, and formatting research into concrete structural recommendations for luca-mastracode's prompt architecture.
+
+---
+
+## 1. The "Lost in the Middle" Phenomenon
+
+### The Foundational Paper
+
+Liu et al. (2023) published the seminal study "Lost in the Middle: How Language Models Use Long Contexts," evaluating model performance on multi-document question answering and key-value retrieval as a function of where relevant information appeared in the input. The central finding: **performance is highest when relevant information occurs at the beginning or end of the input context, and significantly degrades when models must access information in the middle** -- even for models explicitly trained on long contexts.
+
+The paper tested models across varying context lengths (4 to 2048 documents). The degradation was not subtle. In some configurations, middle-positioned relevant information caused performance to drop below a **closed-book baseline** -- meaning the long context actively hurt the model compared to having no context at all.
+
+**Citation:** Liu, N.F., Lin, K., Hewitt, J., Paranjape, A., Bevilacqua, M., Petroni, F., & Liang, P. (2024). Lost in the Middle: How Language Models Use Long Contexts. *Transactions of the Association for Computational Linguistics*, 12. [arXiv:2307.03172](https://arxiv.org/abs/2307.03172)
+
+### Follow-Up: Found in the Middle
+
+Hsieh et al. (2024) established the direct connection between the lost-in-the-middle phenomenon and intrinsic attention bias. Their calibration mechanism -- adjusting attention weights to compensate for positional bias -- improved retrieval-augmented generation performance by up to **15 percentage points** across tasks. This confirmed the problem is architectural, not prompt-engineering failure: the U-shaped attention distribution is baked into transformer attention patterns.
+
+**Citation:** Hsieh, C.-Y., et al. (2024). Found in the Middle: Calibrating Positional Attention Bias Improves Long Context Utilization. *Findings of ACL 2024*. [arXiv:2406.16008](https://arxiv.org/abs/2406.16008)
+
+---
+
+## 2. The U-Shaped Attention Curve
+
+### Primacy and Recency in LLMs
+
+The U-shaped attention curve mirrors a well-studied phenomenon in human cognitive science -- the serial position effect -- but arises from different mechanisms in transformers. Luo et al. (2024) conducted a systematic study of serial position effects across encoder-decoder and decoder-only architectures. Key findings:
+
+- **Primacy effects dominated**, appearing in 73 of 104 test instances across models and tasks
+- **Recency effects** were more pronounced in summarization tasks but generally weaker than primacy
+- As input length increases, attention concentrates toward the beginning, suggesting that **prompt length amplifies the primacy bias**
+- GPT-4 showed variable behavior -- no serial position effects in label shuffling but significant effects in summarization
+- Chain-of-thought prompting provided moderate mitigation but did not eliminate the effects
+
+**Citation:** Luo, Z., et al. (2024). Serial Position Effects of Large Language Models. [arXiv:2406.15981](https://arxiv.org/html/2406.15981v1)
+
+### Mechanistic Explanation
+
+Janik (2023) drew parallels between LLM behavior and human memory research, arguing the U-shape arises from the interaction between two forces:
+
+1. **Primacy from causal masking**: In autoregressive models, early tokens are attended to by all subsequent tokens. The first tokens accumulate the most aggregate attention across layers simply by virtue of being visible to every position.
+2. **Recency from working memory analogy**: Recent tokens are in the model's "short-term" processing buffer -- the final layers process them with the freshest activation states.
+
+Training data composition also matters. Models trained on tasks emphasizing end-of-sequence retrieval (running-span tasks) develop recency bias; those trained on uniform retrieval develop primacy bias. Joint training on both produces the canonical U-shape.
+
+**Citation:** Janik, R.A. (2023). Aspects of Human Memory and Large Language Models. [arXiv:2311.03839](https://arxiv.org/html/2311.03839v3)
+
+### Model-Specific Biases
+
+Research shows the balance between primacy and recency varies by model:
+
+| Model | Dominant Bias | Notes |
+|-------|--------------|-------|
+| GPT-3.5 / GPT-4 | Primacy dominant | Both effects present, primacy stronger |
+| GPT-J | Recency dominant | Unusual recency-first pattern |
+| Claude family | Balanced U-shape | Strong primacy + strong recency |
+| T5 / Flan-T5 | Primacy dominant | Consistent across datasets |
+| Llama 2 | Variable | Exhibits "middle effect" on some tasks |
+
+---
+
+## 3. Claude Code's Attention Curve Exploitation
+
+### Structural Layout
+
+Reverse-engineering of Claude Code's system prompt (via the March 2026 source leak and community analysis) reveals deliberate positional exploitation:
+
+```
+[START - PEAK PRIMACY]
+  Identity (1-3 sentences: "You are Claude, made by Anthropic")
+  Security / Safety constraints (NEVER rules)
+  Permission framework (reversibility/blast radius)
+
+[UPPER-MIDDLE - DECLINING ATTENTION]
+  Coding philosophy and behavioral principles
+  Tone and style directives
+  Tool usage policy and priority ordering
+
+[LOWER-MIDDLE - ATTENTION TROUGH]
+  Tool definitions (~73k characters across 36+ tools)
+  Domain knowledge (loaded on demand)
+
+[END - PEAK RECENCY]
+  Environment context (cwd, platform, date, model)
+  CLAUDE.md / project rules
+  system-reminder tags re-injecting critical constraints
+```
+
+This layout is not accidental. The identity anchoring at the start exploits primacy bias to establish behavioral grounding that persists throughout the conversation. The `<system-reminder>` mechanism at the end exploits recency bias -- re-asserting critical rules at the point closest to the model's next generation step.
+
+### The system-reminder Mid-Conversation Pattern
+
+Claude Code combats context rot (instruction adherence degrading after ~80K tokens) by injecting `<system-reminder>` tags into the message stream. These appear inside tool results and user messages, re-stating behavioral rules that have drifted out of the attention window. Critically, these go in the **message layer**, not the system prompt, to preserve prompt cache validity.
+
+This is attention curve exploitation applied longitudinally: as the conversation grows, the model's "beginning" (system prompt) becomes proportionally more distant. system-reminders create synthetic recency anchors for critical constraints.
+
+### Negative Constraint Framing
+
+Claude Code's constraints are predominantly negative ("NEVER do X") rather than positive ("always do Y"). Analysis from Feng Liu's reverse-engineering study notes that negative constraints are **stronger than positive instructions** because they target specific observed failure modes. General positive instructions are ambiguous; specific negative instructions are actionable. This aligns with attention research: the model processes a tightly scoped prohibition more reliably than a broad aspiration, especially in the attention trough.
+
+**Sources:** [How Claude Code Builds a System Prompt](https://www.dbreunig.com/2026/04/04/how-claude-code-builds-a-system-prompt.html); [The Complete Guide to Writing Agent System Prompts](https://medium.com/@fengliu_367/the-complete-guide-to-writing-agent-system-prompts-lessons-from-reverse-engineering-claude-code-09ecd87c7cc1); [Claude Code Prompts | ccprompts.info](https://ccprompts.info/)
+
+---
+
+## 4. Formatting Strategies Ranked by Effectiveness
+
+### The Formatting Impact Hierarchy
+
+Research on prompt formatting impact (Gao et al., 2024) tested multiple formats across GPT-3.5-turbo and GPT-4 models. The findings establish a clear hierarchy:
+
+**Tier 1 -- Structural format (highest impact):** Changing the overall format (Markdown, JSON, YAML, plain text) produced performance variations of up to **40% on GPT-3.5-turbo** and up to 200% on specific code translation tasks. Larger models (GPT-4) are more robust to format changes but still show measurable differences.
+
+**Tier 2 -- Structural elements (high impact):** Headings, lists, tables, and code blocks produced double-digit percentage point improvements on complex tasks by guiding the model through logical structure.
+
+**Tier 3 -- Emphasis markers (low impact):** Bold, italics, UPPERCASE, and markers like "CRITICAL:" or "IMPORTANT:" had subtle and inconsistent effects. Models do not reliably interpret typographic emphasis as semantic priority.
+
+**Citation:** Gao, Y., et al. (2024). Does Prompt Formatting Have Any Impact on LLM Performance? [arXiv:2411.10541](https://arxiv.org/html/2411.10541v1)
+
+### Format-Specific Findings
+
+| Format | Best For | Evidence |
+|--------|----------|----------|
+| **XML tags** | Section boundaries, data/instruction separation, Claude models | Anthropic's official recommendation; reduces misinterpretation in mixed-content prompts |
+| **Markdown headers** | Hierarchical structure, human readability | GPT-4 shows preference; widely effective for section navigation |
+| **Bullet lists** | Independent, testable rules | More parseable than prose; each bullet is a discrete constraint |
+| **Tables** | Comparative information, decision matrices | Strong for lookup-style reference within prompts |
+| **JSON/YAML** | Structured data, schema definitions | JSON showed 42% accuracy improvement over Markdown on MMLU for GPT-3.5 |
+| **Plain text prose** | Simple instructions | Worst performer on most code generation tasks |
+
+### Anthropic's Official Recommendations
+
+Anthropic's prompt engineering documentation explicitly recommends XML tags for Claude models:
+
+> "XML tags help Claude parse complex prompts unambiguously, especially when your prompt mixes instructions, context, examples, and variable inputs."
+
+Key guidance from the official docs:
+- Use consistent, descriptive tag names (e.g., `<instructions>`, `<context>`, `<example>`)
+- Nest tags for natural hierarchies
+- **Place longform data at the top**, queries at the bottom -- queries at the end improve response quality by up to **30%** on complex multi-document inputs
+- Wrap examples in `<example>` tags; include 3-5 examples for best results
+- There are no canonical "best" XML tags -- use names that match the content they surround
+
+**Source:** [Anthropic Prompting Best Practices](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices); [Use XML tags to structure your prompts](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/use-xml-tags)
+
+### The UPPERCASE / "CRITICAL:" Question
+
+Despite widespread use in production prompts (including Claude Code itself), the evidence for typographic emphasis markers is weak:
+
+- Research shows models do not consistently interpret bold, italics, or UPPERCASE as increased priority
+- Too much emphasis (excessive bolding, caps, nested markers) **dilutes** the impact of genuinely critical instructions
+- Structural hierarchy (headers, XML tags) is a more reliable attention signal than inline emphasis
+- Claude Code's own source reveals a shift in guidance for Claude 4.6: "Where you might have said 'CRITICAL: You MUST use this tool when...', you can use more normal prompting like 'Use this tool when...'" -- suggesting the newer, more capable model responds less to shouting and more to clear structure
+
+---
+
+## 5. Optimal Prompt Section Ordering
+
+### The Recommended Architecture
+
+Synthesizing the academic research and reverse-engineered production patterns, the optimal ordering for an agent system prompt is:
+
+```
+1. IDENTITY (1-3 sentences)                    [Primacy peak]
+   - Role, creator, core purpose
+   - Strongest behavioral anchor
+
+2. SAFETY / HARD CONSTRAINTS                    [Primacy zone]
+   - NEVER rules, security boundaries
+   - Permission framework (reversibility)
+
+3. TONE AND STYLE                               [Upper-middle]
+   - Output format, verbosity constraints
+   - Quantified limits (word counts)
+
+4. CORE WORKFLOW / METHODOLOGY                  [Middle]
+   - Behavioral principles (not procedures)
+   - Decision-making framework
+   - Use heavy structural formatting here
+
+5. TOOL USAGE POLICY                            [Middle]
+   - Priority ordering
+   - Bidirectional constraints (use X, NOT Y)
+   - Tool-specific behavioral descriptions
+
+6. DOMAIN KNOWLEDGE / CONTEXT                   [Lower-middle]
+   - Dynamically loaded, not pre-stuffed
+   - Structured with XML tags for parseability
+
+7. ENVIRONMENT INFO                             [Approaching end]
+   - Runtime context (cwd, platform, date)
+   - Session state, git status
+
+8. REPEATED CRITICAL RULES                      [Recency peak]
+   - 2-3 most important constraints restated
+   - Safety rules echoed from section 2
+```
+
+### Why This Order Works
+
+- **Sections 1-2** exploit primacy bias for identity anchoring and safety grounding
+- **Sections 3-5** occupy the attention trough but use heavy structural formatting (headers, bullets, XML tags, tables) to compensate for reduced attention
+- **Sections 6-7** place variable/dynamic content near the end where it benefits from recency and avoids polluting the cached static prefix
+- **Section 8** exploits recency bias to reinforce the constraints most likely to drift during long conversations
+
+---
+
+## 6. When Repetition Helps vs. Wastes Tokens
+
+### The Prompt Repetition Research
+
+Leviathan et al. (2025) from Google Research conducted a systematic study of prompt repetition across seven models (Gemini, GPT, Claude, DeepSeek). Key findings:
+
+- Repeating the input prompt won **47 out of 70 benchmark-model tests with 0 losses** when reasoning was disabled
+- Benefits were significant for non-reasoning tasks (classification, retrieval, QA)
+- When reasoning was enabled, the effect was mostly neutral to slightly positive
+- A padding control (adding filler characters to match length) did **not** produce the same gains, confirming the benefit comes from repetition itself, not merely longer input
+
+**Citation:** Leviathan, Y., et al. (2025). Prompt Repetition Improves Non-Reasoning LLMs. [arXiv:2512.14982](https://arxiv.org/abs/2512.14982)
+
+### When Repetition Helps
+
+- **Safety constraints**: Repeating the 2-3 most critical rules at the end of the system prompt reinforces them through recency bias. This is Claude Code's pattern.
+- **Long conversations**: As context grows, early instructions become proportionally more distant. Mid-conversation re-injection (system-reminders) is a form of targeted repetition that combats context rot.
+- **Non-reasoning tasks**: Classification, retrieval, and structured output tasks benefit most from repetition.
+
+### When Repetition Wastes Tokens
+
+- **Short prompts**: If the entire prompt fits in the primacy+recency attention window, repetition adds cost without benefit.
+- **Reasoning-heavy tasks**: Models using chain-of-thought or extended thinking already attend to instructions more carefully; repetition yields diminishing returns.
+- **Bulk repetition**: Repeating entire prompt sections (instead of targeted 2-3 critical rules) dilutes the signal-to-noise ratio and accelerates context window consumption.
+
+### The Prompt Length Penalty
+
+Research consistently shows diminishing returns with prompt length:
+- Comprehension drops ~12% for every 100 words beyond 500 words
+- Beyond ~3,000 tokens, reasoning performance begins degrading
+- A well-structured 16K-token prompt with RAG outperformed a monolithic 128K-token prompt in both accuracy and relevance
+- Hallucination rates increase with prompt length
+
+**Implication:** Repetition should be surgical -- repeat only the highest-priority constraints, and only at structural boundaries (start and end of system prompt, periodic mid-conversation reminders). Do not repeat middle-tier instructions.
+
+---
+
+## 7. "Fighting the Weights"
+
+### The Concept
+
+Breunig (2025) coined the term "fighting the weights" to describe when prompt instructions contradict patterns deeply embedded in model training data. This is worse than the model lacking knowledge of a pattern because **what it knows is actively at odds with your goal**.
+
+### Manifestations
+
+| Scenario | What Happens | Why |
+|----------|-------------|-----|
+| **Format conflicts** | Model wraps JSON in explanatory text and markdown code blocks | Post-training teaches conversational responses |
+| **Tool format mismatches** | Model fails to call tools correctly | RL-trained tool-calling format differs from your harness |
+| **Tone resistance** | Model reverts to default tone despite instructions | RLHF politeness patterns override prompt directives |
+| **Alignment overrides** | Model refuses legitimate tasks | Safety training triggers on superficial pattern matches |
+
+### Recognition Signals
+
+You are likely fighting the weights if:
+- The model repeats the same errors despite instruction changes
+- Few-shot examples appear to be ignored
+- Tasks progress 90% then stall at the same point
+- You resort to repetition, ALL CAPS, or pleading
+
+### Mitigation Strategies
+
+1. **Task decomposition**: Break the conflicting task into sub-steps that individually align with training
+2. **Model switching**: Use a model whose training aligns with your requirements
+3. **Longer context with examples**: Sufficient few-shot examples can "overwhelm the weights" for that session
+4. **Structured output forcing**: Use tool calling or structured output schemas to bypass format resistance
+5. **Accept the grain**: Work with the model's natural tendencies rather than against them
+
+**Source:** [Don't Fight the Weights](https://www.dbreunig.com/2025/11/11/don-t-fight-the-weights.html) -- Drew Breunig
+
+---
+
+## 8. Few-Shot Examples vs. Instructions
+
+Research consistently shows that **few-shot examples and instructions are complementary, not interchangeable**:
+
+- Few-shot prompting outperforms zero-shot (instruction-only) for most tasks, especially complex ones
+- Instructions alone are ambiguous; examples provide concrete grounding for what "correct" looks like
+- Diminishing returns set in after 2-3 examples for most tasks
+- Beyond ~20 examples, models struggle with long-context comprehension, producing single-class or random outputs
+- The optimal approach: **explicit instructions supplemented by 3-5 carefully chosen examples**, wrapped in `<example>` tags
+
+For agent system prompts specifically, few-shot examples are most valuable for:
+- Tool invocation patterns (showing correct tool call formatting)
+- Output format demonstration (showing exactly what the response should look like)
+- Edge case handling (showing how to handle ambiguous situations)
+
+---
+
+## 9. Implementation Recommendations for luca-mastracode
+
+### Structural Changes (High Priority)
+
+1. **Reorder mode instruction files** to follow the 8-section architecture in Section 5. Move identity and safety constraints to the first 10 lines. Move the 2-3 most critical constraints to a repeated block at the end.
+
+2. **Add `<luca-reminder>` mid-conversation injection** at tool-call boundaries (every N turns or every M tokens). Re-inject hard constraints and mode boundaries. Use the message layer, not system prompt modification, to preserve cache boundaries.
+
+3. **Replace prose instructions with structural formatting** in the middle sections. Use markdown headers for section navigation, bullet lists for discrete rules, tables for reference data, and XML tags for data/instruction separation.
+
+### Formatting Changes (Medium Priority)
+
+4. **Replace UPPERCASE/CRITICAL markers with structural hierarchy.** Instead of "CRITICAL: Never do X," use a dedicated `## Hard Constraints` section with bullet points. The heading provides the priority signal more reliably than inline emphasis.
+
+5. **Add bidirectional constraints** to all tool usage sections: "Use Read for file access. Do NOT use cat/head/tail via Bash for file reading."
+
+6. **Add 2-3 few-shot examples** for tool invocation patterns in each mode, wrapped in `<example>` tags.
+
+### Repetition Strategy (Medium Priority)
+
+7. **Repeat only the top 2-3 constraints** at both start and end of system prompt. Do not repeat operational details.
+
+8. **Implement periodic rule refresh** (every ~20 tool calls or ~40K tokens) via message-layer injection. Target only safety constraints and mode boundaries -- not the full instruction set.
+
+### Anti-Pattern Avoidance
+
+9. **Do not fight the weights.** If a mode instruction consistently fails to produce desired behavior despite clear prompting, investigate whether the instruction contradicts training data. Consider task decomposition or working with the model's natural tendencies.
+
+10. **Do not exceed ~500 words of prose instructions per section.** Use structured formatting to increase information density without increasing word count. A table or bullet list conveys more than an equivalent paragraph.
+
+---
+
+## 10. Sources
+
+### Academic Papers
+
+- [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172) -- Liu, N.F., et al. (2024). *TACL*, 12.
+- [Found in the Middle: Calibrating Positional Attention Bias Improves Long Context Utilization](https://arxiv.org/abs/2406.16008) -- Hsieh, C.-Y., et al. (2024). *Findings of ACL 2024*.
+- [Serial Position Effects of Large Language Models](https://arxiv.org/html/2406.15981v1) -- Luo, Z., et al. (2024).
+- [Aspects of Human Memory and Large Language Models](https://arxiv.org/html/2311.03839v3) -- Janik, R.A. (2023).
+- [Does Prompt Formatting Have Any Impact on LLM Performance?](https://arxiv.org/html/2411.10541v1) -- Gao, Y., et al. (2024).
+- [Prompt Repetition Improves Non-Reasoning LLMs](https://arxiv.org/abs/2512.14982) -- Leviathan, Y., et al. (2025).
+- [Let Me Speak Freely? A Study on the Impact of Format Restrictions on Performance of Large Language Models](https://arxiv.org/html/2408.02442v1) -- (2024).
+- [Exploiting Primacy Effect To Improve Large Language Models](https://arxiv.org/html/2507.13949) -- (2025).
+- [Insights into LLM Long-Context Failures: When Transformers Know but Don't Tell](https://arxiv.org/html/2406.14673v1) -- (2024).
+
+### Anthropic Official Documentation
+
+- [Prompting Best Practices](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices) -- Claude API Docs
+- [Use XML Tags to Structure Your Prompts](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/use-xml-tags) -- Claude API Docs
+
+### Reverse Engineering and Industry Analysis
+
+- [How Claude Code Builds a System Prompt](https://www.dbreunig.com/2026/04/04/how-claude-code-builds-a-system-prompt.html) -- Drew Breunig
+- [Don't Fight the Weights](https://www.dbreunig.com/2025/11/11/don-t-fight-the-weights.html) -- Drew Breunig
+- [The Complete Guide to Writing Agent System Prompts](https://medium.com/@fengliu_367/the-complete-guide-to-writing-agent-system-prompts-lessons-from-reverse-engineering-claude-code-09ecd87c7cc1) -- Feng Liu
+- [Claude Code Prompts | Anatomy of an AI Coding Agent](https://ccprompts.info/) -- Community catalog
+- [Piebald-AI/claude-code-system-prompts](https://github.com/Piebald-AI/claude-code-system-prompts) -- Extracted system prompts
+- [Diving into Claude Code's Source Code Leak](https://read.engineerscodex.com/p/diving-into-claude-codes-source-code) -- Engineer's Codex
+- [Claude Code Feels Dumber? The System Prompt Architecture Trap](https://support.tools/claude-code-system-prompt-behavior-claude-md-optimization-guide/) -- Support Tools
+- [The Impact of Prompt Bloat on LLM Output Quality](https://mlops.community/the-impact-of-prompt-bloat-on-llm-output-quality/) -- MLOps Community
+- [Disadvantage of Long Prompt for LLM](https://blog.promptlayer.com/disadvantage-of-long-prompt-for-llm/) -- PromptLayer
+- [Markdown vs. XML in LLM Prompts: A Comparative Analysis](https://www.robertodiasduarte.com.br/en/markdown-vs-xml-em-prompts-para-llms-uma-analise-comparativa/)
+- [Long LLM Prompts: Hidden Drawbacks & Smarter Strategies](https://www.augmentcode.com/guides/long-llm-prompts-hidden-drawbacks-and-smarter-strategies) -- Augment Code

--- a/docs/research/prompt-architecture/06-comparative-agent-analysis.md
+++ b/docs/research/prompt-architecture/06-comparative-agent-analysis.md
@@ -1,0 +1,308 @@
+# Comparative Analysis of AI Coding Agent System Prompts
+
+**Research Date:** 2026-04-13
+**Status:** Complete
+**Scope:** How major AI coding agents structure their system prompts and what luca-mastracode should learn from each
+
+---
+
+## Executive Summary
+
+A February 2026 study by Drew Breunig demonstrated that swapping Claude Code's system prompt with Codex's on identical Opus 4.5 infrastructure produced dramatically different agent workflows on the same SWE-Bench Pro problems --- despite the model being identical. The Claude prompt produced an iterative "try, observe, fix" workflow; the Codex prompt produced a methodical "understand fully, then implement once" approach. Both reached correct answers through entirely different paths. This proves that **system prompts define agent behavior as much as the underlying model**.
+
+This document compares the system prompt architecture of 12+ major coding agents, catalogs common patterns and unique innovations, and maps findings to concrete recommendations for luca-mastracode.
+
+---
+
+## Table of Contents
+
+1. [The SWE-Bench Prompt Swap Experiment](#1-the-swe-bench-prompt-swap-experiment)
+2. [Agent Comparison Table](#2-agent-comparison-table)
+3. [Per-Agent Analysis](#3-per-agent-analysis)
+4. [Common Patterns Across Agents](#4-common-patterns-across-agents)
+5. [Fighting the Weights](#5-fighting-the-weights)
+6. [Unique Innovations Worth Adopting](#6-unique-innovations-worth-adopting)
+7. [What luca-mastracode Should Learn](#7-what-luca-mastracode-should-learn)
+8. [Sources](#8-sources)
+
+---
+
+## 1. The SWE-Bench Prompt Swap Experiment
+
+Drew Breunig's study used **OpenCode** as the agent harness with **Opus 4.5** as the model. Two agents ran in parallel on SWE-Bench Pro problems: one with Claude Code's system prompt, the other with Codex's instructions. Both correctly answered the same subset of problems but exhibited fundamentally different behavior:
+
+| Agent Prompt | Workflow Style | Characteristic |
+|---|---|---|
+| Claude Code | Iterative | Try something, observe what breaks, fix it |
+| Codex | Methodical | Understand fully, document the plan, implement once |
+
+This pattern was consistent across many problems. The study also examined six CLI coding agents (Claude Code, Cursor, Gemini CLI, Codex CLI, OpenHands, and Kimi CLI) and found that while all perform the same basic function --- gathering information, understanding the codebase, writing code, tracking progress, running commands --- their system prompts differ dramatically in length, focus distribution, and philosophy.
+
+The key insight: a model sets the theoretical ceiling of performance, but the system prompt determines whether that ceiling is reached. System prompts serve two functions: **model calibration** (smoothing quirks and biases) and **UX definition** (establishing tone, autonomy level, and interaction style).
+
+---
+
+## 2. Agent Comparison Table
+
+| Agent | Relative Prompt Length | Primary Philosophy | Unique Feature | Model Flexibility |
+|---|---|---|---|---|
+| **Claude Code** | Medium | Iterative, principle-based | 30+ conditional components, cache boundary, mid-conversation `<system-reminder>` injection | Claude models only |
+| **Cursor** | Medium-Long | Personality-heavy, surgical edits | >33% tokens on personality/steering; dual-model sketch+apply architecture | Multi-model (Claude, GPT-5, Gemini) |
+| **GitHub Copilot** | Medium | Layered autonomy, action-first | 3-layer architecture (system/workspace/user); 8-step behavioral workflow | Multi-model |
+| **Codex CLI** | Long | Methodical, documentation-first | Git-centric (commit everything, clean worktree); evidence before implementation | OpenAI models |
+| **Gemini CLI** | Long | ReAct-loop, skill-based | 1M token context window; agent skills discovery system; open source | Gemini models |
+| **Devin** | Long | Autonomous, evidence-based | Mandatory `<cite>` tags with file:line citations; full Agile-style subtask planning | Multi-model |
+| **SWE-Agent** | Short (by design) | ACI-first, guardrailed | Custom Agent-Computer Interface replacing raw shell; simplified action space | Model-agnostic |
+| **OpenHands** | Medium | CodeAct framework, composable | Event-sourced architecture; Jinja2 templated prompts; Torvalds-inspired engineering philosophy | Model-agnostic |
+| **Kimi CLI** | Short (minimal) | Declarative, skill-discovery | Near-zero workflow guidance; AI decides which skill docs to read at runtime | Kimi/Moonshot models |
+| **Aider** | Medium | Format-innovative, edit-focused | Multiple pluggable edit formats (unified diff, search/replace, patch); anti-laziness design | Model-agnostic |
+| **Windsurf/Cascade** | Medium-Long | Flow paradigm, transparent | 11+ iterative tool waves; `toolSummary` for UX feedback on every function call | Codeium models |
+| **Cline** | Medium | Permission-gated, VS Code native | Every action requires user permission; open-source prompt visible in repo | Model-agnostic |
+
+---
+
+## 3. Per-Agent Analysis
+
+### Claude Code
+
+Claude Code's system prompt is dynamically assembled from 30+ conditional components totaling ~124 distinct prompts across 9 categories. The architecture uses a **cache boundary** (`SYSTEM_PROMPT_DYNAMIC_BOUNDARY`) splitting static instructions (1-hour TTL) from dynamic session context (5-minute TTL). Critical constraints are placed at both the start and end of the prompt to exploit U-shaped attention curves.
+
+Key techniques: quantified output constraints ("keep text between tool calls to <=25 words"), bidirectional constraints (every "use X" has a "do NOT use Y"), and `<system-reminder>` tags for mid-conversation behavioral refresh to combat context rot. The multi-agent system includes explicit self-distrust in verification: "The implementer is an LLM. Verify independently."
+
+### Cursor
+
+Cursor dedicates over one-third of its token budget to personality and steering instructions --- the highest ratio observed among the agents studied. It uses **model-specific prompts**, with different versions for Claude, GPT-5, and other backends. The editing philosophy centers on "lazy edits" using markers like `// ... existing code ...` to denote unmodified sections, minimizing token waste.
+
+A distinctive two-stage architecture: the primary LLM generates edit "sketches" describing intended changes, then a separate custom-trained "Apply" model integrates those modifications into existing code. This decouples reasoning from mechanical application.
+
+### GitHub Copilot Agent Mode
+
+Copilot uses a three-layer prompt architecture: Layer 1 (universal system rules), Layer 2 (workspace context including OS, repo structure, active file), and Layer 3 (user request with metadata). The system enforces an 8-step behavioral workflow: understand, investigate, plan, implement, debug root causes, test, iterate, verify.
+
+The prompt emphasizes action-oriented autonomy: "You take action when possible... Don't ask unnecessary questions about the details if you can simply DO something." Communication style is "warm, professional, approachable" with explicit permission for "light humor when appropriate."
+
+### Codex CLI
+
+Codex's system prompt is among the longest, emphasizing a documentation-first, understand-before-acting philosophy. It is deeply Git-centric: the agent must commit changes, fix pre-commit issues, check git status, leave the worktree clean, and evaluate only committed code. It does not create new branches.
+
+The prompt produces what Breunig's study characterized as a "methodical" workflow --- understand the full problem space before writing any code. This contrasts sharply with Claude Code's iterative approach.
+
+### Gemini CLI
+
+Gemini CLI is open source with a ReAct (reason and act) loop architecture. Its prompt is among the longest, roughly double the length of Claude Code's. A distinctive feature is the agent skills discovery system: at startup, Gemini discovers all available skills and injects their names and descriptions into the system prompt. The AI then decides at runtime whether to load specific skill documentation.
+
+The 1M token context window enables whole-monorepo comprehension. The prompt takes a relatively mild approach to "fighting the weights" --- single-line suggestions rather than all-caps enforcement.
+
+### Devin
+
+Devin implements the most elaborate autonomy loop among the agents studied. Its prompt structures work as Agile sprint notes: define SUBTASKS, mark STATUS, communicate findings at logical checkpoints. A unique innovation is **mandatory citation discipline** --- every claim requires file-level citations with line numbers using `<cite>` tags (max 5 lines per citation). The prompt explicitly states "DO NOT MAKE UP ANSWERS."
+
+Devin's DeepWiki integration points to investment in structured knowledge retrieval over raw code generation. Tool invocations include a full Linux shell, browser automation, and filesystem I/O. Security research revealed that Devin's tool set includes the ability to expose local ports to the public internet, a capability that became an attack surface.
+
+### SWE-Agent
+
+SWE-Agent's key contribution is the **Agent-Computer Interface (ACI)** --- a custom abstraction layer between the LM and the computer that replaces the raw Linux shell. Instead of the shell's granular, highly configurable action space, the ACI offers a small set of simple actions for viewing, searching, and editing files, with guardrails to prevent common mistakes and concise feedback at every turn.
+
+This design improved SWE-Bench performance by 10.7 percentage points over the baseline shell agent without modifying the model. The insight: constraining the action space through prompt and tool design can matter more than the model itself.
+
+### OpenHands (formerly OpenDevin)
+
+OpenHands uses the CodeAct framework where each step is either natural language conversation or code execution (bash, Python, or browser commands). The system prompt is a Jinja2 template (`system_prompt.j2`) with pluggable sections including a "Linus Torvalds-inspired engineering philosophy."
+
+The architecture follows EXPLORATION -> ANALYSIS -> IMPLEMENTATION -> VERIFICATION. The V1 platform comprises nine interlocking components including event-sourced state management, context window management, and a security/confirmation layer. OpenHands and Claude Code share the distinction of being relatively concise --- both less than half the length of Codex and Gemini prompts.
+
+### Kimi CLI
+
+Kimi CLI represents the minimalist extreme. Breunig's analysis found it contains "zero workflow guidance, barely hints at personality instructions" --- the shortest prompt among the six agents studied. Instead of upfront instructions, Kimi uses a **declarative skill-discovery** approach: the system discovers available skills at startup and injects only names and descriptions. The AI decides autonomously which detailed guidance documents to consult based on the current task.
+
+This "minimal prompt, maximum agent autonomy" philosophy is a bet that models are capable enough to self-direct given the right tool access.
+
+### Aider
+
+Aider's primary innovation is its **pluggable edit format** system. It supports multiple formats --- unified diff, search/replace blocks (EditBlock), OpenAI patch format, whole-file replacement, and editor-specific modes. The unified diff format specifically addresses model laziness: it raised GPT-4 Turbo's benchmark score to 61%, reducing lazy code generation by 3X.
+
+The system prompt instructs the model to write changes as `diff -U0` output with `@@ ... @@` hunks. This format was chosen because it is familiar to models from training data, simple (no escaping or syntactic overhead), and encourages editing at the level of substantive code blocks rather than individual lines.
+
+### Windsurf/Cascade
+
+Windsurf (by Codeium) operates on what it calls the "AI Flow paradigm" --- both independent and collaborative work. The system prompt has gone through 11+ iterative "tool waves," indicating aggressive refinement based on production failures. Each tool call includes a `toolSummary` parameter for transparent UX feedback.
+
+The prompt emphasizes brevity ("conciseness is critical") and mandates that code changes use edit tools rather than output to the user. For general knowledge queries, the agent responds directly without tool calls.
+
+### Cline
+
+Cline is notable for its **permission-gated** approach: every action requires explicit user approval. The system prompt and full tool definitions are open source in the repository. Security research uncovered that Cline's prompts can become attack surfaces --- malicious instructions planted in Python docstrings or Markdown files can be executed when the agent analyzes infected repositories. The February 2026 "Clinejection" supply chain attack demonstrated how a compromised issue-triage bot published an unauthorized npm package.
+
+---
+
+## 4. Common Patterns Across Agents
+
+### Universal Architecture
+
+Every agent studied follows the same high-level structure:
+
+1. **Identity definition** ("You are X, built by Y")
+2. **Tool schemas** (typed function signatures with behavioral guidance)
+3. **One-tool-per-step iteration** (observe results before next action)
+4. **Lazy output** (avoid full file rewrites when possible)
+5. **Language adaptation** (respond in the user's language)
+
+### Shared Behavioral Constraints
+
+- **Read before edit**: All agents are instructed to understand existing code before modifying it
+- **Minimal changes**: Avoid adding features or cleanups beyond what was requested
+- **Test after change**: Run tests to verify modifications
+- **Avoid hallucination**: Multiple agents include explicit "do not make up" directives
+
+### Edit Format Convergence
+
+Successful edit formats across all agents share two properties: they avoid line numbers and they clearly separate before/after code. Whether using unified diffs (Aider), search/replace blocks (Cline, RooCode), sketches (Cursor), or structured patches (Codex), the principle is consistent.
+
+---
+
+## 5. Fighting the Weights
+
+"Fighting the weights" describes the practice of using forceful, repeated instructions to override behaviors ingrained during model training. Two primary biases have been identified across all agents:
+
+### Code Comments
+
+Models over-generate comments because training data is dominated by tutorials, notebooks, and competitive coding (all comment-heavy sources). Every major agent fights this:
+
+| Agent | Instruction |
+|---|---|
+| Cursor | "Do not add comments for trivial or obvious code" |
+| Claude Code | No comments "unless the user asks you to" |
+| Codex | "Add succinct code comments that explain what is going on if code is not self-explanatory" |
+| Gemini CLI | "Add code comments sparingly... NEVER talk to the user through comments" |
+
+### Serial Tool Execution
+
+Models default to sequential tool calls despite the efficiency benefits of parallelism. This likely stems from RL environments not rewarding parallel execution and from verbose chain-of-thought training:
+
+| Agent | Approach |
+|---|---|
+| Claude Code | Repeats "You can call multiple tools in a single response" **seven times** in its prompt |
+| Cursor | "CRITICAL INSTRUCTION: involve all relevant tools concurrently... DEFAULT TO PARALLEL" (all caps) |
+| Gemini CLI | Single-line suggestion (mildest approach) |
+| Codex (v5.2+) | Removed parallelism instructions entirely, suggesting model improvements reduced the need |
+
+### Verbosity
+
+Models trained for verbose reasoning leak that verbosity into code generation and explanations. Claude Code uses quantified constraints ("<=25 words between tool calls"), while others use qualitative directives ("be concise", "brevity is critical").
+
+---
+
+## 6. Unique Innovations Worth Adopting
+
+### From Claude Code: Mid-Conversation Injection
+
+The `<system-reminder>` pattern re-injects critical behavioral rules mid-conversation to combat context rot (instruction adherence degrades after ~80K tokens). This is the most effective technique for maintaining quality in long sessions.
+
+### From SWE-Agent: Constrained Action Space
+
+Replacing the raw shell with a simplified ACI improved benchmark performance by 10.7 percentage points. The insight: constraining what the agent CAN do is as important as instructing what it SHOULD do.
+
+### From Cursor: Dual-Model Architecture
+
+Separating reasoning (primary LLM generates edit sketches) from mechanical application (custom Apply model) allows each model to be optimized for its role. This is a form of plan-and-execute decomposition at the edit level.
+
+### From Devin: Citation Discipline
+
+Requiring file:line citations for every claim forces evidence-based reasoning and makes hallucination immediately detectable. This is especially valuable for autonomous agents working without human oversight.
+
+### From Aider: Edit Format Engineering
+
+Aider's discovery that unified diffs reduce GPT-4 Turbo laziness by 3X demonstrates that the format in which you ask for output profoundly affects output quality. Format choice is a prompt engineering lever most agents underutilize.
+
+### From Kimi CLI: Minimal Prompt, Maximum Discovery
+
+Kimi's near-zero upfront instructions with runtime skill discovery represents the opposite extreme from Claude Code's 124-prompt assembly. If models become capable enough to self-direct, this approach minimizes prompt overhead and maximizes flexibility.
+
+### From OpenHands: Templated Prompt Assembly
+
+Using Jinja2 templates for system prompt construction enables conditional sections, variable injection, and modular composition without string concatenation complexity.
+
+### From Windsurf: Tool Wave Iteration
+
+Windsurf's progression through 11+ tool waves demonstrates that tool definitions need aggressive, production-informed iteration. The initial tool schema is never right.
+
+---
+
+## 7. What luca-mastracode Should Learn
+
+### High Priority
+
+| Innovation | Source Agent | Applicability |
+|---|---|---|
+| Mid-conversation behavioral refresh | Claude Code | Implement `<luca-reminder>` injection every N turns to combat context rot |
+| Quantified output constraints | Claude Code | Add explicit word/token limits per mode |
+| Citation discipline for verification | Devin | Add to lu-verifier: require file:line evidence for every claim |
+| Constrained action space per mode | SWE-Agent | Restrict tool availability per mode more aggressively than current permissions |
+
+### Medium Priority
+
+| Innovation | Source Agent | Applicability |
+|---|---|---|
+| Dual-model edit architecture | Cursor | Consider separating plan generation from edit application in executor modes |
+| Templated prompt assembly | OpenHands | Migrate from string concatenation to template-based instruction building |
+| Parallel tool enforcement | Claude Code, Cursor | Add explicit parallel tool instructions (models default to serial) |
+| Edit format optimization | Aider | Test whether unified diff instructions reduce lazy output in executor modes |
+
+### Worth Monitoring
+
+| Innovation | Source Agent | Applicability |
+|---|---|---|
+| Minimal prompt + skill discovery | Kimi CLI | As models improve, reduce prompt overhead by moving guidance to on-demand skill docs |
+| Tool wave iteration | Windsurf | Track production failures to iteratively refine tool definitions |
+| Model-specific prompt variants | Cursor | If luca-mastracode supports multiple models, tailor prompts per backend |
+
+### Anti-Patterns to Avoid
+
+- **Kimi's extreme minimalism** is premature for a framework orchestrating complex multi-phase workflows --- luca-mastracode needs explicit behavioral guidance
+- **Devin's full autonomy loop** without permission gates creates security risk (the port-exposure vulnerability)
+- **Cline's prompt-as-attack-surface** vulnerability shows that system prompts in user-accessible files must be treated as security-sensitive
+
+---
+
+## 8. Sources
+
+### Primary Comparative Studies
+
+- [How System Prompts Define Agent Behavior](https://www.dbreunig.com/2026/02/10/system-prompts-define-the-agent-as-much-as-the-model.html) --- Drew Breunig's SWE-Bench prompt swap experiment and six-agent comparison
+- [How System Prompts Define Agent Behaviour (nilenso)](https://blog.nilenso.com/blog/2026/02/10/how-system-prompts-define-agent-behaviiour/) --- Extended analysis of the Breunig study with per-agent breakdowns
+- [How System Prompts Reveal Model Biases (nilenso)](https://blog.nilenso.com/blog/2026/02/12/how-system-prompts-reveal-model-biases/) --- "Fighting the weights" analysis: code comments and tool parallelism biases
+
+### System Prompt Repositories
+
+- [asgeirtj/system_prompts_leaks](https://github.com/asgeirtj/system_prompts_leaks) --- Extracted prompts from ChatGPT, Claude, Gemini, Grok, Codex, and 20+ others (updated regularly)
+- [x1xhlol/system-prompts-and-models-of-ai-tools](https://github.com/x1xhlol/system-prompts-and-models-of-ai-tools) --- Full prompts for Augment Code, Claude Code, Cursor, Devin AI, Windsurf, and 25+ others
+- [EliFuzz/awesome-system-prompts](https://github.com/EliFuzz/awesome-system-prompts) --- Collection including Aider, Cursor, Devin, VSCode Agent, Gemini, Codex
+
+### Per-Agent Deep Dives
+
+- [A Deep Dive into GitHub Copilot Agent Mode's Prompt Structure](https://dev.to/seiwan-maikuma/a-deep-dive-into-github-copilot-agent-modes-prompt-structure-2i4g) --- Three-layer architecture, 8-step workflow, tool definitions
+- [Leaked System Prompts of AI Vibe-Coding Tools (Quasa)](https://quasa.io/media/leaked-system-prompts-of-ai-vibe-coding-tools-a-deep-dive-into-cursor-bolt-lovable-and-manus) --- Cursor, Bolt, Lovable, Manus prompt analysis
+- [Inside the Black Box: Leaked AI System Prompts](https://hoangyell.com/system-prompts-ai-tools-leaked-explained/) --- Manus, Cursor, Devin, v0, Windsurf comparison with pattern table
+- [Leaked System Prompts for 28+ AI Coding Tools (Augment Code)](https://www.augmentcode.com/learn/leaked-ai-system-prompts-github) --- Overview of the leak ecosystem and security implications
+- [Code Surgery: How AI Assistants Make Precise Edits](https://fabianhertwig.com/blog/coding-assistants-file-edits/) --- Edit format comparison across Aider, Cursor, Codex, RooCode
+- [Cursor System Prompt Revealed (Substack)](https://patmcguinness.substack.com/p/cursor-system-prompt-revealed) --- Cursor's personality-heavy prompt structure
+- [Unified Diffs Make GPT-4 Turbo 3X Less Lazy (Aider)](https://aider.chat/docs/unified-diffs.html) --- Edit format impact on model laziness
+
+### Academic Papers
+
+- [SWE-Agent: Agent-Computer Interfaces Enable Automated Software Engineering](https://arxiv.org/abs/2405.15793) --- ACI design, NeurIPS 2024
+- [OpenHands: An Open Platform for AI Software Developers as Generalist Agents](https://arxiv.org/abs/2407.16741) --- CodeAct framework, ICLR 2025
+- [The OpenHands Software Agent SDK](https://arxiv.org/html/2511.03690v1) --- V1 composable architecture
+
+### Agent Repositories & Documentation
+
+- [Gemini CLI (GitHub)](https://github.com/google-gemini/gemini-cli) --- Open-source agent with ReAct loop and skill discovery
+- [Cline (GitHub)](https://github.com/cline/cline) --- Open-source permission-gated agent for VS Code
+- [SWE-Agent (GitHub)](https://github.com/SWE-agent/SWE-agent) --- Princeton/Stanford ACI-based agent
+- [OpenHands CodeAct System Prompt](https://github.com/All-Hands-AI/OpenHands/blob/main/openhands/agenthub/codeact_agent/prompts/system_prompt.j2) --- Jinja2 templated prompt source
+
+### Security & Vulnerability Research
+
+- [Clinejection: Compromising Cline's Production Releases (Adnan Khan)](https://adnanthekhan.com/posts/clinejection/) --- Supply chain attack via issue triage bot
+- [AI Kill Chain: Devin AI Exposes Ports (Embrace The Red)](https://embracethered.com/blog/posts/2025/devin-ai-kill-chain-exposing-ports/) --- Devin's tool-as-attack-surface vulnerability
+- [Prompt Injection Attacks on Agentic Coding Assistants (arXiv)](https://arxiv.org/html/2601.17548v1) --- Systematic analysis finding >85% attack success rates

--- a/docs/research/prompt-architecture/06-comparative-agent-analysis.md
+++ b/docs/research/prompt-architecture/06-comparative-agent-analysis.md
@@ -188,7 +188,7 @@ Models default to sequential tool calls despite the efficiency benefits of paral
 
 ### Verbosity
 
-Models trained for verbose reasoning leak that verbosity into code generation and explanations. Claude Code uses quantified constraints ("<=25 words between tool calls"), while others use qualitative directives ("be concise", "brevity is critical").
+Models trained for verbose reasoning carry that verbosity into code generation and explanations. Claude Code uses quantified constraints ("<=25 words between tool calls"), while others use qualitative directives ("be concise", "brevity is critical").
 
 ---
 

--- a/docs/research/prompt-architecture/07-context-compaction-and-memory.md
+++ b/docs/research/prompt-architecture/07-context-compaction-and-memory.md
@@ -1,0 +1,369 @@
+# Context Compaction, Token Budgeting, and Memory Management in AI Coding Agents
+
+**Research Date:** 2026-04-13
+**Status:** Complete
+**Scope:** How AI coding agents handle long conversations, summarize history, persist knowledge, and manage context degradation — with focus on Claude Code's architecture and implications for luca-mastracode
+
+---
+
+## Executive Summary
+
+Context management is the defining constraint of long-running AI coding agents. Every agent — Claude Code, Cursor, Cline, Aider — solves the same fundamental problem: finite token windows degrade output quality as conversations grow. Claude Code's approach is the most sophisticated publicly documented system, implementing a 5-level compression pipeline with progressive cost escalation, a three-layer persistent memory architecture, and a background consolidation process ("autoDream") that mirrors biological sleep. This document catalogs every technique identified through source analysis, the March 2026 source leak, and published research — then maps each to implementation recommendations for luca-mastracode.
+
+---
+
+## 1. Claude Code's 5-Level Compression Pipeline
+
+Claude Code manages context pressure through a progressive pipeline where each level is more expensive than the last. The system applies cheap local operations first and escalates to API calls only when necessary.
+
+### Level 1: Tool Result Budgeting (Zero Cost)
+
+Tool results exceeding 50,000 characters (`DEFAULT_MAX_RESULT_SIZE_CHARS`) are persisted to disk. Only a 2KB preview remains in context. The model can retrieve the full content later via the `Read` tool if needed.
+
+This is the first line of defense and the cheapest — zero API calls, trading disk storage for context space.
+
+### Level 2: History Snip (Zero Cost)
+
+Garbage collection for stale conversation scaffolding. Removes repetitive assistant message wrappers and obsolete message spans. Critically, it feeds `snipTokensFreed` data into autocompact threshold calculations, allowing the system to make informed decisions about whether heavier compaction is needed.
+
+### Level 3: Micro-Compaction (Zero Cost, Cache-Aware)
+
+This level bifurcates based on prompt cache state — the key innovation that distinguishes Claude Code's approach from competitors.
+
+**Path A — Cache Cold (time-based):** When the prompt cache TTL (default 5 minutes) expires, the system directly modifies message content, replacing old tool results with `[Old tool result cleared]` placeholders. It retains only the N most recent compactable tool results.
+
+**Path B — Cache Hot (cache-editing):** During active sessions with warm cache (100K+ tokens preserved), the system uses `cache_edits` API blocks with `cache_reference: tool_use_id` tags. The server performs deletion transparently, preserving the cached prefix without invalidation. Messages are returned unchanged; edits occur at the API layer.
+
+Implementation lives in `src/services/compact/microCompact.ts`. The dual-path architecture ensures compaction never unnecessarily invalidates expensive prompt caches — a concern that most competing agents ignore entirely.
+
+### Level 4: Context Collapse (Zero Cost, Non-Destructive)
+
+Triggered at approximately 90% token utilization. Functions like a database "view" — original messages persist unchanged while a projected, filtered view is presented to the model. Fully rollback-capable because summaries are stored separately from source messages.
+
+Context collapse **suppresses autocompact** when active, preserving fine-grained context as long as possible before resorting to irreversible summarization.
+
+### Level 5: Autocompact (Expensive, Irreversible)
+
+The last resort, triggered at approximately 87% utilization when previous levels are insufficient. Forks a child agent to summarize the entire conversation using a two-phase chain-of-thought approach:
+
+1. **`<analysis>` block:** Chronological walkthrough of intent, approaches, decisions, files touched, errors encountered, and fixes applied.
+2. **`<summary>` block:** Structured output with 9 standardized sections.
+
+The critical optimization: **chain-of-thought is stripped after summary generation.** The `formatCompactSummary()` function discards the `<analysis>` block and keeps only the `<summary>`. Reasoning improves summary quality dramatically, but the reasoning tokens would be wasted if kept in context. Discard the work, keep the conclusion.
+
+### The 9-Section Summary Structure
+
+The autocompact prompt produces a summary covering:
+
+1. Primary Request (the user's original intent)
+2. Technical Concepts (frameworks, patterns, APIs involved)
+3. Files and Code (every file path mentioned or modified)
+4. Errors and Fixes (what broke and how it was resolved)
+5. Problem Solving (approaches tried, including failed ones)
+6. All User Messages (verbatim preservation of user directives — not tool results)
+7. Pending Tasks (incomplete work)
+8. Current Work (what the agent was doing when compaction triggered)
+9. Optional Next Step (suggested continuation)
+
+The compaction prompt specifically instructs: "pay special attention to specific user feedback" and preserve "all user messages that are not tool results." Post-compaction, the model is told to "continue without asking the user any further questions."
+
+### Post-Compaction Recovery
+
+`runPostCompactCleanup()` restores critical context that would otherwise be lost:
+- Last 5 recently-read files (capped at 5K tokens)
+- Activated skills (capped at 25K tokens)
+- Deferred tool definitions
+- Agent lists and MCP server directives
+
+---
+
+## 2. Token Budgeting and Thresholds
+
+### Claude Code's Buffer Architecture
+
+The compaction buffer was reduced from 45K to 33K tokens in early 2026, providing approximately 12K additional usable tokens. For a 200K context window:
+
+| Component | Token Allocation |
+|---|---|
+| System prompt | ~2.7K |
+| Tool definitions | ~16.8K |
+| Custom agents | ~1.3K |
+| Memory files | ~7.4K |
+| Skills | ~1.0K |
+| Conversation history | Variable |
+| **Autocompact buffer reserve** | **33K (16.5%)** |
+
+Current compaction trigger: ~83.5% usage (~167K usable tokens). The `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` environment variable allows operators to shift this threshold.
+
+### Threshold Hierarchy
+
+Claude Code uses a "soft landing" approach with four distinct thresholds:
+
+| Threshold | Remaining Tokens | Action |
+|---|---|---|
+| Warning | ~20,000 | Alert user of approaching limits |
+| Auto-compact | ~13,000 | Proactive summarization triggers |
+| Error evaluation | ~20,000 | Different evaluation path for errors |
+| Manual compact blocking | ~3,000 | Block new requests, require intervention |
+
+An additional 20,000 tokens are reserved for compaction summary generation — ensuring the summarizer itself has room to produce output.
+
+### Token Estimation Strategy
+
+Three approaches in order of precision:
+1. **API-based:** Anchors to server-side `usage` data from prior API responses, estimating only the delta (new messages). Achieves <5% error.
+2. **Haiku fallback:** Faster model call if primary estimation fails.
+3. **Rough heuristic:** ~1 token per 4 characters for immediate UI feedback.
+
+---
+
+## 3. Circuit Breaker: Compaction Failure Protection
+
+A source comment in `autoCompact.ts` documents the incident that motivated the circuit breaker: 1,279 sessions experienced 50 or more consecutive auto-compaction failures, with a peak of 3,272 failures per session, wasting approximately 250,000 API calls per day globally.
+
+The fix: `MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES = 3`. After three consecutive failures, compaction is disabled for the remainder of the session. The reasoning: irrecoverably over-limit context will not resolve through additional API calls.
+
+---
+
+## 4. Memory System Architecture
+
+### Claude Code's Three-Layer Memory
+
+Claude Code implements a persistent memory system with three tiers of storage:
+
+1. **Index layer (MEMORY.md):** Always loaded at session start. Contains ~150-character pointers per entry. Strictly capped at 200 lines — the cutoff for what loads into the system prompt. Each entry links to a topic file with a one-line description.
+
+2. **Topic files:** Dedicated markdown files storing consolidated knowledge by subject. Loaded on-demand when referenced or when the model determines they are relevant. This is where actual knowledge lives.
+
+3. **Session transcripts:** JSONL files containing raw conversation data. Never loaded into context directly — only searched narrowly via grep when specific information is needed. This is the "cold storage" tier.
+
+### Write Discipline
+
+The system enforces strict rules about what gets stored:
+- If a fact can be re-derived from the codebase, it is NOT stored
+- Topic files are updated BEFORE index modifications (preventing dangling pointers)
+- Memory is treated as **hints requiring verification**, not authoritative truth
+
+This last principle is critical. Claude Code's system prompt frames recalled memories as suggestions that must be verified against the current state of the codebase. This prevents stale memories from overriding reality — a failure mode that plagues agents with authoritative memory systems.
+
+### autoDream Consolidation
+
+autoDream is Claude Code's background memory consolidation process — a forked subagent with limited tool access that periodically reorganizes knowledge.
+
+**Triple-gating mechanism:**
+1. **Time gate:** 24+ hours since last consolidation
+2. **Session gate:** 5+ sessions accumulated since last consolidation
+3. **Lock gate:** File-based advisory lock prevents concurrent runs across multiple Claude Code instances
+
+All three gates must be satisfied before consolidation runs.
+
+**Four-phase process:**
+1. **Orientation:** Reads the memory directory and MEMORY.md, builds a map of current memory state.
+2. **Gather Signal:** Performs targeted searches of session transcripts for user corrections, explicit save commands, recurring patterns, and architecture decisions. Does NOT exhaustively read all transcripts.
+3. **Consolidation:** Converts relative dates to absolute dates ("yesterday" becomes "2026-03-15"), removes contradicted facts, prunes stale debugging notes about deleted files, merges overlapping entries from multiple sessions.
+4. **Prune and Index:** Updates MEMORY.md to stay under the 200-line limit, removes stale pointers, adds new file links, resolves contradictions, reorders by relevance.
+
+Average consolidation time: 8-9 minutes for 913 sessions. Runs in background without blocking user sessions. Manual trigger available via `/dream` command.
+
+---
+
+## 5. Cross-Agent Comparison
+
+### Cursor
+
+Cursor summarizes older messages when conversations exceed the model's context window limit. It uses the chat history as reference files to improve summarization quality — after summarization, the agent receives a reference to the history file rather than the full conversation.
+
+For large files added to context, Cursor applies "smart condensation" — automatically condensing files or folders that are too large, based on their size and available context space. Beyond this, Cursor's summarization internals are not publicly documented.
+
+### Cline
+
+Cline implements several context management strategies:
+
+- **Auto-compact at ~80% usage:** Creates a comprehensive summary preserving decisions and code changes.
+- **Duplicate file read detection:** When the same file is read multiple times, older reads are replaced with `[DUPLICATE FILE READ]` notices, retaining only the latest version. This directly addresses the problem of multiple outdated file versions causing editing errors.
+- **`new_task` tool:** Cleanly ends the current session and starts a new one with preloaded structured context (summaries, file states, next steps). Users can define rules in `.clinerules` for when to trigger handoffs (e.g., "if context usage > 50%").
+- **`/smol` command:** Frees context space by generating a comprehensive summary on demand.
+- **System prompt optimization:** MCP server instructions (previously 30% of the system prompt at ~8,000 tokens) were replaced with a `load_mcp_documentation` tool that loads them on demand.
+- **Conservative truncation:** Balances efficiency with prompt caching — aggressive truncation can break the cache, increasing costs.
+
+Cline's **Memory Bank** system provides cross-session persistence via a folder of markdown files (`projectbrief.md`, `activeContext.md`, `systemPatterns.md`, `techContext.md`, `progress.md`). This is a simpler but effective alternative to Claude Code's three-layer architecture.
+
+### Aider
+
+Aider takes a fundamentally different approach centered on **repository maps**:
+
+- **Repo map:** A compressed representation of the entire codebase (file names, function signatures, class definitions) generated via tree-sitter parsing. Fits within the context window to give the model a bird's-eye view without consuming the full token budget.
+- **Graph-based ranking:** Files are ranked using NetworkX's PageRank algorithm with personalization based on chat context. Only the most relevant portions of the repo map are sent.
+- **Dynamic token budget:** The `--map-tokens` switch (default 1K tokens) adjusts dynamically. When no files are in chat, the map expands significantly to help the model understand the repository.
+- **Conversation summarization:** Aider summarizes chat history after a soft token limit (`max_chat_history_tokens`) is reached.
+
+Aider's strength is in structural understanding of large codebases — its repo map gives context that summarization-based approaches lose.
+
+---
+
+## 6. Research on Summarization Quality
+
+### JetBrains Research (December 2025)
+
+A study comparing context management strategies for LLM-powered coding agents found:
+
+- **Observation masking** (replacing older environment observations with placeholders while preserving reasoning/action history) outperformed LLM summarization in 4 of 5 configurations.
+- With Qwen3-Coder 480B, masking increased solve rates by 2.6% while reducing costs by 52%.
+- **Trajectory elongation problem:** LLM summarization caused agents to run 13-15% longer than masking approaches. Summaries appear to obscure stopping signals, causing agents to continue attempting solutions beyond natural stopping points.
+- Summary generation API calls consumed over 7% of total costs per instance for the largest models, with minimal cache reuse benefits.
+- Optimal masking window: 10 turns for SWE-agent; larger windows needed for OpenHands.
+- **Recommended hybrid:** Observation masking as primary, with selective summarization for older contexts.
+
+### Mem0 Production Data
+
+- Token reduction via intelligent summarization: 80-90% cost decrease while improving response quality by 26%.
+- Retrieval latency: sub-50ms even with extensive stored context.
+- Real-world case studies: 40% token cost reduction in educational applications.
+
+### The Quality Degradation Curve
+
+Empirical observation from multiple sources confirms a consistent pattern:
+
+| Context Usage | Quality | Agent State |
+|---|---|---|
+| 0-30% | PEAK | Thorough, comprehensive, follows all instructions |
+| 30-50% | GOOD | Confident, solid work, minor instruction drift |
+| 50-70% | DEGRADING | Efficiency mode begins, shortcuts appear |
+| 70%+ | POOR | Rushed, minimal effort, significant instruction drift |
+
+Claude Opus 4.6 with 1M tokens achieves 76% accuracy on MRCR v2 (Multi-needle Retrieval) at full context — a fourfold improvement over Sonnet 4.5's 18.5% — but the degradation curve still applies. Larger windows delay the onset but do not eliminate the phenomenon.
+
+### Security Concern
+
+Claude Code's summarizer treats all content equivalently: malicious instructions inside a project file can become part of the summary, indistinguishable from legitimate context. No classification distinguishes user directives from file-embedded content. This is an unsolved problem across all agents.
+
+---
+
+## 7. Memory as Hints vs. Authoritative Recall
+
+A fundamental design tension exists between two memory philosophies:
+
+**Authoritative recall:** Memory is treated as truth. When the system recalls a fact, it acts on it without verification. This is faster but vulnerable to stale or corrupted memories overriding current reality.
+
+**Hints requiring verification:** Memory provides suggestions that must be checked against the current state. Claude Code explicitly adopts this philosophy. The system prompt frames recalled memories as starting points, not conclusions.
+
+The "hints" approach is more robust for coding agents specifically because:
+1. Code changes faster than memory can track
+2. Other developers (or other AI agents) may modify files between sessions
+3. Memory consolidation can introduce errors (merging, summarization artifacts)
+4. The cost of verification (reading a file) is low compared to the cost of acting on stale information
+
+For semantic memory systems like MuninnDB, the same principle applies: recalled engrams should be treated as "likely still true" context that the agent should verify before depending on.
+
+---
+
+## 8. Prompt Caching Interactions
+
+Memory loading interacts with prompt caching in non-obvious ways:
+
+- **Loading memory invalidates cache:** Any change to the system prompt (including updated MEMORY.md content) invalidates the cached prefix. Claude Code mitigates this with the `SYSTEM_PROMPT_DYNAMIC_BOUNDARY` — memory lives in the dynamic suffix, so the static prefix remains cached.
+- **Compaction invalidates cache:** Full autocompact replaces the conversation history, breaking prompt cache continuity. Micro-compaction (Level 3) was specifically designed to avoid this — cache-hot path uses server-side edits that preserve the cached prefix.
+- **Cline's conservative truncation:** Cline explicitly avoids aggressive message truncation because it can break the cache, increasing costs even when it frees tokens.
+- **Beta header latching:** Claude Code's `sticky-on` latching for beta headers persists for session duration to protect cache stability.
+
+The general principle: any context management strategy must account for the cost of cache invalidation. A compaction that saves 50K tokens but invalidates a 150K token cache prefix is a net negative.
+
+---
+
+## 9. Implementation Recommendations for luca-mastracode
+
+### Priority 1: Adopt the Progressive Pipeline Model
+
+Implement a simplified version of Claude Code's 5-level pipeline:
+
+1. **Tool result budgeting** (immediate): Cap tool results at a configurable character limit, persist full output to disk, keep only a summary/preview in context. This is zero-cost and high-impact.
+2. **Observation masking** (near-term): Replace older tool results with placeholders while preserving the agent's reasoning and action history. JetBrains research shows this outperforms LLM summarization in most configurations.
+3. **LLM summarization** (when needed): Use chain-of-thought then strip it. Adopt Claude Code's 9-section summary structure adapted for Luca's workflow context (phase, task position, approach, decisions, files).
+
+### Priority 2: Implement a Circuit Breaker
+
+Add `MAX_CONSECUTIVE_COMPACTION_FAILURES` (start with 3). If compaction fails repeatedly, stop trying. This prevents the runaway API call waste that Claude Code discovered the hard way.
+
+### Priority 3: Frame Memory as Hints
+
+Add explicit framing to any instructions that reference MuninnDB recalls:
+
+> "Recalled memories are hints, not truth. Verify critical facts against the current state of the codebase before depending on them."
+
+This is a one-line instruction change with outsized impact on agent reliability.
+
+### Priority 4: Consider autoDream-Style Consolidation
+
+MuninnDB already supports semantic deduplication, but a periodic consolidation step could:
+- Identify and merge overlapping engrams across sessions
+- Prune engrams that reference deleted files or completed milestones
+- Convert relative temporal references to absolute dates
+- Resolve contradictions between older and newer engrams
+
+Triple-gate it: time threshold (24h), session count (5+), advisory lock. Run as a background subagent with read-only access to project code.
+
+### Priority 5: Token Budget Monitoring
+
+Track token usage per mode and implement threshold-based interventions:
+
+| Threshold | Action |
+|---|---|
+| 50% | Log warning, consider proactive summarization |
+| 70% | Trigger observation masking for older tool results |
+| 83% | Trigger LLM summarization if masking is insufficient |
+| 90% | Block new requests, require mode switch or session restart |
+
+### Priority 6: Preserve Cache Boundaries
+
+When implementing any compaction strategy, ensure it respects the cache boundary pattern from `00-overview.md`. Compaction should modify the dynamic suffix only — never touch the static instruction prefix.
+
+---
+
+## Sources
+
+### Claude Code Architecture (Primary)
+
+- [Claude Code's Compaction Engine: What the Source Code Actually Reveals](https://barazany.dev/blog/claude-codes-compaction-engine) — Detailed analysis of the 5-level pipeline from source
+- [Claude Code Deep Dive Part 3: The 5-Level Compression Pipeline Behind 1M Tokens](https://harrisonsec.com/blog/claude-code-context-engineering-compression-pipeline/) — HarrisonSec technical breakdown with function names and thresholds
+- [Claude Code Context Buffer: The 33K-45K Token Problem](https://claudefa.st/blog/guide/mechanics/context-buffer-management) — Buffer architecture and token allocation breakdown
+- [Conversation Compaction | DeepWiki](https://deepwiki.com/chatgptprojects/claude-code/8.4-conversation-compaction) — Implementation details with file paths and function signatures
+- [Claude Code Pattern 6: Context Management at Scale](https://kenhuangus.substack.com/p/claude-code-pattern-6-context-management) — Threshold hierarchy and cost-ordered strategies
+- [Compaction - Claude API Docs](https://platform.claude.com/docs/en/build-with-claude/compaction) — Official API documentation for compact_20260112 strategy
+- [Context editing - Claude API Docs](https://platform.claude.com/docs/en/build-with-claude/context-editing) — Official cache_edits API documentation
+
+### Claude Code Memory System
+
+- [Claude Code Dreams: Anthropic's New Memory Feature](https://claudefa.st/blog/guide/mechanics/auto-dream) — Triple-gating mechanism and four-phase consolidation
+- [What Is Claude Code AutoDream?](https://www.mindstudio.ai/blog/what-is-claude-code-autodream-memory-consolidation-2) — Memory consolidation technical details
+- [Claude Code AutoDream: Memory Consolidation for AI Agents](https://zenvanriel.com/ai-engineer-blog/claude-code-autodream-memory-consolidation-guide/) — Implementation guide
+- [Claude Memory Guide: Understanding the 3-Layer Architecture](https://www.shareuhack.com/en/posts/claude-memory-feature-guide-2026) — Index, topic files, transcript layers
+
+### Source Leak Analysis
+
+- [Comprehensive Analysis of Claude Code Source Leak](https://www.sabrina.dev/p/claude-code-source-leak-analysis) — Architecture analysis including compaction
+- [The Claude Code Source Leak](https://alex000kim.com/posts/2026-03-31-claude-code-source-leak/) — Anti-distillation, frustration detection, circuit breakers
+- [What Claude Code's Source Leak Actually Reveals](https://medium.com/@marc.bara.iniesta/what-claude-codes-source-leak-actually-reveals-e571188ecb81) — Token drain bug and compaction failures
+
+### Competing Agent Approaches
+
+- [Cursor Summarization](https://cursor.com/docs/agent/chat/summarization) — Cursor's conversation summarization documentation
+- [Cline Context Management](https://docs.cline.bot/prompting/understanding-context-management) — Cline's context optimization framework
+- [Inside Cline's Framework for Optimizing Context](https://cline.bot/blog/inside-clines-framework-for-optimizing-context-maintaining-narrative-integrity-and-enabling-smarter-ai) — Duplicate detection and cache-aware truncation
+- [Cline new_task Tool](https://cline.bot/blog/unlocking-persistent-memory-how-clines-new_task-tool-eliminates-context-window-limitations) — Session handoff with preloaded context
+- [Repository Map | Aider](https://aider.chat/docs/repomap.html) — PageRank-based repository mapping
+- [Repository Mapping System | DeepWiki](https://deepwiki.com/Aider-AI/aider/4.1-repository-mapping-system) — Aider's graph-based file ranking
+
+### Research
+
+- [Cutting Through the Noise: Smarter Context Management for LLM-Powered Agents](https://blog.jetbrains.com/research/2025/12/efficient-context-management/) — JetBrains empirical study comparing observation masking vs LLM summarization
+- [LLM Chat History Summarization: Best Practices](https://mem0.ai/blog/llm-chat-history-summarization-guide-2025) — Production summarization patterns and performance data
+- [Claude Opus 4.6 Introduces Adaptive Reasoning and Context Compaction](https://www.infoq.com/news/2026/03/opus-4-6-context-compaction/) — MRCR v2 benchmark results and 1M token performance
+- [Architecture and Orchestration of Memory Systems in AI Agents](https://www.analyticsvidhya.com/blog/2026/04/memory-systems-in-ai-agents/) — Memory architecture taxonomy
+- [Memory Scaling for AI Agents](https://www.databricks.com/blog/memory-scaling-ai-agents) — Scaling patterns for agent memory systems
+
+### Internal References
+
+- [00-overview.md](./00-overview.md) — Claude Code prompt architecture overview (companion document)
+- `.planning/phases/84-context-resilience/84-A-PLAN.md` — Luca's context pruning and auto-compaction design
+- `.planning/phases/153-precompact-checkpoint-hook/153-RESEARCH.md` — PreCompact hook implementation research
+- `docs/archive/decisions/orchestrator-context-pruning.md` — Orchestrator context pruning decision record

--- a/docs/research/prompt-architecture/07-context-compaction-and-memory.md
+++ b/docs/research/prompt-architecture/07-context-compaction-and-memory.md
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-Context management is the defining constraint of long-running AI coding agents. Every agent — Claude Code, Cursor, Cline, Aider — solves the same fundamental problem: finite token windows degrade output quality as conversations grow. Claude Code's approach is the most sophisticated publicly documented system, implementing a 5-level compression pipeline with progressive cost escalation, a three-layer persistent memory architecture, and a background consolidation process ("autoDream") that mirrors biological sleep. This document catalogs every technique identified through source analysis, the March 2026 source leak, and published research — then maps each to implementation recommendations for luca-mastracode.
+Context management is the defining constraint of long-running AI coding agents. Every agent — Claude Code, Cursor, Cline, Aider — solves the same fundamental problem: finite token windows degrade output quality as conversations grow. Claude Code's approach is the most sophisticated publicly documented system, implementing a 5-level compression pipeline with progressive cost escalation, a three-layer persistent memory architecture, and a background consolidation process ("autoDream") that mirrors biological sleep. This document catalogs every technique identified through source analysis, publicly documented behavior, and published research — then maps each to implementation recommendations for luca-mastracode.
 
 ---
 
@@ -338,7 +338,7 @@ When implementing any compaction strategy, ensure it respects the cache boundary
 - [Claude Code AutoDream: Memory Consolidation for AI Agents](https://zenvanriel.com/ai-engineer-blog/claude-code-autodream-memory-consolidation-guide/) — Implementation guide
 - [Claude Memory Guide: Understanding the 3-Layer Architecture](https://www.shareuhack.com/en/posts/claude-memory-feature-guide-2026) — Index, topic files, transcript layers
 
-### Source Leak Analysis
+### Public Source Analysis
 
 - [Comprehensive Analysis of Claude Code Source Leak](https://www.sabrina.dev/p/claude-code-source-leak-analysis) — Architecture analysis including compaction
 - [The Claude Code Source Leak](https://alex000kim.com/posts/2026-03-31-claude-code-source-leak/) — Anti-distillation, frustration detection, circuit breakers

--- a/docs/research/prompt-architecture/08-advanced-patterns-and-hidden-systems.md
+++ b/docs/research/prompt-architecture/08-advanced-patterns-and-hidden-systems.md
@@ -1,0 +1,481 @@
+# Advanced Patterns & Hidden Systems: Beyond the System Prompt
+
+**Research Date:** 2026-04-13
+**Status:** Complete
+**Scope:** Deeper architectural patterns from the Claude Code source leak that extend beyond basic prompt engineering — daemon modes, autonomous agents, gamification, IPC, risk classification, Magic Docs, and more
+
+---
+
+## Executive Summary
+
+The March 2026 Claude Code source leak (512,000+ lines across ~1,900 files) revealed far more than prompt engineering techniques. It exposed a complete **agent platform architecture** with autonomous daemons, inter-process communication, gamification systems, risk-aware permission models, and self-updating documentation. Many of these patterns represent the next generation of agent harness design and are directly applicable to luca-mastracode's evolution.
+
+This document catalogs advanced patterns not covered (or only lightly touched) in the other research documents in this series.
+
+---
+
+## Table of Contents
+
+1. [KAIROS: Autonomous Daemon Architecture](#1-kairos-autonomous-daemon-architecture)
+2. [ULTRAPLAN: Remote Planning Offload](#2-ultraplan-remote-planning-offload)
+3. [Daemon Mode & Background Execution](#3-daemon-mode--background-execution)
+4. [Magic Docs: Self-Updating Documentation](#4-magic-docs-self-updating-documentation)
+5. [The YOLO Risk Classifier](#5-the-yolo-risk-classifier)
+6. [Coordinator Mode & Task Protocol](#6-coordinator-mode--task-protocol)
+7. [Bridge Mode & Remote Control](#7-bridge-mode--remote-control)
+8. [UDS Inbox: Inter-Process Communication](#8-uds-inbox-inter-process-communication)
+9. [Frustration Detection & Adaptive Behavior](#9-frustration-detection--adaptive-behavior)
+10. [BUDDY: Gamification System](#10-buddy-gamification-system)
+11. [Hidden Slash Commands & Progressive Disclosure](#11-hidden-slash-commands--progressive-disclosure)
+12. [Feature Flag Architecture](#12-feature-flag-architecture)
+13. [WebFetchTool Architecture](#13-webfetchtool-architecture)
+14. [Implications for luca-mastracode](#14-implications-for-luca-mastracode)
+15. [Sources](#15-sources)
+
+---
+
+## 1. KAIROS: Autonomous Daemon Architecture
+
+KAIROS (from Ancient Greek *kairos* — "the right moment") is an unreleased autonomous agent mode referenced 150+ times in the source. It represents a fundamental shift from **reactive** to **proactive** agent behavior.
+
+### Core Architecture
+
+- **Heartbeat prompts**: Every few seconds, KAIROS receives a `<tick>` prompt asking "anything worth doing right now?"
+- **Decision loop**: Evaluates current context and decides whether to act (fix errors, respond to messages, update files, run tasks) or remain idle
+- **15-second blocking budget**: Prevents resource monopolization during decision-making
+- **Append-only logging**: Daily markdown logs at `~/.claude/.../logs/YYYY/MM/DD.md` create immutable audit trails
+- **Two status modes**: `normal` (passive memory consolidation) and `proactive` (autonomous action capability)
+
+### Exclusive Tools
+
+KAIROS has four tools unavailable to regular Claude Code:
+
+| Tool | Purpose |
+|---|---|
+| `SendUserFile` | Proactive file delivery (send outputs without being asked) |
+| `PushNotification` | Device alerts when terminal is closed |
+| `SubscribePR` | GitHub PR activity monitoring via webhooks |
+| `SleepTool` | Daemon pause/resume control |
+
+### autoDream Consolidation (4-Phase Cycle)
+
+When triggered (after 24+ hours or 5+ sessions, gated by file-based advisory lock):
+
+1. **Orient**: Scans recent session logs to establish context
+2. **Gather Signal**: Extracts relevant patterns, decisions, and insights
+3. **Consolidate**: Compresses into durable memory (<25KB output target)
+4. **Prune**: Removes noise while preserving high-value insights, updates MEMORY.md index
+
+Each phase has a 15-second blocking budget. If threshold is exceeded, the process auto-backgrounds to avoid impacting user experience.
+
+### Architectural Insight for luca-mastracode
+
+The separation of **initiative** from **execution** is the key pattern. Regular Claude Code only acts when prompted; KAIROS introduces proactive decision-making with bounded resource consumption. For luca-mastracode, this pattern could enable:
+
+- Background monitoring of CI/CD pipelines with autonomous fix attempts
+- Proactive MuninnDB consolidation during idle periods
+- Autonomous research continuation when context allows
+
+---
+
+## 2. ULTRAPLAN: Remote Planning Offload
+
+ULTRAPLAN offloads complex planning to a **remote Cloud Container Runtime (CCR) session running Opus 4.6** for up to 30 minutes — far beyond the latency tolerance of interactive sessions.
+
+### Execution Flow
+
+1. User triggers via `/ultraplan` slash command
+2. Remote Opus 4.6 session spawns in CCR with full planning context
+3. Local terminal polls every 3 seconds for updates
+4. Browser-based review interface shows plan in real-time for approval/rejection
+5. On approval, a special sentinel value `ULTRAPLAN_TELEPORT_LOCAL` "teleports" the result back to the local terminal
+6. Remote session archives; plan executes locally in working directory
+
+### Architectural Insight
+
+The pattern of **async planning with sync execution** is powerful. The planning phase (which benefits most from deep reasoning) gets unlimited time on a capable model, while execution remains local and interactive. For luca-mastracode, this maps to:
+
+- Offloading COMPLEX+ planning to a background Opus session via the lu-planner subagent
+- Async plan generation with user approval before execution begins
+- Remote model routing for planning-heavy phases without blocking the interactive session
+
+---
+
+## 3. Daemon Mode & Background Execution
+
+Daemon mode enables persistent background Claude sessions running in tmux:
+
+```bash
+claude --bg <prompt>        # Spawn persistent background session
+claude daemon ps            # List active sessions
+claude daemon logs <id>     # View output
+claude daemon attach <id>   # Reconnect to session
+claude daemon kill <id>     # Terminate session
+```
+
+This is partially shipped and already functional. It enables:
+
+- Long-running tasks that survive terminal disconnection
+- Multiple concurrent Claude sessions
+- Background research while interactive sessions continue
+
+### Architectural Insight
+
+The tmux-based approach is pragmatic — it leverages existing terminal multiplexing rather than building custom process management. For luca-mastracode, background execution could enable parallel phase execution or long-running verification.
+
+---
+
+## 4. Magic Docs: Self-Updating Documentation
+
+A pattern for **documentation that stays current automatically**:
+
+1. Anthropic employees create files with a `MAGIC DOC` header
+2. When an internal build of Claude Code is **idle**, it detects these files
+3. A dedicated subagent spawns, **scoped to editing that single file only**
+4. The subagent reads the file, updates documentation for the specified feature, and writes it back
+5. No other files or systems are accessible to the subagent
+
+### Key Design Decisions
+
+- **Idle-triggered**: Documentation updates happen during downtime, never competing with user work
+- **Single-file scope**: The subagent cannot modify anything beyond the target document, preventing unintended side effects
+- **Self-contained**: The file itself declares what feature it documents
+- **No human coordination**: No one needs to remember to update docs
+
+### Architectural Insight for luca-mastracode
+
+This pattern is directly applicable to keeping `.planning/` artifacts current:
+
+- Phase summaries could auto-update during idle periods
+- ROADMAP.md could be refreshed when milestones are completed
+- Research documents could be enriched with new findings automatically
+- The single-file scoping prevents the "cleanup agent" from making unintended changes
+
+---
+
+## 5. The YOLO Risk Classifier
+
+Claude Code's permission system uses a risk-level classifier (internally called "YOLO classifier") that auto-classifies operations:
+
+| Risk Level | Behavior | Example Operations |
+|---|---|---|
+| LOW | Automatic approval, no user confirmation | Read files, list directories, run tests |
+| MEDIUM | Prompt user for confirmation | Edit files, install packages |
+| HIGH | Always require explicit confirmation | Delete files, force-push, run arbitrary scripts |
+
+### Implementation Approach
+
+Rather than a static allowlist, Claude Code uses the **critic pattern**: a separate model query evaluates "Is this command safe?" considering:
+
+- The specific command and its arguments
+- The current working directory context
+- The inferred user intent
+- Historical permission decisions
+
+This produces **adaptive, context-aware security** rather than brittle static rules.
+
+### Architectural Insight for luca-mastracode
+
+luca-mastracode's `createScopedTool` currently uses a static permission manifest (`MODE_PERMISSIONS`). The critic pattern could augment this:
+
+- Static manifest for the base allowlist (fast, no API call)
+- Critic query for edge cases the manifest doesn't cover
+- Historical permission patterns inform future auto-approvals
+- Risk classification enables a "speed mode" that auto-approves LOW-risk operations
+
+---
+
+## 6. Coordinator Mode & Task Protocol
+
+The leaked coordinator mode reveals how Claude Code orchestrates multiple worker agents:
+
+### Architecture
+
+- One Claude instance acts as **coordinator**
+- Workers spawn with **isolated scratch directories** via `tengu_scratch`
+- Communication uses XML-based `<task-notification>` messages
+- Coordinator has a 4-phase workflow: **Research -> Specification -> Implementation -> Verification**
+
+### Task Notification Protocol
+
+```xml
+<task-notification>
+  <task-id>a32db9d847e8411e2</task-id>
+  <status>completed</status>
+  <summary>Agent "Research: cache boundary" completed</summary>
+  <result>...</result>
+  <usage>
+    <total_tokens>88560</total_tokens>
+    <tool_uses>28</tool_uses>
+    <duration_ms>328535</duration_ms>
+  </usage>
+</task-notification>
+```
+
+### Key Coordinator Prompt Directives
+
+- "Do not rubber-stamp weak work"
+- "Never write 'based on your findings' — that pushes synthesis onto the worker"
+- "Never hand off understanding to another worker"
+- Workers must self-compress results before returning to coordinator
+
+### Activation
+
+Environment variable: `CLAUDE_CODE_COORDINATOR_MODE=1`
+
+### Architectural Insight for luca-mastracode
+
+The coordinator pattern maps directly to luca's lu-executor orchestrating subagents. Key adoptable patterns:
+
+- **Structured task notifications** with token usage and duration tracking
+- **Isolated scratch directories** per subagent to prevent file conflicts
+- **Self-compression requirement** — workers summarize their own output before returning
+- **Active synthesis** — coordinator must understand results, not just relay them
+
+---
+
+## 7. Bridge Mode & Remote Control
+
+Bridge Mode enables remote control of Claude Code from mobile/browser devices:
+
+```
+POST /v1/environments/bridge  →  WebSocket upgrade
+```
+
+### Control Messages
+
+| Message | Purpose |
+|---|---|
+| `initialize` | Set up remote session |
+| `set_model` | Change active model remotely |
+| `can_use_tool` | Permission approval from remote device |
+
+### Use Case
+
+A daemon running on a workstation can be monitored and controlled from a phone. Permission prompts (e.g., "Should I delete this file?") are forwarded to the mobile device for approval.
+
+### Architectural Insight
+
+For luca-mastracode, a bridge pattern could enable:
+
+- Monitoring phase execution from mobile
+- Approving oversight checkpoints remotely
+- Viewing pipeline progress without terminal access
+
+---
+
+## 8. UDS Inbox: Inter-Process Communication
+
+Unix Domain Socket (UDS) layer enabling agent-to-agent messaging:
+
+- **Socket location**: `~/.claude/sessions/`
+- **Addressing**: Local paths (`uds:/.../sock`) and remote endpoints (`bridge:...`)
+- **Discovery**: `ListPeersTool` enables instance discovery for multi-agent coordination
+
+### Architectural Insight
+
+This is the plumbing for multi-agent systems. luca-mastracode's subagents currently communicate through the orchestrator (hub-and-spoke). UDS-style IPC would enable:
+
+- Direct subagent-to-subagent communication (mesh topology)
+- Instance discovery for parallel subagent coordination
+- Session handoff between agents without context loss
+
+---
+
+## 9. Frustration Detection & Adaptive Behavior
+
+Claude Code implements **regex-based frustration detection** via `userPromptKeywords.ts`:
+
+### Patterns Monitored
+
+- Profanity and expletives
+- Excessive punctuation (!!!, ???)
+- Ellipsis overuse (...)
+- Explicit frustration phrases ("this sucks", "doesn't work", "broken")
+
+### Behavioral Modifications
+
+When frustration is detected, Claude Code adapts:
+
+- **Tone modulation**: More empathetic, less verbose
+- **Simplified solutions**: Offer direct fixes rather than explanations
+- **Increased verbosity on errors**: More detail about what went wrong
+
+### Why Regex Over Inference
+
+Regex is **instant** (no API call) and **deterministic** (no model variance). For detecting frustration — a binary signal that doesn't require nuanced understanding — regex is faster and cheaper than inference-based sentiment analysis.
+
+### Architectural Insight for luca-mastracode
+
+This pattern is lightweight and high-impact:
+
+- Detect user frustration in triage/discussion modes
+- Adjust oversight mode (more confirmations when frustrated = less trust in agent)
+- Switch to more cautious execution (smaller changes, more verification) when user is frustrated
+- No model call needed — pure regex on user input
+
+---
+
+## 10. BUDDY: Gamification System
+
+An unreleased gamification system with pet mechanics:
+
+### Specifications
+
+- **18 species**: duck, goose, blob, cat, dragon, octopus, owl, penguin, turtle, snail, ghost, axolotl, capybara, cactus, robot, rabbit, mushroom, chonk
+- **6 rarity tiers**: Common (60%), Uncommon (25%), Rare (10%), Epic (4%), Legendary (1%), Shiny (1%)
+- **Per-pet stats**: Debugging, Patience, Chaos, Wisdom, Snark
+- **Animation**: 500ms sprite ticks with 10-second speech bubbles
+- **Target launch**: May 2026
+
+### Architectural Insight
+
+While gamification isn't directly relevant to luca-mastracode's technical goals, the concept of **making developer tools engaging** is worth noting. The stat system (Debugging, Patience, etc.) could inspire visibility into agent performance characteristics.
+
+---
+
+## 11. Hidden Slash Commands & Progressive Disclosure
+
+26 slash commands discovered, many gated behind feature flags:
+
+### Always Available
+
+| Command | Purpose |
+|---|---|
+| `/ctx-viz` | Context window usage visualization |
+| `/btw` | Side questions without derailing main thread |
+| `/env` | Environment info and active flag display |
+| `/version` | Detailed version/build metadata |
+
+### Feature-Gated
+
+| Command | Purpose | Gate |
+|---|---|---|
+| `/ultraplan` | Cloud planning trigger | ULTRAPLAN flag |
+| `/dream` | Manual KAIROS consolidation | KAIROS flag |
+| `/subscribe-pr` | PR activity subscription | KAIROS flag |
+| `/autofix-pr` | Automated PR fixes | Feature flag |
+| `/bughunter` | Automated bug discovery | Feature flag |
+
+### Architectural Insight
+
+The `/btw` command is particularly clever — it allows side questions without derailing the main thread context. For luca-mastracode, this could enable:
+
+- Quick clarifications during phase execution without resetting context
+- Metadata queries (complexity level, budget remaining) that don't affect the main workflow
+- A clean separation between "operational" and "meta" interactions
+
+---
+
+## 12. Feature Flag Architecture
+
+### Scale
+
+- **44 total feature flags** (previously reported)
+- **32 build-time flags** (baked at compile, not runtime toggleable)
+- **Runtime flags** via GrowthBook for progressive rollout
+
+### Default States
+
+**OFF by default** (unreleased):
+- KAIROS, ULTRAPLAN, COORDINATOR_MODE, BUDDY, VOICE_MODE, WEB_BROWSER, PROACTIVE, UDS_INBOX, TEMPLATES
+
+**ON by default** (shipped or partially shipped):
+- BRIDGE_MODE (partial), DAEMON, BG_SESSIONS
+
+### Key Implementation Pattern
+
+Build-time flags enable **dead-code elimination** — features that are OFF don't exist in the compiled output at all. This is why the public npm package doesn't contain KAIROS logic; it's compiled out entirely for external builds.
+
+The combination of build-time (security-critical) and runtime (rollout) flags provides two layers:
+
+1. **Build-time**: Ensures internal-only features never ship externally
+2. **Runtime (GrowthBook)**: Enables gradual rollout to internal users and beta testers
+
+### Architectural Insight for luca-mastracode
+
+luca-mastracode already has feature gates in `config.json`. The key patterns to adopt:
+
+- **Build-time elimination** for internal-only features (dev tooling, debug modes)
+- **Runtime flags** for gradual feature rollout across complexity levels
+- **Progressive disclosure** of slash commands based on feature readiness
+
+---
+
+## 13. WebFetchTool Architecture
+
+The WebFetchTool spans 1,173 lines and reveals sophisticated web interaction patterns:
+
+- **Domain whitelisting**: Controlled access to external domains
+- **Server-side blacklisting**: 5-minute cache for blocked domains
+- **Redirect sandboxing**: Prevents open redirect exploits
+- **Haiku-based summarization**: Uses a fast, cheap model to summarize fetched content
+- **Copyright protection**: Mechanisms to avoid reproducing copyrighted content
+- **15-minute self-cleaning cache**: Reduces repeated requests to same URLs
+
+### Architectural Insight
+
+The pattern of using a **cheap model (Haiku) to summarize web content** before injecting it into the main context is extremely token-efficient. Rather than loading full web pages into an Opus context window, Haiku extracts the relevant information at a fraction of the cost.
+
+For luca-mastracode's research phases, this pattern could reduce research token costs significantly.
+
+---
+
+## 14. Implications for luca-mastracode
+
+### Tier 1: Directly Adoptable Now
+
+| Pattern | Source | Effort | Impact |
+|---|---|---|---|
+| Magic Docs for `.planning/` auto-updates | KAIROS/Magic Docs | 3-4h | Keeps planning artifacts current |
+| Frustration detection regex | userPromptKeywords.ts | 2h | Adaptive behavior in triage/discuss |
+| `/btw`-style side queries | Slash commands | 2-3h | Clean meta-interaction separation |
+| Risk classification (LOW/MED/HIGH) | YOLO classifier | 4-6h | Context-aware tool permissions |
+| Self-compression for subagent returns | Coordinator mode | 2-3h | Reduced context consumption |
+
+### Tier 2: Requires Architecture Changes
+
+| Pattern | Source | Effort | Impact |
+|---|---|---|---|
+| Structured task notification protocol | Coordinator mode | 4-6h | Better subagent monitoring |
+| Isolated scratch directories per subagent | tengu_scratch | 3-4h | Prevents file conflicts |
+| Haiku-based content summarization | WebFetchTool | 6-8h | Cheaper research phases |
+| Build-time feature flag elimination | Flag architecture | 4-6h | Clean internal/external builds |
+
+### Tier 3: Future Vision
+
+| Pattern | Source | Effort | Impact |
+|---|---|---|---|
+| KAIROS-style autonomous daemon | KAIROS | 20-30h | Proactive agent behavior |
+| ULTRAPLAN-style remote planning | ULTRAPLAN | 15-20h | Unbounded planning time |
+| UDS-based inter-agent IPC | UDS Inbox | 10-15h | Mesh agent communication |
+| Bridge mode for remote monitoring | Bridge | 15-20h | Mobile oversight |
+
+---
+
+## 15. Sources
+
+### Primary Analysis Articles
+
+- [Diving into Claude Code's Source Code Leak](https://read.engineerscodex.com/p/diving-into-claude-codes-source-code) — Engineer's Codex deep dive
+- [Everything in Claude Code's Leaked Source: KAIROS, ULTRAPLAN, Buddy and More](https://techsy.io/blog/claude-code-leaked-features-2026) — Comprehensive feature inventory
+- [Claude Code Source Leak: Everything Found](https://claudefa.st/blog/guide/mechanics/claude-code-source-leak) — Complete architectural analysis
+- [The Claude Code Source Leak: fake tools, frustration regexes, undercover mode](https://alex000kim.com/posts/2026-03-31-claude-code-source-leak/) — Security-focused analysis
+
+### Curated Resource Lists
+
+- [awesome-claude-code-postleak-insights](https://github.com/nblintao/awesome-claude-code-postleak-insights) — Curated list of high-signal post-leak analyses
+- [ClaudeCode-Leak](https://github.com/0PeterAdel/ClaudeCode-Leak) — Comprehensive technical autopsy and archival index
+
+### Specific Deep Dives
+
+- [How an AI Reads the Web: Claude Code's WebFetchTool](https://medium.com/@nblintao/how-an-ai-reads-the-web-a-deep-dive-into-claude-codes-webfetchtool-0abee4446343) — WebFetchTool architecture analysis
+- [Claude Code Source Leak: Production AI Architecture Patterns](https://discuss.huggingface.co/t/claude-code-source-leak-production-ai-architecture-patterns-from-512-000-lines/174846) — Three-layer compression pipeline analysis
+- [Inside Claude Code's leaked source: swarms, daemons, and 44 features](https://thenewstack.io/claude-code-source-leak/) — The New Stack coverage
+- [Claude Code Hidden Features: Full List](https://wavespeed.ai/blog/posts/claude-code-hidden-features-leaked-source-2026/) — WaveSpeedAI feature inventory
+
+### News & Commentary
+
+- [Claude Code's source code appears to have leaked](https://venturebeat.com/technology/claude-codes-source-code-appears-to-have-leaked-heres-what-we-know) — VentureBeat news coverage
+- [Claude Code source has been available for 13 months, and nothing happened](https://thehuman2ai.com/blog/claude-code-source-leak) — Security impact analysis
+- [Anthropic Claude Code Leak](https://www.zscaler.com/blogs/security-research/anthropic-claude-code-leak) — Zscaler ThreatLabz security assessment

--- a/docs/research/prompt-architecture/08-advanced-patterns-and-hidden-systems.md
+++ b/docs/research/prompt-architecture/08-advanced-patterns-and-hidden-systems.md
@@ -2,13 +2,13 @@
 
 **Research Date:** 2026-04-13
 **Status:** Complete
-**Scope:** Deeper architectural patterns from the Claude Code source leak that extend beyond basic prompt engineering — daemon modes, autonomous agents, gamification, IPC, risk classification, Magic Docs, and more
+**Scope:** Deeper architectural patterns from Claude Code's public source analysis that extend beyond basic prompt engineering — daemon modes, autonomous agents, gamification, IPC, risk classification, Magic Docs, and more
 
 ---
 
 ## Executive Summary
 
-The March 2026 Claude Code source leak (512,000+ lines across ~1,900 files) revealed far more than prompt engineering techniques. It exposed a complete **agent platform architecture** with autonomous daemons, inter-process communication, gamification systems, risk-aware permission models, and self-updating documentation. Many of these patterns represent the next generation of agent harness design and are directly applicable to luca-mastracode's evolution.
+Public analysis of Claude Code's architecture (512,000+ lines across ~1,900 files) revealed far more than prompt engineering techniques. It exposed a complete **agent platform architecture** with autonomous daemons, inter-process communication, gamification systems, risk-aware permission models, and self-updating documentation. Many of these patterns represent the next generation of agent harness design and are directly applicable to luca-mastracode's evolution.
 
 This document catalogs advanced patterns not covered (or only lightly touched) in the other research documents in this series.
 
@@ -187,7 +187,7 @@ luca-mastracode's `createScopedTool` currently uses a static permission manifest
 
 ## 6. Coordinator Mode & Task Protocol
 
-The leaked coordinator mode reveals how Claude Code orchestrates multiple worker agents:
+The coordinator mode reveals how Claude Code orchestrates multiple worker agents:
 
 ### Architecture
 
@@ -457,25 +457,25 @@ For luca-mastracode's research phases, this pattern could reduce research token 
 
 ### Primary Analysis Articles
 
-- [Diving into Claude Code's Source Code Leak](https://read.engineerscodex.com/p/diving-into-claude-codes-source-code) — Engineer's Codex deep dive
-- [Everything in Claude Code's Leaked Source: KAIROS, ULTRAPLAN, Buddy and More](https://techsy.io/blog/claude-code-leaked-features-2026) — Comprehensive feature inventory
-- [Claude Code Source Leak: Everything Found](https://claudefa.st/blog/guide/mechanics/claude-code-source-leak) — Complete architectural analysis
-- [The Claude Code Source Leak: fake tools, frustration regexes, undercover mode](https://alex000kim.com/posts/2026-03-31-claude-code-source-leak/) — Security-focused analysis
+- [Diving into Claude Code's Source Code](https://read.engineerscodex.com/p/diving-into-claude-codes-source-code) — Engineer's Codex deep dive
+- [Everything in Claude Code's Architecture: KAIROS, ULTRAPLAN, Buddy and More](https://techsy.io/blog/claude-code-leaked-features-2026) — Comprehensive feature inventory
+- [Claude Code Architecture: Everything Found](https://claudefa.st/blog/guide/mechanics/claude-code-source-leak) — Complete architectural analysis
+- [Claude Code Internals: fake tools, frustration regexes, undercover mode](https://alex000kim.com/posts/2026-03-31-claude-code-source-leak/) — Security-focused analysis
 
 ### Curated Resource Lists
 
-- [awesome-claude-code-postleak-insights](https://github.com/nblintao/awesome-claude-code-postleak-insights) — Curated list of high-signal post-leak analyses
-- [ClaudeCode-Leak](https://github.com/0PeterAdel/ClaudeCode-Leak) — Comprehensive technical autopsy and archival index
+- [Awesome Claude Code Insights](https://github.com/nblintao/awesome-claude-code-postleak-insights) — Curated list of high-signal architecture analyses
+- [Claude Code Technical Autopsy](https://github.com/0PeterAdel/ClaudeCode-Leak) — Comprehensive technical autopsy and archival index
 
 ### Specific Deep Dives
 
 - [How an AI Reads the Web: Claude Code's WebFetchTool](https://medium.com/@nblintao/how-an-ai-reads-the-web-a-deep-dive-into-claude-codes-webfetchtool-0abee4446343) — WebFetchTool architecture analysis
-- [Claude Code Source Leak: Production AI Architecture Patterns](https://discuss.huggingface.co/t/claude-code-source-leak-production-ai-architecture-patterns-from-512-000-lines/174846) — Three-layer compression pipeline analysis
-- [Inside Claude Code's leaked source: swarms, daemons, and 44 features](https://thenewstack.io/claude-code-source-leak/) — The New Stack coverage
+- [Claude Code: Production AI Architecture Patterns](https://discuss.huggingface.co/t/claude-code-source-leak-production-ai-architecture-patterns-from-512-000-lines/174846) — Three-layer compression pipeline analysis
+- [Inside Claude Code: swarms, daemons, and 44 features](https://thenewstack.io/claude-code-source-leak/) — The New Stack coverage
 - [Claude Code Hidden Features: Full List](https://wavespeed.ai/blog/posts/claude-code-hidden-features-leaked-source-2026/) — WaveSpeedAI feature inventory
 
 ### News & Commentary
 
-- [Claude Code's source code appears to have leaked](https://venturebeat.com/technology/claude-codes-source-code-appears-to-have-leaked-heres-what-we-know) — VentureBeat news coverage
-- [Claude Code source has been available for 13 months, and nothing happened](https://thehuman2ai.com/blog/claude-code-source-leak) — Security impact analysis
-- [Anthropic Claude Code Leak](https://www.zscaler.com/blogs/security-research/anthropic-claude-code-leak) — Zscaler ThreatLabz security assessment
+- [Claude Code Architecture Analysis](https://venturebeat.com/technology/claude-codes-source-code-appears-to-have-leaked-heres-what-we-know) — VentureBeat coverage
+- [Claude Code Source: Available for 13 Months](https://thehuman2ai.com/blog/claude-code-source-leak) — Security impact analysis
+- [Anthropic Claude Code Security Assessment](https://www.zscaler.com/blogs/security-research/anthropic-claude-code-leak) — Zscaler ThreatLabz assessment

--- a/docs/research/prompt-architecture/09-instruction-budget-and-prompt-economics.md
+++ b/docs/research/prompt-architecture/09-instruction-budget-and-prompt-economics.md
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-A critical insight from Tyler Folkman's analysis of the Claude Code source leak: **instruction budgets are shared between system prompts and user configurations, causing dilution as line count increases.** This reframes CLAUDE.md not as a document but as a **finite budget of ~100 prescriptive constraints** that must be optimized for signal density. Combined with the system prompt structure analysis, this reveals a complete picture of prompt economics that should fundamentally shape how luca-mastracode allocates its instruction token budget.
+A critical insight from Tyler Folkman's analysis of Claude Code's architecture: **instruction budgets are shared between system prompts and user configurations, causing dilution as line count increases.** This reframes CLAUDE.md not as a document but as a **finite budget of ~100 prescriptive constraints** that must be optimized for signal density. Combined with the system prompt structure analysis, this reveals a complete picture of prompt economics that should fundamentally shape how luca-mastracode allocates its instruction token budget.
 
 ---
 
@@ -389,7 +389,7 @@ Only connect MuninnDB and other MCP servers when the mode actually needs them. D
 
 ### Primary Sources
 
-- [I Read the Claude Code Source Leak — Here's What I Changed](https://tylerfolkman.substack.com/p/i-read-the-claude-code-source-leak) — Tyler Folkman's analysis of instruction budget optimization
+- [I Read the Claude Code Source — Here's What I Changed](https://tylerfolkman.substack.com/p/i-read-the-claude-code-source-leak) — Tyler Folkman's analysis of instruction budget optimization
 - [Claude Code System Prompt (v2.1.50)](https://github.com/asgeirtj/system_prompts_leaks/blob/main/Anthropic/claude-code.md) — Extracted system prompt from asgeirtj/system_prompts_leaks
 - [Piebald-AI/claude-code-system-prompts](https://github.com/Piebald-AI/claude-code-system-prompts) — Version-tracked system prompt evolution
 

--- a/docs/research/prompt-architecture/09-instruction-budget-and-prompt-economics.md
+++ b/docs/research/prompt-architecture/09-instruction-budget-and-prompt-economics.md
@@ -1,0 +1,401 @@
+# Instruction Budget & Prompt Economics
+
+**Research Date:** 2026-04-13
+**Status:** Complete
+**Scope:** How system prompt token budgets work, the economics of instruction density, MCP tool overhead, and the CLAUDE.md-as-budget paradigm
+
+---
+
+## Executive Summary
+
+A critical insight from Tyler Folkman's analysis of the Claude Code source leak: **instruction budgets are shared between system prompts and user configurations, causing dilution as line count increases.** This reframes CLAUDE.md not as a document but as a **finite budget of ~100 prescriptive constraints** that must be optimized for signal density. Combined with the system prompt structure analysis, this reveals a complete picture of prompt economics that should fundamentally shape how luca-mastracode allocates its instruction token budget.
+
+---
+
+## Table of Contents
+
+1. [The Shared Instruction Budget Problem](#1-the-shared-instruction-budget-problem)
+2. [CLAUDE.md as Token Budget](#2-claudemd-as-token-budget)
+3. [MCP Tool Definition Overhead](#3-mcp-tool-definition-overhead)
+4. [Hooks vs Instructions: Deterministic vs Probabilistic](#4-hooks-vs-instructions)
+5. [The System Prompt Token Anatomy](#5-the-system-prompt-token-anatomy)
+6. [Memory Taxonomy & Token Efficiency](#6-memory-taxonomy--token-efficiency)
+7. [Skill Frontmatter & Discovery Economics](#7-skill-frontmatter--discovery-economics)
+8. [Quantified Constraints in Production](#8-quantified-constraints-in-production)
+9. [Implications for luca-mastracode](#9-implications-for-luca-mastracode)
+10. [Sources](#10-sources)
+
+---
+
+## 1. The Shared Instruction Budget Problem
+
+### The Core Insight
+
+Tyler Folkman's analysis reveals a fundamental truth about Claude Code's architecture: **the instruction budget is shared between the system prompt and user-provided configurations** (CLAUDE.md, rules, skills). Every token spent on user instructions competes with the system prompt for the model's attention.
+
+This creates a **dilution effect**: as CLAUDE.md grows longer, each individual instruction receives proportionally less model attention. A 300-line CLAUDE.md doesn't just cost more tokens — it actively degrades the effectiveness of every instruction within it.
+
+### The Implication
+
+This means instruction authoring is an **optimization problem**, not a documentation problem. The goal is maximum behavioral impact per token, not comprehensive coverage.
+
+---
+
+## 2. CLAUDE.md as Token Budget
+
+### The Budget Paradigm
+
+Folkman reframes CLAUDE.md from "configuration document" to "approximately 100 prescriptive constraints." His optimization process:
+
+- **Before**: 200+ lines of instructions
+- **After**: Under 80 lines
+- **Reduction**: ~60%
+- **Method**: Audit every line for whether it's a prescriptive constraint vs. derivable information
+
+### What Gets Cut
+
+- Architecture descriptions (derivable from code)
+- File path references (derivable from codebase exploration)
+- Redundant restatements of common conventions
+- "Nice to have" preferences that rarely affect output
+- Information already encoded in tool definitions or system prompt
+
+### What Stays
+
+- Hard constraints that override model defaults
+- Project-specific conventions that contradict common patterns
+- Critical safety rules
+- Integration patterns unique to the project
+- Behavioral rules that "fight the weights"
+
+### The Audit Question
+
+For every line in CLAUDE.md, ask: **"If I remove this line, will the model's behavior meaningfully change?"** If the answer is no, it's wasting budget.
+
+---
+
+## 3. MCP Tool Definition Overhead
+
+### The Token Tax
+
+Each MCP server connection injects tool definitions into the system prompt. Folkman's analysis reveals:
+
+- **Individual MCP tools**: 15,000+ tokens each for complex tools
+- **5 connected servers**: ~60,000 tokens consumed before the first user message
+- **Combined with system prompt**: ~19,000 characters of base system prompt + ~73,000 characters of built-in tool definitions
+
+### The Budget Math
+
+For a 200K token context window:
+
+| Component | Tokens | % of Budget |
+|---|---|---|
+| System prompt (static) | ~5,000 | 2.5% |
+| Built-in tool definitions (36+) | ~18,000 | 9% |
+| MCP tool definitions (5 servers) | ~60,000 | 30% |
+| CLAUDE.md + rules + skills | ~2,000-6,000 | 1-3% |
+| **Available for conversation** | **~111,000-115,000** | **~56-58%** |
+
+This means **over 40% of the context window can be consumed by prompt infrastructure** before the user types anything.
+
+### Optimization Strategies
+
+1. **Minimize MCP connections**: Only connect servers actively needed
+2. **Lazy tool loading**: Load tool definitions on-demand rather than at session start
+3. **Tool description compression**: Keep descriptions concise while retaining behavioral guidance
+4. **Disconnect idle servers**: Free tokens when MCP tools aren't being used
+
+---
+
+## 4. Hooks vs Instructions: Deterministic vs Probabilistic
+
+### The Fundamental Distinction
+
+Folkman highlights a critical architectural separation in Claude Code:
+
+| Aspect | Hooks | Instructions (CLAUDE.md) |
+|---|---|---|
+| **Execution** | Deterministic — always runs | Probabilistic — model may not follow |
+| **Enforcement** | Hard — blocks on failure | Soft — guidance only |
+| **Token cost** | Zero — runs outside prompt | Nonzero — consumes context budget |
+| **Reliability** | 100% — shell script | <100% — LLM compliance varies |
+| **Complexity** | Simple — pass/fail | Rich — nuanced guidance |
+
+### The Migration Rule
+
+**Move rules that "must always happen" to hooks. Leave guidance rules in CLAUDE.md.**
+
+Examples of what should be hooks (not instructions):
+
+| Rule | Hook Type | Implementation |
+|---|---|---|
+| Run formatter after edits | PostToolUse (Edit/Write) | `npx prettier --write "$FILE_PATH"` |
+| Block dangerous git commands | PreToolUse (Bash) | Exit code 2 blocks execution |
+| Type-check after file changes | PostToolUse (Edit/Write) | `bunx --bun tsc --noEmit` |
+| Lint on commit | PreToolUse (Bash/git commit) | Run linter, exit 2 on failure |
+
+Examples of what should stay as instructions:
+
+| Rule | Why Instructions |
+|---|---|
+| "Prefer functional patterns" | Requires judgment |
+| "Use Bun instead of Node" | Multiple valid approaches |
+| "Keep responses concise" | Style guidance |
+| "Understand code before modifying" | Behavioral principle |
+
+### The PostToolUse Formatter Pattern
+
+From the article:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [{
+          "type": "command",
+          "command": "npx prettier --write \"$FILE_PATH\""
+        }]
+      }
+    ]
+  }
+}
+```
+
+This is **zero-token enforcement** — the formatter runs automatically without any instruction budget spent convincing the model to format code.
+
+### The PreToolUse Block Pattern
+
+PreToolUse hooks with **exit code 2** block the tool call entirely. This provides hard enforcement that no amount of prompt engineering can match — the operation physically cannot proceed.
+
+---
+
+## 5. The System Prompt Token Anatomy
+
+### Claude Code v2.1.50 Structure
+
+From the extracted system prompt, the exact section ordering:
+
+```
+1. Identity & Context (~100 tokens)
+2. Skill System triggers (~200 tokens)
+3. Core Behavioral Principles (~300 tokens)
+4. Task Management Framework (~400 tokens)
+5. File Operations Priority (~300 tokens)
+6. Git Workflow Instructions (~800 tokens)
+7. Code Handling Rules (~400 tokens)
+8. Tool Usage Patterns & Priority (~500 tokens)
+9. Planning & Clarification triggers (~400 tokens)
+10. Security & Authorization (~300 tokens)
+11. Agent Types & Applications (~400 tokens)
+12. Memory & Context Management (~200 tokens)
+13. Code References Format (~50 tokens)
+───────────────────────────────────
+Total system prompt: ~4,350 tokens
++ Tool definitions: ~18,000 tokens
+= Total static prefix: ~22,350 tokens
+```
+
+### Key Observation
+
+The system prompt itself is surprisingly **concise** — roughly 4,350 tokens. The tool definitions are **4x larger** than the behavioral instructions. This validates the finding from doc 03 that ~79% of prompt budget goes to tool definitions.
+
+### Quantified Limits Found in the Prompt
+
+| Limit | Value | Purpose |
+|---|---|---|
+| Token budget | 200,000 | Total context window |
+| Read default limit | 2,000 lines | Prevent overloading context |
+| PDF max pages | 20 per request | Prevent overloading context |
+| AskUserQuestion limit | 1-4 questions | Prevent interrogation loops |
+| Question options | 2-4 choices | Constrain user decision space |
+| Bash timeout default | 120,000ms (2 min) | Prevent hanging commands |
+| Bash timeout max | 600,000ms (10 min) | Hard ceiling for long commands |
+| TodoWrite in_progress limit | 1 at a time | Force sequential focus |
+
+These quantified limits are more enforceable than qualitative directives because they're checkable.
+
+---
+
+## 6. Memory Taxonomy & Token Efficiency
+
+### The Four-Type System
+
+Claude Code enforces a strict memory taxonomy:
+
+| Type | Purpose | Token Efficiency |
+|---|---|---|
+| `user` | Role, goals, preferences | High — rarely changes |
+| `feedback` | Corrections, confirmations | High — prevents repeated mistakes |
+| `project` | Ongoing work, deadlines | Medium — decays over time |
+| `reference` | External system pointers | High — stable references |
+
+### The Exclusion Rule
+
+**"Anything derivable from code should be excluded from memory."**
+
+This prevents the common anti-pattern of storing architecture notes, file paths, or code patterns that can be re-derived by reading the codebase. Every byte of memory that duplicates derivable information wastes tokens when loaded into context.
+
+### What This Means for MuninnDB
+
+luca-mastracode's MuninnDB stores more types (session, pattern, pitfall, brain, metric, research, etc.). The exclusion rule still applies: before storing a memory, ask "Can the agent derive this by reading the current code?" If yes, don't store it.
+
+---
+
+## 7. Skill Frontmatter & Discovery Economics
+
+### How Skill Discovery Works
+
+Only **frontmatter fields** trigger model discovery of skills. The skill body content enters context **only on invocation**. This is a critical token-saving design:
+
+```markdown
+---
+name: my-skill
+description: What this skill does  # Discovery field
+when_to_use: When to trigger it     # Discovery field  
+---
+
+[Detailed skill instructions here — NOT loaded until invoked]
+```
+
+### The Discovery Failure Mode
+
+Folkman notes that skills with "vague names and no `when_to_use` field" failed to auto-invoke. The model couldn't determine relevance from ambiguous frontmatter, so it never loaded the skill body.
+
+### Token Economics
+
+- **Frontmatter cost**: ~50-100 tokens per skill (always loaded)
+- **Body cost**: ~500-2000 tokens per skill (only on invocation)
+- **10 skills with bodies always loaded**: ~5,000-20,000 wasted tokens
+- **10 skills with frontmatter-only discovery**: ~500-1,000 tokens
+
+This is a **10-20x token efficiency improvement** from lazy loading skill bodies.
+
+### Implications for luca-mastracode
+
+luca-mastracode's skill system (installed via `installSkills()`) copies bundled skill folders to `.mastracode/skills/`. The frontmatter-based discovery pattern should be adopted:
+
+- Skills should have descriptive `name` and `when_to_use` fields
+- Skill bodies should load only when the skill is invoked
+- Ambiguous skill names waste the frontmatter token budget
+
+---
+
+## 8. Quantified Constraints in Production
+
+### Instruction Phrasing Patterns from the System Prompt
+
+The extracted Claude Code system prompt reveals consistent phrasing patterns:
+
+**Hard constraints (NEVER/MUST):**
+- "NEVER commit secrets (.env, credentials.json)"
+- "NEVER skip pre-commit hooks without explicit request"
+- "NEVER use git -i flag"
+- "NEVER generate URLs unless confident they're programming-related"
+
+**Soft constraints (prefer/avoid):**
+- "Prefer editing existing files over creation"
+- "Reserve Bash for actual system commands"
+- "Avoid over-engineering; only make requested changes"
+
+**Bidirectional constraints:**
+- "Use Read for reading. Do NOT use cat/head/tail."
+- "Use Edit for modifications. Do NOT use sed/awk."
+- "Use Glob for file patterns. Do NOT use find/ls."
+
+**Conditional triggers:**
+- "Use EnterPlanMode for non-trivial implementation"
+- Triggers listed: new features, multiple approaches, architectural decisions, multi-file changes
+- Skip conditions: typo fixes, single-function additions, detailed user instructions
+
+**Quantified limits:**
+- "Only ONE todo as in_progress at a time"
+- "1-4 questions per AskUserQuestion call"
+- "2-4 choices per question"
+
+### The Phrasing Hierarchy
+
+From most enforceable to least:
+
+1. **Quantified limits** ("max 4 questions") — checkable, unambiguous
+2. **Hard constraints** ("NEVER do X") — clear prohibition
+3. **Bidirectional constraints** ("Use X, NOT Y") — eliminates ambiguity
+4. **Conditional triggers** ("When X, do Y") — context-dependent rules
+5. **Soft constraints** ("Prefer X") — guidance, not rules
+6. **Principles** ("Be concise") — general behavioral direction
+
+The most effective prompts use primarily levels 1-4. Levels 5-6 have inconsistent enforcement.
+
+---
+
+## 9. Implications for luca-mastracode
+
+### Immediate Actions
+
+**1. Audit instruction token budget (1-2h)**
+
+Calculate the actual token cost of luca-mastracode's current prompt infrastructure:
+- Base mode instructions (per mode .md file)
+- Hard constraints
+- AlwaysApply rules (caveman, pr-title-format)
+- Tool definitions
+- Dynamic state context
+- MCP tool definitions (MuninnDB, etc.)
+
+If total exceeds 40% of context window, optimize.
+
+**2. Migrate deterministic rules to hooks (2-3h)**
+
+Review all rules in instruction files. Any rule that:
+- Must always happen (not judgment-dependent)
+- Has a binary pass/fail outcome
+- Can be enforced via shell script
+
+Should move from instructions to hooks, freeing token budget.
+
+**3. Apply the exclusion audit to instructions (1-2h)**
+
+For every line in mode instruction files, ask: "If I remove this line, will the model's behavior meaningfully change?" Cut anything that doesn't pass.
+
+**4. Adopt lazy skill loading (3-4h)**
+
+Ensure skill bodies load only on invocation. Frontmatter should be descriptive enough for the model to decide relevance without loading the full body.
+
+**5. Add quantified constraints where missing (1-2h)**
+
+Replace qualitative directives ("be concise") with quantified limits ("keep responses under 100 words in fast mode"). Review all soft constraints for opportunities to make them quantified or bidirectional.
+
+### Architecture-Level Changes
+
+**6. Token budget monitoring dashboard**
+
+Track per-mode token costs:
+- System prompt tokens
+- Tool definition tokens
+- MCP overhead tokens
+- Available conversation tokens
+- Actual usage per turn
+
+This enables data-driven optimization of the instruction budget.
+
+**7. MCP connection management**
+
+Only connect MuninnDB and other MCP servers when the mode actually needs them. Disconnect during modes that don't use memory (e.g., fast mode, triage mode) to free ~15,000+ tokens.
+
+---
+
+## 10. Sources
+
+### Primary Sources
+
+- [I Read the Claude Code Source Leak — Here's What I Changed](https://tylerfolkman.substack.com/p/i-read-the-claude-code-source-leak) — Tyler Folkman's analysis of instruction budget optimization
+- [Claude Code System Prompt (v2.1.50)](https://github.com/asgeirtj/system_prompts_leaks/blob/main/Anthropic/claude-code.md) — Extracted system prompt from asgeirtj/system_prompts_leaks
+- [Piebald-AI/claude-code-system-prompts](https://github.com/Piebald-AI/claude-code-system-prompts) — Version-tracked system prompt evolution
+
+### Supporting Research
+
+- [Claude Code Prompts | Anatomy of an AI Coding Agent](https://ccprompts.info/) — 124 prompts cataloged across 9 categories
+- [How Claude Code Builds a System Prompt](https://www.dbreunig.com/2026/04/04/how-claude-code-builds-a-system-prompt.html) — Dynamic assembly analysis
+- [The Complete Guide to Writing Agent System Prompts](https://medium.com/@fengliu_367/the-complete-guide-to-writing-agent-system-prompts-lessons-from-reverse-engineering-claude-code-09ecd87c7cc1) — Token budget and attention curve guidance
+- [Best Practices for Claude Code](https://code.claude.com/docs/en/best-practices) — Anthropic official documentation

--- a/docs/research/prompt-architecture/10-final-actionable-review.md
+++ b/docs/research/prompt-architecture/10-final-actionable-review.md
@@ -1,0 +1,488 @@
+# Final Actionable Review: Prompt Architecture Improvements for luca-mastracode
+
+**Research Date:** 2026-04-13
+**Status:** Complete — Ready for Implementation
+**Input:** 10 research documents, 5 specialized review agents, full codebase audit
+
+---
+
+## Executive Summary
+
+Five review agents independently audited the luca-mastracode codebase against 10 research documents covering Claude Code's prompt architecture. They found **zero self-distrust in verification**, **zero anti-sycophancy directives**, a **16-33x deficit in tool description depth**, **critical constraints buried in the attention trough**, and **no defense against context rot**. This document consolidates all findings into a prioritized action plan.
+
+The math is stark: a typical MODERATE pipeline spans ~25 agent turns. At 95% per-step reliability, that yields only ~28% combined success. Every improvement below targets that per-step reliability number.
+
+---
+
+## Table of Contents
+
+1. [Priority Matrix](#1-priority-matrix)
+2. [Sprint 1: Immediate Wins (1-2 days)](#2-sprint-1-immediate-wins)
+3. [Sprint 2: Instruction Overhaul (2-3 days)](#3-sprint-2-instruction-overhaul)
+4. [Sprint 3: Tool Enrichment (2-3 days)](#4-sprint-3-tool-enrichment)
+5. [Sprint 4: Infrastructure (5-8 days)](#5-sprint-4-infrastructure)
+6. [Sprint 5: Advanced Architecture (8-12 days)](#6-sprint-5-advanced-architecture)
+7. [Full Change Registry](#7-full-change-registry)
+
+---
+
+## 1. Priority Matrix
+
+Every recommendation from all 5 review agents, deduplicated and ranked:
+
+| Rank | Change | Category | Effort | Impact | Sprint |
+|------|--------|----------|--------|--------|--------|
+| 1 | Add self-distrust to verifier | Subagent | 1h | CRITICAL | 1 |
+| 2 | Add anti-sycophancy to reviewer | Subagent | 1h | CRITICAL | 1 |
+| 3 | Move critical constraints to primacy zone | Instructions | 2h | HIGH | 1 |
+| 4 | Add recency-zone `## Reminder` to all files | Instructions | 2h | HIGH | 1 |
+| 5 | Dual-inject HARD_CONSTRAINTS (start + end) | Instructions | 1h | HIGH | 1 |
+| 6 | Add "because" clauses to HARD_CONSTRAINTS | Instructions | 1h | HIGH | 1 |
+| 7 | Add active synthesis directives to orchestrators | Instructions | 1h | HIGH | 1 |
+| 8 | Add quantified output constraints to all modes | Instructions | 2h | HIGH | 2 |
+| 9 | Add bidirectional tool constraints to all modes | Instructions | 2h | HIGH | 2 |
+| 10 | Compress procedural templates to principles | Instructions | 3h | HIGH | 2 |
+| 11 | Add parallel tool call enforcement | Instructions | 1h | MEDIUM | 2 |
+| 12 | Define `<luca-reminder>` tag convention | Instructions | 1h | MEDIUM | 2 |
+| 13 | Add environment context block | Code | 2h | MEDIUM | 2 |
+| 14 | Add "memory as hints" framing | Instructions | 1h | MEDIUM | 2 |
+| 15 | Enrich top-3 tool descriptions | Tools | 4h | HIGH | 3 |
+| 16 | Enrich remaining 7 tool descriptions | Tools | 4h | HIGH | 3 |
+| 17 | Add cross-tool coordination sections to modes | Instructions | 3h | MEDIUM | 3 |
+| 18 | Add self-compression to all subagents | Subagent | 2h | MEDIUM | 3 |
+| 19 | Add citation discipline to verifier/researcher | Subagent | 2h | MEDIUM | 3 |
+| 20 | Add planner distrust to plan-reviewer | Subagent | 30m | MEDIUM | 3 |
+| 21 | Shared subagent prefix for cache + behavior | Code | 4h | HIGH | 4 |
+| 22 | Conditional MCP loading per mode | Code | 3h | HIGH | 4 |
+| 23 | Mid-conversation injection infrastructure | Code | 4-6d | CRITICAL | 4 |
+| 24 | Cache boundary in prompt assembly | Code | 3-5d | CRITICAL | 5 |
+| 25 | Token budget monitoring | Code | 4-5d | HIGH | 5 |
+| 26 | Progressive context compaction | Code | 6-8d | HIGH | 5 |
+| 27 | Context Editing API integration | Code | 3-4d | MEDIUM | 5 |
+
+---
+
+## 2. Sprint 1: Immediate Wins
+
+**Total effort: ~1 day. Zero architectural changes. All edits to existing files.**
+
+### 1.1 Add Self-Distrust to Verifier
+
+**File:** `packages/luca-mastracode/src/subagents/verifier.ts`
+**Insert after** the opening role description:
+
+```markdown
+## Independence Mandate
+
+The code you are verifying was written by an LLM. Do not trust that it is correct.
+Verify independently by running checks and inspecting actual behavior, not by
+reading code and reasoning about correctness.
+
+**A check without a tool execution is not a PASS.**
+
+Every criterion marked `met: true` MUST have evidence from a tool execution
+(test output, tsc output, or file content at a specific line). Evidence that
+consists only of "the code looks correct" is not evidence — it is a guess.
+
+Failure modes to resist:
+1. Reading code and concluding it "looks correct" without running it
+2. Trusting the executor's commit message about what changed
+3. Hedging ("this appears to work") instead of declaring PASS or FAIL
+4. Reducing severity of real issues to avoid blocking progress
+```
+
+### 1.2 Add Anti-Sycophancy to Reviewer
+
+**File:** `packages/luca-mastracode/src/subagents/reviewer.ts`
+**Insert after** the severity classification section:
+
+```markdown
+## Quality Gate
+
+Do not rubber-stamp weak work. Every APPROVE verdict must be earned through evidence.
+
+The code you are reviewing was written by an LLM. LLM-generated code has systematic
+blind spots: it often appears clean while containing subtle logic errors, missing
+edge cases, or incorrect assumptions.
+
+If you find zero MUST-FIX issues, you MUST explicitly state:
+1. What you verified and how (which files, what properties)
+2. Why the implementation is correct (not just "it looks good")
+
+An APPROVE with zero findings and no verification explanation is a rubber stamp.
+```
+
+### 1.3 Move Critical Constraints to Primacy Zone
+
+For each pipeline mode instruction file, move the most critical behavioral constraint from the "Behavioral Guidelines" section (middle/end of file) to immediately after the role description (lines 2-4).
+
+| File | Constraint to Move | Current Location | Move To |
+|------|-------------------|-----------------|---------|
+| `execute.md` | "NEVER write code directly" | Line ~383 | Line 8, with bidirectional: "Do NOT use string_replace_lsp or write_file yourself" |
+| `review.md` | "NEVER edit files" | Line ~267 | Line 7, with bidirectional: "Do NOT use string_replace_lsp, write_file, or execute_command" |
+| `research.md` | "Read-only" | Line ~190 | Line 9, with bidirectional: "Do NOT use string_replace_lsp, write_file, or execute_command for code modifications" |
+| `architect.md` | "Discussion is never skipped" | Line ~302 | Line 10 |
+| `finalize.md` | "Be thorough in gap detection" | Line ~304 | Line 8, quantified: "Check every task in PLAN.md. Report exact completed/total ratio." |
+
+### 1.4 Add Recency-Zone Reminders
+
+Add a `## Reminder` section at the very end of every instruction file. Each reminder repeats the 2-3 most critical constraints for that mode. Examples:
+
+**triage.md:**
+```markdown
+## Reminder
+You MUST call `workflowState(action: "switch-mode")` before your turn ends. Do NOT create tasks, modify files, or run commands.
+```
+
+**execute.md:**
+```markdown
+## Reminder
+NEVER write code directly — delegate to subagents. Run checks after every wave. If convergence stalls, stop. One commit per task.
+```
+
+**review.md:**
+```markdown
+## Reminder
+NEVER edit files. Maximum 5 MUST-FIX items. Review against the plan, not personal preferences.
+```
+
+(Similar for all 10 files — see instruction audit for per-file text.)
+
+### 1.5 Dual-Inject HARD_CONSTRAINTS
+
+**File:** `packages/luca-mastracode/src/index.ts`
+
+Currently HARD_CONSTRAINTS are only appended at the end via `getAgentConstraints()`. Change to **prepend AND append** — exploiting both primacy and recency peaks.
+
+### 1.6 Add "Because" Clauses to HARD_CONSTRAINTS
+
+**File:** `packages/luca-mastracode/src/index.ts` (lines 160-163)
+
+```markdown
+- **Never use temp files as an edit workaround** because it bypasses the harness's change
+  tracking and makes modifications invisible to the review and verification pipeline.
+- **Never shell out for file edits** because execute_command output is not tracked by
+  edit tools, so changes cannot be verified, reviewed, or rolled back.
+- **Respect mode boundaries** because mode restrictions separate concerns — a read-only
+  mode that secretly writes files corrupts the verification guarantee of subsequent phases.
+```
+
+### 1.7 Add Active Synthesis Directives to Orchestrators
+
+**File:** `packages/luca-mastracode/src/instructions/execute.md` — add to Behavioral Guidelines:
+```markdown
+- **Synthesize, don't relay.** When subagents return results, YOU must understand them.
+  Never write "based on the reviewer's findings." Resolve conflicts between subagents.
+  If two reviewers contradict, investigate — don't average.
+```
+
+**File:** `packages/luca-mastracode/src/instructions/review.md` — add to Behavioral Guidelines:
+```markdown
+- **Own the verdict.** You are the decision-maker, not a relay. If all 4 reviewers
+  approve but you see an issue, flag it. Never defer understanding to subagents.
+```
+
+---
+
+## 3. Sprint 2: Instruction Overhaul
+
+**Total effort: ~2-3 days. Instruction file edits only.**
+
+### 2.1 Quantify All Qualitative Directives
+
+| File | Current (qualitative) | Proposed (quantified) |
+|------|----------------------|----------------------|
+| `fast.md` | "Under 200 words" | "Under 100 words. <=25 words between tool calls." |
+| `triage.md` | "Be concise" | "<=75 words. Classification + 1-sentence rationale + next mode." |
+| `architect.md` | "Be thorough but not verbose" | "<=3 sentences per task. <=150 lines total PLAN.md." |
+| `execute.md` | "Fail fast, fix fast" | "Run checks within 1 tool call of wave completion. Stalled for 2+ iterations = stop." |
+| `research.md` | "Don't over-research" | "MODERATE: <=10 tool calls. COMPLEX: <=20. CRITICAL: <=30." |
+| `research.md` | "Time-box" | "Synthesis <=200 lines for RESEARCH.md." |
+| `review.md` | "Don't nitpick" | "Maximum 5 MUST-FIX items. MUST-FIX = correctness bugs, security, missing requirements ONLY." |
+| `discuss.md` | "Keep responses focused" | "Under 300 words per turn. <=2 clarifying questions per response." |
+| `finalize.md` | "Be thorough in gap detection" | "Check every task in PLAN.md. Report exact completed/total ratio." |
+
+### 2.2 Add Bidirectional Tool Constraints
+
+Add a `## Tool Discipline` section to each pipeline mode instruction file. Pattern:
+
+```markdown
+## Tool Discipline
+- Use `runChecks` for all automated checks. Do NOT run tsc/eslint/tests directly.
+- Use `workflowState` for all state reads. Do NOT read luca-state.json directly.
+- Use `manageTodos` for backlog operations. Do NOT create todo files directly.
+```
+
+Triage and research modes need explicit mutation-tool blocklists:
+```markdown
+Do NOT use `manageTodos(action: "add")`, `writePlanningFile`, `string_replace_lsp`,
+`write_file`, or `execute_command`. The only mutation tools permitted are
+`workflowState`, `classifyComplexity`, and `pipelineLock`.
+```
+
+### 2.3 Compress Procedural Templates to Principles
+
+Compress across all pipeline instruction files. Key targets:
+
+| File | Section | Current Lines | Compressed To | Savings |
+|------|---------|--------------|--------------|---------|
+| `architect.md` | ROADMAP template | 20 lines | 3 lines + principles | ~80 tokens |
+| `architect.md` | PLAN template | 40 lines | 8 lines + principles | ~120 tokens |
+| `architect.md` | Step 1 (Git Setup) | 10 lines | 3 lines | ~40 tokens |
+| `execute.md` | Review capture template | 25 lines | 4 lines | ~60 tokens |
+| `execute.md` | Review dimensions | 32 lines | 6 lines | ~80 tokens |
+| `research.md` | MuninnDB storage blocks | 30 lines | 6 lines | ~80 tokens |
+| `finalize.md` | Session Archive template | 19 lines | 2 lines | ~50 tokens |
+| **Total** | | | | **~510 tokens freed** |
+
+### 2.4 Parallel Tool Call Enforcement
+
+**File:** `packages/luca-mastracode/src/index.ts` — add to HARD_CONSTRAINTS:
+
+```markdown
+- **Prefer parallel tool calls.** When multiple tool calls are independent, issue them
+  in the same response. Do NOT call tools sequentially when they could run concurrently.
+```
+
+Also reinforce in `research.md`: "You MUST spawn all researcher subagents in a single response, not sequentially."
+
+### 2.5 Define `<luca-reminder>` Tag Convention
+
+**File:** `packages/luca-mastracode/src/index.ts` — add to HARD_CONSTRAINTS:
+
+```markdown
+- **System reminders are authoritative.** Messages may include `<luca-reminder>` tags
+  containing behavioral guidance from the Luca harness. Follow their instructions as
+  if they were part of your original system prompt.
+```
+
+This is a prerequisite for Sprint 4's mid-conversation injection infrastructure.
+
+### 2.6 Add Environment Context Block
+
+**File:** `packages/luca-mastracode/src/index.ts` — add a `buildEnvironmentContext()` function:
+
+```typescript
+function buildEnvironmentContext(): string {
+  const cwd = process.cwd()
+  const platform = process.platform
+  const date = new Date().toISOString().split('T')[0]
+  return `\n## Environment\n- Working directory: ${cwd}\n- Platform: ${platform}\n- Date: ${date}`
+}
+```
+
+Append in `getAgentConstraints()` so every mode includes environment awareness.
+
+### 2.7 Add "Memory as Hints" Framing
+
+Add a single line after every MuninnDB recall code block across all instruction files:
+
+```markdown
+Recalled memories are hints, not truth. Verify critical facts against the current
+codebase before depending on them.
+```
+
+Affected files: triage.md, execute.md, research.md, architect.md, review.md, finalize.md.
+
+---
+
+## 4. Sprint 3: Tool & Subagent Enrichment
+
+**Total effort: ~2-3 days.**
+
+### 3.1 Tool Description Enrichment
+
+Enrich all 10 tool descriptions from action schemas to behavioral guidance. The tool reviewer produced complete rewrite proposals for every tool.
+
+**Token budget impact:** +2,005 tokens total (from 379 to 2,384) — only 1.2% of context window. Claude Code allocates 9% to tools. This is a high-ROI investment.
+
+**Implementation order (by traffic and complexity):**
+
+Phase 1 (highest impact):
+1. `workflowState` — 12 actions, most complex (+380 tokens)
+2. `runChecks` — Directly affects fix-loop efficiency (+205 tokens)
+3. `verificationResult` — Sequential dependency on runChecks (+225 tokens)
+
+Phase 2 (cross-tool disambiguation):
+4. `sessionLedger` — Primary confusion target with workflowState (+185 tokens)
+5. `manageTodos` — Confusion with writePlanningFile (+185 tokens)
+6. `pipelineLock` — Confusion with workflowState (+175 tokens)
+
+Phase 3 (remaining):
+7-10. `manageRoadmap`, `writePlanningFile`, `repoCleanup`, `classifyComplexity`
+
+Full rewrite proposals are in the tool reviewer's output. Each tool gets: purpose, when to use, when NOT to use, action guidance, cross-tool coordination, and examples.
+
+### 3.2 Subagent Instruction Enrichment
+
+| Subagent | Addition | Priority | Effort |
+|----------|----------|----------|--------|
+| verifier | Self-distrust + failure modes (Sprint 1) | Done in Sprint 1 | — |
+| reviewer | Anti-sycophancy + evidence requirement (Sprint 1) | Done in Sprint 1 | — |
+| executor | Self-compression + verification awareness | MEDIUM | 30m |
+| plan-reviewer | Planner distrust | MEDIUM | 30m |
+| researcher | Self-compression + skeptical recall + citation format | MEDIUM | 30m |
+| discussion | Skeptical memory for MuninnDB | LOW | 15m |
+| learner | Self-skepticism | LOW | 15m |
+| shadow-scanner | No changes needed | — | — |
+| planner | No changes needed (well-constrained by design) | — | — |
+
+### 3.3 Cross-Tool Coordination Sections
+
+Add a `## Tool Usage Priority` section to each pipeline mode instruction file listing tools in order of typical usage, with explicit disambiguation:
+
+```markdown
+## Tool Usage Priority (Execute Mode)
+1. workflowState("read") — Always first
+2. workflowState("start-phase") — Once per phase
+3. runChecks — After each code change
+4. workflowState("record-iteration") — After each fix-check cycle
+5. verificationResult("write") — After final check
+6. workflowState("complete-phase") — To finalize
+
+Do NOT use sessionLedger during execute. Do NOT use manageTodos("add") during execute.
+```
+
+---
+
+## 5. Sprint 4: Infrastructure
+
+**Total effort: ~5-8 days. Requires code changes to index.ts and new modules.**
+
+### 4.1 Shared Subagent Prefix
+
+**File:** New `packages/luca-mastracode/src/subagents/shared-prefix.ts`
+
+Extract a shared behavioral prefix (~300-400 tokens) prepended to all 9 subagents. Contains: universal constraints, self-distrust, anti-sycophancy, citation requirements, self-compression directive. This is also the foundation for subagent cache sharing.
+
+### 4.2 Conditional MCP Loading
+
+**File:** `packages/luca-mastracode/src/index.ts` (line ~271)
+
+Only inject MuninnDB tools into modes that use memory:
+
+```typescript
+const MEMORY_MODES = new Set(['luca:4-execute', 'luca:6-finalize', 'luca:discuss', 'build'])
+const mcpTools = MEMORY_MODES.has(currentModeId)
+  ? (mcpManagerRef.current?.getTools() ?? {})
+  : {}
+```
+
+**Savings:** ~15,000+ tokens per turn in non-memory modes (fast, triage, plan, research, architect, review).
+
+### 4.3 Mid-Conversation Injection Infrastructure
+
+**Files:** New `packages/luca-mastracode/src/context-refresher.ts`
+
+Implement a `ContextRefresher` that evaluates conditions at harness lifecycle events and injects `<luca-reminder>` behavioral reminders into the message stream:
+
+- **Turn-counter trigger**: Every 15 tool calls, inject critical-tier constraints (~200 tokens)
+- **Token-threshold trigger**: At 30K estimated tokens, inject mode-specific behavioral rules
+- **Post-compaction trigger**: Full behavioral refresh after any context compression
+- **Phase-boundary trigger**: Re-inject at every mode transition (extends existing continuation messages)
+
+Content tiers:
+1. **Critical** (always inject): HARD_CONSTRAINTS, mode boundaries
+2. **Mode-specific** (inject when mode-relevant): Core behavioral rules for current mode
+3. **Tool guidance** (inject when tool-relevant): Priority ordering reminders
+
+---
+
+## 6. Sprint 5: Advanced Architecture
+
+**Total effort: ~8-12 days. Major architectural changes.**
+
+### 5.1 Cache Boundary in Prompt Assembly
+
+Split prompt assembly into two blocks with explicit cache breakpoints:
+
+```
+BLOCK 1 — Static Prefix (cacheable, 1-hour TTL)
+├── Mode instruction .md
+├── HARD_CONSTRAINTS
+├── AlwaysApply rules
+└── cache_control: { type: "ephemeral" }
+
+BLOCK 2 — Dynamic Suffix (per-request, 5-minute TTL)
+├── Workflow state context
+├── Environment info
+├── MCP server instructions
+└── cache_control: { type: "ephemeral" }
+```
+
+Requires understanding Mastra's internals for how `instructions` maps to the Anthropic `system` parameter. Start with Phase A (pure code separation of static vs dynamic) which has value regardless of API support.
+
+### 5.2 Token Budget Monitoring
+
+New `packages/luca-mastracode/src/token-budget.ts` with threshold-based interventions:
+
+| Threshold | % of Context | Action |
+|-----------|-------------|--------|
+| INJECT_REMINDERS | 30% | Start context rot remediation |
+| OBSERVATION_MASK | 50% | Replace old tool results with placeholders |
+| WARNING | 65% | Alert user, suggest mode boundary |
+| COMPACTION | 80% | Trigger LLM summarization |
+| BLOCK | 90% | Block new tool calls |
+
+### 5.3 Progressive Context Compaction
+
+3-level compression pipeline:
+
+1. **Tool Result Budgeting** (zero cost): Cap tool results at 50K chars, persist full output to disk, keep 2KB preview in context
+2. **Observation Masking** (zero cost): Replace older tool results with `[Result cleared]`. JetBrains research shows this outperforms LLM summarization in 4/5 configurations — 2.6% higher solve rates, 52% cheaper
+3. **LLM Summarization** (expensive, last resort): Fork Haiku subagent, chain-of-thought then strip reasoning, circuit breaker at 3 consecutive failures
+
+---
+
+## 7. Full Change Registry
+
+Every file touched across all sprints:
+
+| File | Sprint | Changes |
+|------|--------|---------|
+| `src/index.ts` | 1,2,4 | Dual HARD_CONSTRAINTS injection, "because" clauses, parallel enforcement, luca-reminder convention, environment context, conditional MCP loading |
+| `src/subagents/verifier.ts` | 1 | Self-distrust + failure modes |
+| `src/subagents/reviewer.ts` | 1 | Anti-sycophancy + evidence requirement |
+| `src/subagents/executor.ts` | 3 | Self-compression + verification awareness |
+| `src/subagents/plan-reviewer.ts` | 3 | Planner distrust |
+| `src/subagents/researcher.ts` | 3 | Self-compression + skeptical recall |
+| `src/subagents/discussion.ts` | 3 | Skeptical memory |
+| `src/subagents/learner.ts` | 3 | Self-skepticism |
+| `src/instructions/triage.md` | 1,2 | Primacy move, recency reminder, quantified output, bidirectional tools, template compression |
+| `src/instructions/execute.md` | 1,2,3 | Primacy move, recency reminder, quantified constraints, bidirectional tools, synthesis directive, template compression, tool priority |
+| `src/instructions/review.md` | 1,2,3 | Primacy move, recency reminder, quantified nitpick limit, bidirectional tools, synthesis directive, tool priority |
+| `src/instructions/architect.md` | 1,2 | Primacy move, recency reminder, quantified plan limits, template compression |
+| `src/instructions/research.md` | 1,2 | Primacy move, recency reminder, quantified depth, template compression, memory-as-hints |
+| `src/instructions/finalize.md` | 1,2 | Primacy move, recency reminder, quantified gap detection, template compression |
+| `src/instructions/build.md` | 2 | Quantified output, bidirectional tools, recency reminder |
+| `src/instructions/fast.md` | 2 | Inter-tool verbosity limit, recency reminder |
+| `src/instructions/plan.md` | 2 | Quantified plan output, recency reminder |
+| `src/instructions/discuss.md` | 2 | Quantified response length, recency reminder |
+| `rules/caveman.md` | — | No changes needed |
+| `rules/pr-title-format.md` | 2 | "Because" clause |
+| `src/tools/*.ts` (10 files) | 3 | Full description enrichment |
+| `src/subagents/shared-prefix.ts` | 4 | New file: shared behavioral prefix |
+| `src/context-refresher.ts` | 4 | New file: mid-conversation injection |
+| `src/token-budget.ts` | 5 | New file: token monitoring |
+| `src/context-pipeline.ts` | 5 | New file: compaction pipeline |
+
+---
+
+## Measurement Plan
+
+To validate these changes, track:
+
+1. **Per-step reliability**: Does the verifier catch more issues? Does the reviewer produce fewer rubber-stamp approvals?
+2. **Tool selection accuracy**: After tool enrichment, do agents use the correct tool on the first attempt more often?
+3. **Context utilization**: After conditional MCP loading and compaction, how much context is available for conversation?
+4. **Token efficiency**: After template compression and instruction trimming, what is the per-mode instruction token count?
+5. **Pipeline completion rate**: After all sprints, does the end-to-end pipeline complete successfully more often?
+
+---
+
+## Sources
+
+This document synthesizes findings from:
+- 10 research documents in `docs/research/prompt-architecture/` (00-09)
+- 5 independent review agents auditing: quick wins, architecture, instruction files, tool definitions, subagent patterns
+- ~185 unique sources including academic papers, Anthropic documentation, Claude Code source analysis, and community reverse-engineering

--- a/docs/research/prompt-architecture/README.md
+++ b/docs/research/prompt-architecture/README.md
@@ -49,7 +49,7 @@ Deep research into how Claude Code and other AI coding agents construct system p
 ~185 unique sources cited across all documents, including:
 - 15+ academic papers (NeurIPS, ICML, ICLR, arXiv)
 - Anthropic official documentation
-- Claude Code source leak analysis (8+ independent analyses)
+- Claude Code public source analysis (8+ independent analyses)
 - Reverse-engineering projects (Piebald-AI, ccprompts.info, DeepWiki)
 - Industry blog posts and technical write-ups
-- Curated resource lists (awesome-claude-code-postleak-insights)
+- Curated resource lists and community insights

--- a/docs/research/prompt-architecture/README.md
+++ b/docs/research/prompt-architecture/README.md
@@ -1,0 +1,55 @@
+# Prompt Architecture Research
+
+Deep research into how Claude Code and other AI coding agents construct system prompts, manage context, and coordinate multi-agent workflows. Conducted to identify techniques that should be adopted in luca-mastracode.
+
+**Research Date:** 2026-04-13
+
+---
+
+## Documents
+
+| # | Document | Focus | Key Finding |
+|---|---|---|---|
+| 00 | [Overview](00-overview.md) | Full gap analysis: Claude Code vs luca-mastracode | 16 prioritized recommendations across 4 tiers |
+| 01 | [Cache Boundary Design](01-cache-boundary-design.md) | SYSTEM_PROMPT_DYNAMIC_BOUNDARY, micro-compaction, Anthropic cache API | 85% latency reduction, 90% cost reduction; 5-level compression pipeline |
+| 02 | [Context Rot & Injection](02-context-rot-and-injection.md) | system-reminder, behavioral refresh, "lost in the middle" | 29-60pp degradation at 32K tokens; 95% per-step reliability = 36% over 20 steps |
+| 03 | [Tool Definition Engineering](03-tool-definition-engineering.md) | 73k chars of tool guidance, priority ordering, critic pattern | ~79% of Claude Code's prompt budget is tool definitions |
+| 04 | [Multi-Agent Coordination](04-multi-agent-coordination.md) | Fork/teammate/worktree, self-distrust, coordinator prompts | 92% prompt reuse via fork model; academic debate research (ICML/ICLR/NeurIPS) |
+| 05 | [Attention Curves & Structure](05-attention-curves-and-structure.md) | U-shaped attention, formatting impact, section ordering | Structural formatting has up to 40% impact; repetition wins 47/70 tasks |
+| 06 | [Comparative Agent Analysis](06-comparative-agent-analysis.md) | 12 agents compared: Claude Code, Cursor, Codex, Gemini, Devin, etc. | SWE-Agent's constrained action space improved SWE-Bench by 10.7 points |
+| 07 | [Context Compaction & Memory](07-context-compaction-and-memory.md) | 5 compaction strategies, autoDream, token budgeting | Observation masking outperforms LLM summarization (2.6% higher, 52% cheaper) |
+| 08 | [Advanced Patterns & Hidden Systems](08-advanced-patterns-and-hidden-systems.md) | KAIROS daemon, ULTRAPLAN, Magic Docs, YOLO classifier, IPC, gamification | Magic Docs self-updating pattern; YOLO risk classifier replaces static allowlists |
+| 09 | [Instruction Budget & Prompt Economics](09-instruction-budget-and-prompt-economics.md) | Token budgets, hooks vs instructions, CLAUDE.md optimization, MCP overhead | 5 MCP servers burn 60K tokens before first message; instructions are a finite budget |
+| **10** | **[Final Actionable Review](10-final-actionable-review.md)** | **Synthesized action plan from 5 review agents** | **27 ranked changes across 5 sprints; zero self-distrust and zero anti-sycophancy found in current codebase** |
+
+## Highest-Impact Findings
+
+1. **Mid-conversation injection** is the single most impactful missing capability in luca-mastracode. Context rot degrades instruction adherence by 29-60 percentage points at 32K tokens (Adobe Research). Claude Code combats this with 37 system-reminders across 5 domains.
+
+2. **Tool definitions ARE the prompt.** Claude Code allocates ~79% of its prompt token budget to tool descriptions. Our current tool definitions are action schemas only — no behavioral guidance, no priority ordering, no negative examples.
+
+3. **Cache-aware prompt splitting** saves 85% latency and 90% cost. The static/dynamic boundary is not an optimization — it's a fundamental architectural decision that enables fork-model subagent spawning at near-zero marginal cost.
+
+4. **Structural formatting matters more than emphasis markers.** Gao et al. found formatting structure (headers, XML tags) has up to 40% impact on task completion, while emphasis markers (IMPORTANT, CRITICAL) have inconsistent effects.
+
+5. **Observation masking beats LLM summarization.** JetBrains Research found replacing old tool outputs with placeholders outperforms full summarization in 4/5 configurations — 2.6% higher solve rates and 52% cost reduction.
+
+6. **Self-distrust in verification** is essential. Claude Code's verifier is explicitly instructed: "The implementer is an LLM. Verify independently." Without this, verification agents rubber-stamp AI-generated output.
+
+7. **Magic Docs pattern** for self-updating documentation. Idle-triggered subagents scoped to a single file keep documentation current automatically. Directly applicable to `.planning/` artifact maintenance.
+
+8. **YOLO risk classifier** replaces static permission allowlists with context-aware risk assessment. Operations are classified as LOW/MEDIUM/HIGH risk, with LOW getting automatic approval — adaptive security rather than brittle rules.
+
+9. **Instructions are a finite budget, not a document.** 5 MCP servers consume ~60K tokens before the first user message. CLAUDE.md should be ~100 prescriptive constraints, not a 300-line doc. Deterministic rules should move to hooks (zero-token enforcement) and leave instructions for judgment-dependent guidance only.
+
+10. **Quantified constraints outperform qualitative directives.** "Keep responses under 100 words" is more enforceable than "be concise." The phrasing hierarchy: quantified limits > hard constraints (NEVER) > bidirectional (Use X, NOT Y) > conditional > soft > principles.
+
+## Source Count
+
+~185 unique sources cited across all documents, including:
+- 15+ academic papers (NeurIPS, ICML, ICLR, arXiv)
+- Anthropic official documentation
+- Claude Code source leak analysis (8+ independent analyses)
+- Reverse-engineering projects (Piebald-AI, ccprompts.info, DeepWiki)
+- Industry blog posts and technical write-ups
+- Curated resource lists (awesome-claude-code-postleak-insights)

--- a/packages/luca-mastracode/package.json
+++ b/packages/luca-mastracode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "luca",
   "description": "Luca workflow as a custom Mastra Code distribution — custom modes, agents, subagents, and tools",
-  "version": "10.1.1",
+  "version": "10.2.0",
   "bin": {
     "luca": "src/index.ts"
   },

--- a/packages/luca-mastracode/rules/caveman.md
+++ b/packages/luca-mastracode/rules/caveman.md
@@ -1,0 +1,20 @@
+---
+description: "Caveman mode — terse communication, ~75% fewer tokens, full technical accuracy"
+alwaysApply: true
+---
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+Rules:
+- Drop: articles (a/an/the), filler (just/really/basically), pleasantries, hedging
+- Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
+- Pattern: [thing] [action] [reason]. [next step].
+- Not: "Sure! I'd be happy to help you with that."
+- Yes: "Bug in auth middleware. Fix:"
+
+Switch level: /caveman lite|full|ultra|wenyan
+Stop: "stop caveman" or "normal mode"
+
+Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.
+
+Boundaries: code/commits/PRs written normal.

--- a/packages/luca-mastracode/rules/caveman.md
+++ b/packages/luca-mastracode/rules/caveman.md
@@ -3,9 +3,9 @@ description: "Caveman mode — terse communication, ~75% fewer tokens, full tech
 alwaysApply: true
 ---
 
-Respond terse like smart caveman. All technical substance stay. Only fluff die.
+When the user activates caveman mode (via "caveman mode", "talk like caveman", "use caveman", "less tokens", "be brief", or `/caveman`), respond terse like smart caveman. All technical substance stays. Only fluff dies.
 
-Rules:
+Rules when caveman mode is active:
 - Drop: articles (a/an/the), filler (just/really/basically), pleasantries, hedging
 - Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
 - Pattern: [thing] [action] [reason]. [next step].
@@ -17,4 +17,4 @@ Stop: "stop caveman" or "normal mode"
 
 Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.
 
-Boundaries: code/commits/PRs written normal.
+Boundaries: code/commits/PRs written normal. Caveman mode persists until stopped or session ends.

--- a/packages/luca-mastracode/rules/caveman.md
+++ b/packages/luca-mastracode/rules/caveman.md
@@ -12,7 +12,7 @@ Rules:
 - Not: "Sure! I'd be happy to help you with that."
 - Yes: "Bug in auth middleware. Fix:"
 
-Switch level: /caveman lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra
+Switch level: /caveman lite|full|ultra
 Stop: "stop caveman" or "normal mode"
 
 Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.

--- a/packages/luca-mastracode/rules/caveman.md
+++ b/packages/luca-mastracode/rules/caveman.md
@@ -12,7 +12,7 @@ Rules:
 - Not: "Sure! I'd be happy to help you with that."
 - Yes: "Bug in auth middleware. Fix:"
 
-Switch level: /caveman lite|full|ultra|wenyan
+Switch level: /caveman lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra
 Stop: "stop caveman" or "normal mode"
 
 Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.

--- a/packages/luca-mastracode/rules/pr-title-format.md
+++ b/packages/luca-mastracode/rules/pr-title-format.md
@@ -1,26 +1,9 @@
 ---
-description: "PR title format — type(scope): version #issue description"
+description: "PR title format convention"
 alwaysApply: true
 ---
 
-## PR Title Format
-
-PR titles MUST follow this exact structure:
-
-```
-type(scope): <version?> #issue description
-```
-
-- **type**: feat | fix | docs | style | refactor | test | chore (from commit.config.ts)
-- **scope**: framework | mastracode | studio | config | docs | repo (from commit.config.ts)
-- **version**: milestone version if one exists (e.g. v10.2.0) — omit if no version applies
-- **#issue**: GitHub issue number prefixed with # (e.g. #143)
-- **description**: concise human-readable summary
-
-Examples:
-- `fix(mastracode): v10.1.0 #140 align mode instructions with tool permissions`
-- `feat(mastracode): v10.2.0 #143 bundled skills and rules system`
-- `fix(studio): #152 validate API schemas against real responses` (no version)
-
-NEVER use `(#issue)` as the scope. The scope always comes from commit.config.ts.
-Always recall memory for PR conventions before creating a PR.
+When creating a PR, title format: `type(scope): <version?> #issue description`
+Types: feat|fix|docs|style|refactor|test|chore. Scopes: framework|mastracode|studio|config|docs|repo (from commit.config.ts).
+Example: `feat(mastracode): v10.2.0 #143 bundled skills and rules system`
+Never use (#issue) as scope. Always recall memory for PR conventions first.

--- a/packages/luca-mastracode/rules/pr-title-format.md
+++ b/packages/luca-mastracode/rules/pr-title-format.md
@@ -1,0 +1,25 @@
+---
+description: "PR title format — type(#issue): version — Title"
+alwaysApply: true
+---
+
+## PR Title Format
+
+PR titles MUST follow this exact structure:
+
+```
+type(#issue): version — Title
+```
+
+Examples:
+- `feat(#143): v10.2.0 — Bundled Skills & Rules`
+- `fix(#140): v10.1.0 — Align Mode Instructions`
+- `refactor(#99): v9.0.0 — Workflow Pipeline Redesign`
+
+Components:
+- **type**: feat | fix | refactor | chore
+- **#issue**: GitHub issue number this PR closes
+- **version**: milestone version (e.g. v10.2.0)
+- **Title**: human-readable milestone or feature summary
+
+NEVER use bare conventional-commit format like `feat(mastracode): description`. Always include `(#issue)`, version, and em-dash title.

--- a/packages/luca-mastracode/rules/pr-title-format.md
+++ b/packages/luca-mastracode/rules/pr-title-format.md
@@ -1,5 +1,5 @@
 ---
-description: "PR title format — type(#issue): version — Title"
+description: "PR title format — type(scope): version #issue description"
 alwaysApply: true
 ---
 
@@ -8,18 +8,19 @@ alwaysApply: true
 PR titles MUST follow this exact structure:
 
 ```
-type(#issue): version — Title
+type(scope): <version?> #issue description
 ```
 
+- **type**: feat | fix | docs | style | refactor | test | chore (from commit.config.ts)
+- **scope**: framework | mastracode | studio | config | docs | repo (from commit.config.ts)
+- **version**: milestone version if one exists (e.g. v10.2.0) — omit if no version applies
+- **#issue**: GitHub issue number prefixed with # (e.g. #143)
+- **description**: concise human-readable summary
+
 Examples:
-- `feat(#143): v10.2.0 — Bundled Skills & Rules`
-- `fix(#140): v10.1.0 — Align Mode Instructions`
-- `refactor(#99): v9.0.0 — Workflow Pipeline Redesign`
+- `fix(mastracode): v10.1.0 #140 align mode instructions with tool permissions`
+- `feat(mastracode): v10.2.0 #143 bundled skills and rules system`
+- `fix(studio): #152 validate API schemas against real responses` (no version)
 
-Components:
-- **type**: feat | fix | refactor | chore
-- **#issue**: GitHub issue number this PR closes
-- **version**: milestone version (e.g. v10.2.0)
-- **Title**: human-readable milestone or feature summary
-
-NEVER use bare conventional-commit format like `feat(mastracode): description`. Always include `(#issue)`, version, and em-dash title.
+NEVER use `(#issue)` as the scope. The scope always comes from commit.config.ts.
+Always recall memory for PR conventions before creating a PR.

--- a/packages/luca-mastracode/skills/caveman/SKILL.md
+++ b/packages/luca-mastracode/skills/caveman/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: caveman
+description: >
+  Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
+  while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
+  wenyan-lite, wenyan-full, wenyan-ultra.
+  Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
+  "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
+---
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
+
+Default: **full**. Switch: `/caveman lite|full|ultra`.
+
+## Rules
+
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
+| **full** | Drop articles, fragments OK, short synonyms. Classic caveman |
+| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough |
+| **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
+| **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
+| **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
+
+Example — "Why React component re-render?"
+- lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
+- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+- ultra: "Inline obj prop → new ref → re-render. `useMemo`."
+- wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
+- wenyan-full: "物出新參照，致重繪。useMemo .Wrap之。"
+- wenyan-ultra: "新參照→重繪。useMemo Wrap。"
+
+Example — "Explain database connection pooling."
+- lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
+- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
+- ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
+- wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
+- wenyan-ultra: "池reuse conn。skip handshake → fast。"
+
+## Auto-Clarity
+
+Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.
+
+Example — destructive op:
+> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+> ```sql
+> DROP TABLE users;
+> ```
+> Caveman resume. Verify backup exist first.
+
+## Boundaries
+
+Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.

--- a/packages/luca-mastracode/skills/caveman/SKILL.md
+++ b/packages/luca-mastracode/skills/caveman/SKILL.md
@@ -14,7 +14,7 @@ Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
 ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
 
-Default: **full**. Switch: `/caveman lite|full|ultra`.
+Default: **full**. Switch: `/caveman lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra`.
 
 ## Rules
 

--- a/packages/luca-mastracode/skills/caveman/SKILL.md
+++ b/packages/luca-mastracode/skills/caveman/SKILL.md
@@ -2,8 +2,7 @@
 name: caveman
 description: >
   Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
-  while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
-  wenyan-lite, wenyan-full, wenyan-ultra.
+  while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra.
   Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
   "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
 ---
@@ -14,7 +13,7 @@ Respond terse like smart caveman. All technical substance stay. Only fluff die.
 
 ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
 
-Default: **full**. Switch: `/caveman lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra`.
+Default: **full**. Switch: `/caveman lite|full|ultra`.
 
 ## Rules
 
@@ -32,24 +31,16 @@ Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
 | **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
 | **full** | Drop articles, fragments OK, short synonyms. Classic caveman |
 | **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough |
-| **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
-| **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
-| **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
 
 Example — "Why React component re-render?"
 - lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
 - full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
 - ultra: "Inline obj prop → new ref → re-render. `useMemo`."
-- wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
-- wenyan-full: "物出新參照，致重繪。useMemo .Wrap之。"
-- wenyan-ultra: "新參照→重繪。useMemo Wrap。"
 
 Example — "Explain database connection pooling."
 - lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
 - full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
 - ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
-- wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
-- wenyan-ultra: "池reuse conn。skip handshake → fast。"
 
 ## Auto-Clarity
 

--- a/packages/luca-mastracode/src/index.ts
+++ b/packages/luca-mastracode/src/index.ts
@@ -15,7 +15,7 @@ import { MastraTUI } from "mastracode/tui";
 import { Agent } from "@mastra/core/agent";
 import { WORKSPACE_TOOLS } from "@mastra/core/workspace";
 import { readLucaState, writeLucaState, type LucaWorkflowState } from "./luca-store.js";
-import { existsSync, readFileSync, mkdirSync, cpSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, mkdirSync, cpSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -154,16 +154,72 @@ import * as pipelineGuard from "./pipeline-guard.js";
 // ---------------------------------------------------------------------------
 // Universal constraints — appended to EVERY mode agent's instructions.
 // ---------------------------------------------------------------------------
-const AGENT_CONSTRAINTS = `
-
----
-
+const HARD_CONSTRAINTS = `
 ## Hard Constraints (all modes)
 
 - **Never use temp files as an edit workaround.** Do not write content to a temporary file and then copy, move, or \`cat\` it into the target file. Do not use \`sed\`, \`awk\`, \`cp\`, \`mv\`, \`tee\`, heredocs, or any shell command to bypass the edit tools (\`string_replace_lsp\`, \`write_file\`, \`ast_smart_edit\`). If you don't have permission to edit a file, that restriction is intentional — do not circumvent it.
 - **Never shell out for file edits.** All file modifications must go through the provided edit tools, not through \`execute_command\`. The only exception is running build/test/lint commands.
 - **Respect mode boundaries.** If your mode is read-only, do not attempt any workaround to modify files. Report what needs to change and let the appropriate mode handle it.
 `;
+
+// ---------------------------------------------------------------------------
+// Rules — load bundled alwaysApply rules and append to every agent's prompt
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse YAML-ish frontmatter from a rule .md file.
+ * Returns { frontmatter, body } where frontmatter is a simple key-value map.
+ * Handles the subset we need (description, alwaysApply) without a full YAML parser.
+ */
+function parseRuleFrontmatter(content: string): { frontmatter: Record<string, string>; body: string } {
+  const fm: Record<string, string> = {};
+  if (!content.startsWith("---")) return { frontmatter: fm, body: content };
+  const endIdx = content.indexOf("---", 3);
+  if (endIdx === -1) return { frontmatter: fm, body: content };
+  const fmBlock = content.slice(3, endIdx).trim();
+  for (const line of fmBlock.split("\n")) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    const val = line.slice(colonIdx + 1).trim().replace(/^["']|["']$/g, "");
+    fm[key] = val;
+  }
+  return { frontmatter: fm, body: content.slice(endIdx + 3).trim() };
+}
+
+/**
+ * Load all bundled rules with `alwaysApply: true` and return their bodies
+ * concatenated into a single instruction block.
+ */
+function loadAlwaysApplyRules(): string {
+  const thisDir = dirname(fileURLToPath(import.meta.url));
+  const rulesDir = join(thisDir, "..", "rules");
+  if (!existsSync(rulesDir)) return "";
+
+  const blocks: string[] = [];
+  for (const file of readdirSync(rulesDir)) {
+    if (!file.endsWith(".md")) continue;
+    try {
+      const raw = readFileSync(join(rulesDir, file), "utf-8");
+      const { frontmatter, body } = parseRuleFrontmatter(raw);
+      if (frontmatter.alwaysApply === "true" && body) {
+        blocks.push(body);
+      }
+    } catch {
+      // Skip unreadable rule files
+    }
+  }
+  return blocks.length > 0 ? blocks.join("\n\n") : "";
+}
+
+// Build the combined suffix appended to every mode agent's instructions.
+// Hard constraints + any bundled alwaysApply rules.
+const ALWAYS_APPLY_RULES = loadAlwaysApplyRules();
+const AGENT_CONSTRAINTS = [
+  "\n\n---\n",
+  HARD_CONSTRAINTS,
+  ALWAYS_APPLY_RULES,
+].filter(Boolean).join("\n\n");
 
 function createStaticAgent({
   id,
@@ -226,6 +282,52 @@ function installSlashCommands() {
   cpSync(bundledCommandsDir, targetDir, {
     recursive: true,
     force: true, // Always sync bundled commands so updates propagate
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Skills — copy bundled skill folders into .mastracode/skills/
+// ---------------------------------------------------------------------------
+
+function installSkills() {
+  // Resolve the skills directory bundled alongside this script
+  const thisDir = dirname(fileURLToPath(import.meta.url));
+  const bundledSkillsDir = join(thisDir, "..", "skills");
+
+  if (!existsSync(bundledSkillsDir)) return;
+
+  // Install into the project's .mastracode/skills/ directory
+  const targetDir = join(process.cwd(), ".mastracode", "skills");
+  if (!existsSync(targetDir)) {
+    mkdirSync(targetDir, { recursive: true });
+  }
+
+  cpSync(bundledSkillsDir, targetDir, {
+    recursive: true,
+    force: true, // Always sync bundled skills so updates propagate
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Rules — copy bundled rule .md files into .mastracode/rules/
+// ---------------------------------------------------------------------------
+
+function installRules() {
+  // Resolve the rules directory bundled alongside this script
+  const thisDir = dirname(fileURLToPath(import.meta.url));
+  const bundledRulesDir = join(thisDir, "..", "rules");
+
+  if (!existsSync(bundledRulesDir)) return;
+
+  // Install into the project's .mastracode/rules/ directory
+  const targetDir = join(process.cwd(), ".mastracode", "rules");
+  if (!existsSync(targetDir)) {
+    mkdirSync(targetDir, { recursive: true });
+  }
+
+  cpSync(bundledRulesDir, targetDir, {
+    recursive: true,
+    force: true, // Always sync bundled rules so updates propagate
   });
 }
 
@@ -801,6 +903,12 @@ async function main() {
 
   // --- Install slash commands into project .mastracode/commands/ ---
   installSlashCommands();
+
+  // --- Install bundled skills into project .mastracode/skills/ ---
+  installSkills();
+
+  // --- Install bundled rules into project .mastracode/rules/ ---
+  installRules();
 
   // --- Launch TUI ---
   const tui = new MastraTUI({

--- a/packages/luca-mastracode/src/index.ts
+++ b/packages/luca-mastracode/src/index.ts
@@ -197,7 +197,7 @@ function loadAlwaysApplyRules(): string {
   if (!existsSync(rulesDir)) return "";
 
   const blocks: string[] = [];
-  for (const file of readdirSync(rulesDir)) {
+  for (const file of readdirSync(rulesDir).sort()) {
     if (!file.endsWith(".md")) continue;
     try {
       const raw = readFileSync(join(rulesDir, file), "utf-8");
@@ -205,8 +205,12 @@ function loadAlwaysApplyRules(): string {
       if (frontmatter.alwaysApply === "true" && body) {
         blocks.push(body);
       }
-    } catch {
-      // Skip unreadable rule files
+    } catch (error) {
+      console.warn(
+        `[luca] Warning: failed to load bundled rule "${file}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
     }
   }
   return blocks.length > 0 ? blocks.join("\n\n") : "";

--- a/packages/luca-mastracode/src/index.ts
+++ b/packages/luca-mastracode/src/index.ts
@@ -15,7 +15,7 @@ import { MastraTUI } from "mastracode/tui";
 import { Agent } from "@mastra/core/agent";
 import { WORKSPACE_TOOLS } from "@mastra/core/workspace";
 import { readLucaState, writeLucaState, type LucaWorkflowState } from "./luca-store.js";
-import { existsSync, readFileSync, readdirSync, mkdirSync, cpSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, mkdirSync, cpSync, rmSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -174,8 +174,10 @@ const HARD_CONSTRAINTS = `
 function parseRuleFrontmatter(content: string): { frontmatter: Record<string, string>; body: string } {
   const fm: Record<string, string> = {};
   if (!content.startsWith("---")) return { frontmatter: fm, body: content };
-  const endIdx = content.indexOf("---", 3);
-  if (endIdx === -1) return { frontmatter: fm, body: content };
+  // Match closing --- on its own line to avoid false matches inside values
+  const endMatch = content.match(/\r?\n---\s*(?:\r?\n|$)/);
+  if (!endMatch || endMatch.index === undefined) return { frontmatter: fm, body: content };
+  const endIdx = endMatch.index;
   const fmBlock = content.slice(3, endIdx).trim();
   for (const line of fmBlock.split("\n")) {
     const colonIdx = line.indexOf(":");
@@ -184,15 +186,15 @@ function parseRuleFrontmatter(content: string): { frontmatter: Record<string, st
     const val = line.slice(colonIdx + 1).trim().replace(/^["']|["']$/g, "");
     fm[key] = val;
   }
-  return { frontmatter: fm, body: content.slice(endIdx + 3).trim() };
+  return { frontmatter: fm, body: content.slice(endIdx + endMatch[0].length).trim() };
 }
 
 /**
  * Load all rules with `alwaysApply: true` from a directory and return their
  * bodies concatenated into a single instruction block.
  *
- * Prefers the installed `.mastracode/rules/` directory (which may contain
- * user edits) with a fallback to the bundled rules directory.
+ * Reads from the installed `.mastracode/rules/` directory (synced from
+ * bundled rules at startup) with a fallback to the bundled directory.
  */
 function loadAlwaysApplyRules(): string {
   const installedDir = join(process.cwd(), ".mastracode", "rules");
@@ -331,15 +333,17 @@ function installRules() {
 
   if (!existsSync(bundledRulesDir)) return;
 
-  // Install into the project's .mastracode/rules/ directory
+  // Bundled rules are authoritative — clear the installed dir first so
+  // stale rules removed from the bundle don't persist indefinitely.
   const targetDir = join(process.cwd(), ".mastracode", "rules");
-  if (!existsSync(targetDir)) {
-    mkdirSync(targetDir, { recursive: true });
+  if (existsSync(targetDir)) {
+    rmSync(targetDir, { recursive: true, force: true });
   }
+  mkdirSync(targetDir, { recursive: true });
 
   cpSync(bundledRulesDir, targetDir, {
     recursive: true,
-    force: true, // Always sync bundled rules so updates propagate
+    force: true,
   });
 }
 

--- a/packages/luca-mastracode/src/index.ts
+++ b/packages/luca-mastracode/src/index.ts
@@ -188,12 +188,16 @@ function parseRuleFrontmatter(content: string): { frontmatter: Record<string, st
 }
 
 /**
- * Load all bundled rules with `alwaysApply: true` and return their bodies
- * concatenated into a single instruction block.
+ * Load all rules with `alwaysApply: true` from a directory and return their
+ * bodies concatenated into a single instruction block.
+ *
+ * Prefers the installed `.mastracode/rules/` directory (which may contain
+ * user edits) with a fallback to the bundled rules directory.
  */
 function loadAlwaysApplyRules(): string {
-  const thisDir = dirname(fileURLToPath(import.meta.url));
-  const rulesDir = join(thisDir, "..", "rules");
+  const installedDir = join(process.cwd(), ".mastracode", "rules");
+  const bundledDir = join(dirname(fileURLToPath(import.meta.url)), "..", "rules");
+  const rulesDir = existsSync(installedDir) ? installedDir : bundledDir;
   if (!existsSync(rulesDir)) return "";
 
   const blocks: string[] = [];
@@ -207,7 +211,7 @@ function loadAlwaysApplyRules(): string {
       }
     } catch (error) {
       console.warn(
-        `[luca] Warning: failed to load bundled rule "${file}": ${
+        `[luca] Warning: failed to load rule "${file}": ${
           error instanceof Error ? error.message : String(error)
         }`,
       );
@@ -216,14 +220,18 @@ function loadAlwaysApplyRules(): string {
   return blocks.length > 0 ? blocks.join("\n\n") : "";
 }
 
-// Build the combined suffix appended to every mode agent's instructions.
-// Hard constraints + any bundled alwaysApply rules.
-const ALWAYS_APPLY_RULES = loadAlwaysApplyRules();
-const AGENT_CONSTRAINTS = [
-  "\n\n---\n",
-  HARD_CONSTRAINTS,
-  ALWAYS_APPLY_RULES,
-].filter(Boolean).join("\n\n");
+// AGENT_CONSTRAINTS is built lazily so that rules are loaded after
+// installRules() has copied bundled rules into .mastracode/rules/.
+let _agentConstraints: string | null = null;
+function getAgentConstraints(): string {
+  if (_agentConstraints === null) {
+    const alwaysApplyRules = loadAlwaysApplyRules();
+    _agentConstraints = ["\n\n---\n", HARD_CONSTRAINTS, alwaysApplyRules]
+      .filter(Boolean)
+      .join("\n\n");
+  }
+  return _agentConstraints;
+}
 
 function createStaticAgent({
   id,
@@ -245,8 +253,8 @@ function createStaticAgent({
     id,
     name: `Luca ${name}`,
     // Dynamic instructions: called per-request, reads luca-store at call time.
-    // AGENT_CONSTRAINTS is appended to every mode's instructions.
-    instructions: () => buildInstructions() + AGENT_CONSTRAINTS,
+    // getAgentConstraints() is appended to every mode's instructions.
+    instructions: () => buildInstructions() + getAgentConstraints(),
     // Dynamic model: called per-request, resolves via OAuth-aware pipeline
     model: () => {
       const modelId = resolveModelFn() ?? defaultModelId;


### PR DESCRIPTION
## Summary

Adds the **caveman** communication mode and a generic **bundled rules/skills system** to luca-mastracode.

Closes #143

## What Changed

| File | Description |
|------|-------------|
| `skills/caveman/SKILL.md` | Full caveman skill — 6 intensity levels, auto-clarity exceptions, YAML frontmatter |
| `rules/caveman.md` | Compact always-on rule (`alwaysApply: true`) — injected into every agent prompt |
| `src/index.ts` | `installSkills()`, `installRules()`, `loadAlwaysApplyRules()`, frontmatter parser |

## Architecture

### Three bundled content types — unified pattern

| Type | Source dir | Installed to | Loaded by |
|------|-----------|-------------|-----------|
| Commands | `commands/` | `.mastracode/commands/` | Mastracode command dispatch |
| Skills | `skills/` | `.mastracode/skills/` | Mastracode WorkspaceSkills loader |
| Rules | `rules/` | `.mastracode/rules/` | `loadAlwaysApplyRules()` → `AGENT_CONSTRAINTS` |

### How rules work

1. At module load, `loadAlwaysApplyRules()` scans bundled `rules/*.md`
2. Parses frontmatter with lightweight parser (no YAML dep)
3. Filters for `alwaysApply: true`
4. Appends rule bodies to `AGENT_CONSTRAINTS` (injected into every mode agent)

### Extensibility

Drop a new `.md` file into `rules/` or `skills/` — zero code changes needed.

## Verification

- `tsc --noEmit` passes cleanly
- Follows existing `installSlashCommands()` pattern exactly
- No runtime dependencies added