### PR TITLE
chore(release): v11.0.0 escape old version namespace collision

### DIFF
--- a/packages/luca-framework/CHANGELOG.md
+++ b/packages/luca-framework/CHANGELOG.md
@@ -1,6 +1,10 @@
 # @alecsibilia/luca-framework
 
-## 10.1.0
+## 11.0.0
+
+### Major Changes
+
+- Version jump from 10.0.5 → 11.0.0 to escape the version namespace collision with old `luca-mastracode`-era releases. Between April 9–18, the old `publish.yml` workflow derived the npm version from the GitHub release tag name. Releases created for the internal `luca-mastracode` package (v10.1.0–v10.3.2) inadvertently published `@alecsibilia/luca-framework` at those same version numbers. Versions 10.1.0 through 10.3.2 are permanently claimed on npm. Starting fresh at 11.0.0 avoids any future collisions.
 
 ### Minor Changes
 

--- a/packages/luca-framework/package.json
+++ b/packages/luca-framework/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alecsibilia/luca-framework",
   "description": "Luca CLI — bootstrap MuninnDB and launch the Mastra Code harness",
-  "version": "10.1.0",
+  "version": "11.0.0",
   "bin": {
     "luca": "./bin/luca.js"
   },


### PR DESCRIPTION
## Problem

The CI publish job for PR #166's changeset (Version PR #167) failed with:

```
403 Forbidden: You cannot publish over the previously published versions: 10.1.0.
```

### Root cause

The old `publish.yml` workflow (deleted in #162) derived the npm version from the GitHub release **tag name** rather than from `package.json`. When GitHub releases were created for the internal `luca-mastracode` package using tags `v10.1.0` through `v10.3.2`, the workflow published `@alecsibilia/luca-framework` at those same version numbers.

This means versions **10.1.0, 10.1.1, 10.2.0, 10.3.0, 10.3.1, 10.3.2** are permanently claimed on npm by `@alecsibilia/luca-framework` even though they correspond to `luca-mastracode` releases.

When the changesets action bumped from `10.0.5` → `10.1.0` (minor for the move-batch feature), it collided with the already-published `10.1.0`.

### Fix

Jump to **11.0.0** — clean namespace with no risk of future collisions. CHANGELOG includes both the version-jump explanation and the `move-batch` feature notes from `10.1.0`.

### What gets published

When this merges, the Release workflow will:
1. Find no pending changesets → run `create-release.ts`
2. Create GitHub release `v11.0.0`
3. Trigger publish job → `bun publish` at version `11.0.0` ✅

---

Closes the failed run from #167.