### PR TITLE
chore(mastracode): v10.3.2 version bump

### DIFF
--- a/packages/luca-mastracode/package.json
+++ b/packages/luca-mastracode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "luca",
   "description": "Luca workflow as a custom Mastra Code distribution — custom modes, agents, subagents, and tools",
-  "version": "10.3.1",
+  "version": "10.3.2",
   "bin": {
     "luca": "src/index.ts"
   },


### PR DESCRIPTION
Version bump to 10.3.2 for release. Follows squash merge of #151.

No code changes — version number only.

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-6) <noreply@mastra.ai>