### PR TITLE
fix(mastracode): #147 fix review verificationResult(write) error & add execute re-entry context

### DIFF
--- a/packages/luca-mastracode/src/instructions/execute.md
+++ b/packages/luca-mastracode/src/instructions/execute.md
@@ -379,7 +379,7 @@ When `iterationPlan` is present in workflow state, you are re-entering from **Re
 1. **Read `iterationPlan`** from state — it contains the focused list of fixes from the reviewer
 2. **Read `.planning/REVIEW-{wave}.md`** — the full audit report with file paths, evidence, and fix suggestions
 3. **Scope your work** to the iteration plan items ONLY — do not re-execute the full plan
-4. After fixes, run checks and transition back to Review: `workflowState(switch-mode, targetMode: "luca:5-review")`
+4. After fixes, run checks and transition back to Review: `workflowState(action: "switch-mode", targetMode: "luca:5-review")`
 
 The iteration plan is your task list for this pass. Treat each item as a focused fix, not a full wave.
 

--- a/packages/luca-mastracode/src/instructions/execute.md
+++ b/packages/luca-mastracode/src/instructions/execute.md
@@ -369,6 +369,19 @@ Read `workflowState(action: "read")` for:
 - Plan and research data
 - `currentPhase` / `totalPhases` — phase progress
 - `oversight` — checkpoint behavior
+- `iterationPlan` — if set, this is a **review iteration** (see below)
+- `reviewIteration` — current review loop count
+
+### Review Iteration Re-entry
+
+When `iterationPlan` is present in workflow state, you are re-entering from **Review mode** to fix must-fix issues. This changes your behavior:
+
+1. **Read `iterationPlan`** from state — it contains the focused list of fixes from the reviewer
+2. **Read `.planning/REVIEW-{wave}.md`** — the full audit report with file paths, evidence, and fix suggestions
+3. **Scope your work** to the iteration plan items ONLY — do not re-execute the full plan
+4. After fixes, run checks and transition back to Review: `workflowState(switch-mode, targetMode: "luca:5-review")`
+
+The iteration plan is your task list for this pass. Treat each item as a focused fix, not a full wave.
 
 ### TODO Progress
 

--- a/packages/luca-mastracode/src/instructions/review.md
+++ b/packages/luca-mastracode/src/instructions/review.md
@@ -266,7 +266,9 @@ Read `workflowState(action: "read")` for:
 - `intent` — original user intent
 
 ## Tool Coordination
-Sequence: (1) Spawn 4 reviewer subagents → (2) aggregate findings → (3) `verificationResult(write)` → (4) if must-fix: `workflowState(switch-mode → execute)`, else: `workflowState(switch-mode → finalize)`.
+Sequence: (1) Spawn 4 reviewer subagents → (2) capture raw findings via `writePlanningFile` → (3) consolidate & write audit report to `.planning/REVIEW-{wave}.md` → (4) `workflowState(save-review-results)` with iteration plan → (5) if must-fix: `workflowState(switch-mode → execute)`, else: `workflowState(switch-mode → finalize)`.
+
+> **Note**: Review does NOT write verification results. The `verificationResult` tool is read-only in this mode — use it to read what the executor/verifier produced. Review's output is the audit report and iteration plan.
 
 ## Luca Reminders
 Obey `<luca-reminder>` tags when they appear in conversation — they contain authoritative mid-session guidance that supersedes stale context.

--- a/packages/luca-mastracode/src/instructions/review.md
+++ b/packages/luca-mastracode/src/instructions/review.md
@@ -266,7 +266,7 @@ Read `workflowState(action: "read")` for:
 - `intent` — original user intent
 
 ## Tool Coordination
-Sequence: (1) Spawn 4 reviewer subagents → (2) capture raw findings via `writePlanningFile` → (3) consolidate & write audit report to `.planning/REVIEW-{wave}.md` → (4) `workflowState(save-review-results)` with iteration plan → (5) if must-fix: `workflowState(switch-mode → execute)`, else: `workflowState(switch-mode → finalize)`.
+Sequence: (1) Spawn 4 reviewer subagents → (2) capture raw findings via `writePlanningFile` → (3) consolidate & write audit report to `.planning/REVIEW-{wave}.md` → (4) `workflowState(action: "save-review-results")` with iteration plan → (5) if must-fix: `workflowState(action: "switch-mode", targetMode: "luca:4-execute")`, else: `workflowState(action: "switch-mode", targetMode: "luca:6-finalize")`.
 
 > **Note**: Review does NOT write verification results. The `verificationResult` tool is read-only in this mode — use it to read what the executor/verifier produced. Review's output is the audit report and iteration plan.
 

