### PR TITLE
chore(release): include package name in GH release title

### DIFF
--- a/.github/scripts/create-release.ts
+++ b/.github/scripts/create-release.ts
@@ -3,6 +3,7 @@ import { $ } from 'bun'
 
 const pkg = await Bun.file('packages/luca-framework/package.json').json()
 const tag = `v${pkg.version}`
+const title = `luca-framework@${pkg.version}`
 
 const exists = await $`gh release view ${tag}`.quiet().nothrow()
 if (exists.exitCode === 0) {
@@ -21,7 +22,7 @@ const run_id = process.env.GITHUB_RUN_ID ?? process.pid
 const notes_file = `${import.meta.dir}/../../.release-notes-${tag}-${run_id}.md`
 await Bun.write(notes_file, notes)
 try {
-  await $`gh release create ${tag} --title ${tag} --notes-file ${notes_file}`
+  await $`gh release create ${tag} --title ${title} --notes-file ${notes_file}`
 } finally {
   await Bun.file(notes_file).exists() && (await $`rm ${notes_file}`.quiet().nothrow())
 }


### PR DESCRIPTION
## Summary

Future GH Releases created by \`create-release.ts\` will be titled \`luca-framework@<version>\` instead of just \`v<version>\`, so they disambiguate from historical \`luca-mastracode\` releases that share the same \`vX.Y.Z\` tag namespace.

The git tag still stays \`vX.Y.Z\` (unchanged — preserves npm + git convention).

\`\`\`
Before: v10.0.2
After:  luca-framework@10.0.2
\`\`\`

## Backfill

Already retitled the 9 existing releases manually via \`gh release edit\`:

- \`luca-framework@10.0.0 — Complete Mastra Code Transition\`
- \`luca-framework@10.0.1 — @types/semver CI fix\`
- \`luca-framework@10.0.2 — Update harness lookup path & adopt eslint config\`
- \`luca-mastracode@10.1.0 — Pipeline Mode Permissions & TUI\`
- \`luca-mastracode@10.1.1 — Pipeline Reliability\`
- \`luca-mastracode@10.2.0 — Bundled Skills & Rules\`
- \`luca-mastracode@10.3.0 — Prompt Engineering & Context Window Hardening\`
- \`luca-mastracode@10.3.1 — Review/Execute Iteration Loop Fix\`
- \`luca-mastracode@10.3.2 — Subagent Output Preservation\`

## Test plan

- [ ] Next changeset-driven release shows up as \`luca-framework@<version>\` in the releases list

🤖 Generated with [Claude Code](https://claude.com/claude-code)