### PR TITLE
Add changeset for PR #153 (release pipeline & naming)

### DIFF
--- a/.changeset/release-pipeline-and-naming.md
+++ b/.changeset/release-pipeline-and-naming.md
@@ -1,0 +1,9 @@
+---
+'@alecsibilia/luca-framework': patch
+---
+
+Update harness lookup path and adopt repo-wide eslint config.
+
+- `luca run` now resolves the mastracode harness at `node_modules/@alecsibilia/luca-mastracode/...` (the harness package was renamed from `luca` to `@alecsibilia/luca-mastracode`). Workspace and global installs that previously fell through to the old path will now find the harness correctly.
+- Added per-package `eslint.config.mjs` extending the new root config (typescript-eslint recommended, prettier with 4-space indent, no semicolons, single quotes, `import/order`). All source files were reformatted accordingly via `bun run lint:fix` — purely cosmetic, no behavior change.
+- Added `lint` and `lint:fix` scripts to the package.


### PR DESCRIPTION
## Summary

PR #153 shipped real changes to \`@alecsibilia/luca-framework\` (notably the \`run.ts\` path update for the mastracode rename, plus the eslint config + repo-wide reformat) but didn't include a changeset, so the release flow no-op'd on merge (\`Release v10.0.1 already exists, skipping\`).

This adds a patch changeset retroactively. Once merged:

1. \`release.yml\` opens a "Version Packages" PR bumping \`@alecsibilia/luca-framework\` 10.0.1 → 10.0.2
2. Merge that PR → \`release.yml\` cuts a GitHub Release tagged \`v10.0.2\`
3. \`publish.yml\` fires on the release → \`npm publish\`

## Test plan

- [ ] After merge, "Version Packages" PR is opened with the framework bump
- [ ] After Version PR merges, \`v10.0.2\` release is created
- [ ] \`publish.yml\` fires and publishes to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)