### PR TITLE
chore(mastracode): upgrade opus model from 4.6 to 4.7

### DIFF
--- a/.changeset/upgrade-opus-4-7.md
+++ b/.changeset/upgrade-opus-4-7.md
@@ -1,0 +1,11 @@
+---
+'@alecsibilia/luca-mastracode': patch
+---
+
+Upgrade default model from Claude Opus 4.6 to Claude Opus 4.7 across all model routing and mode configurations.
+
+**Changed files:**
+- `model-routing.ts` — `capable` tier now resolves to `anthropic/claude-opus-4-7`
+- `modes/build.ts` — `resolveBuildModel()` and `defaultModelId`
+- `modes/architect.ts` — `defaultModelId`
+- `modes/execute.ts` — `defaultModelId`

--- a/packages/luca-mastracode/src/model-routing.ts
+++ b/packages/luca-mastracode/src/model-routing.ts
@@ -15,7 +15,7 @@ export type ModelTier = 'fast' | 'balanced' | 'capable'
 const MODEL_IDS: Record<ModelTier, string> = {
     fast: 'anthropic/claude-haiku-4-5',
     balanced: 'anthropic/claude-sonnet-4-6',
-    capable: 'anthropic/claude-opus-4-6',
+    capable: 'anthropic/claude-opus-4-7',
 }
 
 // ---------------------------------------------------------------------------
@@ -164,7 +164,7 @@ function adjustTier({
  *
  * @example
  * resolveModel({ subagentType: 'lu-executor', complexity: 'CRITICAL', profile: 'balanced' })
- * // → 'anthropic/claude-opus-4-6'
+ * // → 'anthropic/claude-opus-4-7'
  */
 export function resolveModel({
     subagentType,

--- a/packages/luca-mastracode/src/modes/architect.ts
+++ b/packages/luca-mastracode/src/modes/architect.ts
@@ -73,7 +73,7 @@ export const architectMode = {
     description:
         'Git workflow, roadmap creation, .planning/PLAN.md via goal-backward analysis, and plan review.',
     color: '#a855f7',
-    defaultModelId: 'anthropic/claude-opus-4-6',
+    defaultModelId: 'anthropic/claude-opus-4-7',
     buildInstructions: buildArchitectInstructions,
     resolveModel: resolveArchitectModel,
 }

--- a/packages/luca-mastracode/src/modes/build.ts
+++ b/packages/luca-mastracode/src/modes/build.ts
@@ -22,7 +22,7 @@ export function buildBuildInstructions(): string {
 }
 
 export function resolveBuildModel(): string {
-    return 'anthropic/claude-opus-4-6'
+    return 'anthropic/claude-opus-4-7'
 }
 
 export const buildMode = {
@@ -30,7 +30,7 @@ export const buildMode = {
     name: 'Build',
     description: 'Full-access build mode for implementing changes.',
     color: '#16c858',
-    defaultModelId: 'anthropic/claude-opus-4-6',
+    defaultModelId: 'anthropic/claude-opus-4-7',
     buildInstructions: buildBuildInstructions,
     resolveModel: resolveBuildModel,
 }

--- a/packages/luca-mastracode/src/modes/execute.ts
+++ b/packages/luca-mastracode/src/modes/execute.ts
@@ -97,7 +97,7 @@ export const executeMode = {
     description:
         'Implement code changes atomically with automated checks, verification, code review, and learning capture.',
     color: '#10b981',
-    defaultModelId: 'anthropic/claude-opus-4-6',
+    defaultModelId: 'anthropic/claude-opus-4-7',
     buildInstructions: buildExecuteInstructions,
     resolveModel: resolveExecuteModel,
 }


### PR DESCRIPTION
## Summary

Upgrade all runtime model references from `anthropic/claude-opus-4-6` to `anthropic/claude-opus-4-7`.

## Changes

| File | What changed |
|------|-------------|
| `model-routing.ts` | `capable` tier `MODEL_IDS` entry + JSDoc example |
| `modes/build.ts` | `resolveBuildModel()` return value + `defaultModelId` |
| `modes/architect.ts` | `defaultModelId` |
| `modes/execute.ts` | `defaultModelId` |

## Notes

- Sonnet and Haiku model references are unchanged (no 4.7 variants targeted)
- Documentation-only references in `docs/research/` left as-is (historical context)
- TypeScript compiles cleanly