--- a/packages/luca-mastracode/src/luca-store.ts
+++ b/packages/luca-mastracode/src/luca-store.ts
@@ -58,6 +58,7 @@ export interface LucaWorkflowState {
 
   // --- Review tracking ---
   reviewIteration?: number;
+  iterationPlan?: string[];
 
   // --- Plan artifacts ---
   planFile?: string;

--- a/packages/luca-mastracode/src/modes/execute.ts
+++ b/packages/luca-mastracode/src/modes/execute.ts
@@ -39,7 +39,8 @@ export function buildExecuteInstructions(_harnessState?: Record<string, unknown>
   ].filter(Boolean).join('\n');
 
   // Inject review iteration context when re-entering from Review mode
-  const iterationPlan = state.iterationPlan;
+  const rawPlan = state.iterationPlan;
+  const iterationPlan = Array.isArray(rawPlan) ? rawPlan : undefined;
   const reviewIteration = state.reviewIteration;
   const reviewContext = iterationPlan?.length ? [
     '',

--- a/packages/luca-mastracode/src/modes/execute.ts
+++ b/packages/luca-mastracode/src/modes/execute.ts
@@ -38,7 +38,22 @@ export function buildExecuteInstructions(_harnessState?: Record<string, unknown>
     state.assignedTodos?.length ? `- Assigned TODOs: #${state.assignedTodos.join(', #')}` : null,
   ].filter(Boolean).join('\n');
 
-  return base + stateContext;
+  // Inject review iteration context when re-entering from Review mode
+  const iterationPlan = state.iterationPlan;
+  const reviewIteration = state.reviewIteration;
+  const reviewContext = iterationPlan?.length ? [
+    '',
+    '## ⚠️ Review Iteration Re-entry',
+    `**This is review iteration ${reviewIteration ?? 1}.** You are re-entering from Review mode to fix must-fix issues.`,
+    '',
+    '**Iteration plan (your task list for this pass):**',
+    ...iterationPlan.map((fix, i) => `${i + 1}. ${fix}`),
+    '',
+    `Read the latest \`.planning/REVIEW-*.md\` for full context (file paths, evidence, fix suggestions).`,
+    'Scope your work to these items ONLY — do not re-execute the full plan.',
+  ].join('\n') : '';
+
+  return base + stateContext + reviewContext;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes two related issues in the review → execute iteration loop:

### 1. Review mode `verificationResult(write)` permission error
The review instructions told the agent to call `verificationResult(write)`, but permissions correctly restrict it to read-only. This caused a runtime validation error that the agent had to recover from. Fixed the stale instruction to match the actual correct flow.

### 2. Execute mode missing review iteration re-entry context
When review sends execute back to fix must-fix issues, the execute agent had **zero awareness** of the iteration plan. Now:
- Execute instructions document the re-entry flow (read `iterationPlan`, read `REVIEW-*.md`, scope work to fixes only)
- Execute mode builder **dynamically injects** the iteration plan items directly into the system prompt
- `iterationPlan` is properly typed on `LucaWorkflowState`

### Files Changed
| File | Change |
|------|--------|
| `instructions/review.md` | Fix Tool Coordination sequence, add read-only note |
| `instructions/execute.md` | Add Review Iteration Re-entry section |
| `modes/execute.ts` | Dynamic injection of iteration plan into system prompt |
| `luca-store.ts` | Type `iterationPlan?: string[]` on interface |

### Context Preservation
Verified that `luca-state.json` persists across mode transitions — `iterationPlan`, `reviewIteration`, and all review artifacts (`.planning/REVIEW-*.md`) survive the switch. No context is lost.

### Verification
- `tsc --noEmit` passes clean

Closes #147