### PR TITLE
fix(config): include luca-framework in changeset + add workspace dep

### DIFF
--- a/.changeset/upgrade-opus-4-7.md
+++ b/.changeset/upgrade-opus-4-7.md
@@ -1,5 +1,6 @@
 ---
 '@alecsibilia/luca-mastracode': patch
+'@alecsibilia/luca-framework': patch
 ---
 
 Upgrade default model from Claude Opus 4.6 to Claude Opus 4.7 across all model routing and mode configurations.

--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
     },
     "packages/luca-framework": {
       "name": "@alecsibilia/luca-framework",
-      "version": "10.0.4",
+      "version": "11.0.0",
       "bin": {
         "luca": "./bin/luca.js",
       },
@@ -45,6 +45,7 @@
         "zod": "catalog:",
       },
       "devDependencies": {
+        "@alecsibilia/luca-mastracode": "workspace:*",
         "@types/semver": "^7.5.8",
         "@types/update-notifier": "^6.0.8",
       },

--- a/packages/luca-framework/package.json
+++ b/packages/luca-framework/package.json
@@ -19,6 +19,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@alecsibilia/luca-mastracode": "workspace:*",
     "@types/semver": "^7.5.8",
     "@types/update-notifier": "^6.0.8"
   },


### PR DESCRIPTION
## Context

PR #169 upgraded Opus 4.6 → 4.7 in `luca-mastracode`, but the changeset only listed `@alecsibilia/luca-mastracode`. The automated release PR (#170) therefore only bumps `luca-mastracode@10.4.1` — it doesn't touch `luca-framework`.

Since `luca-framework` [bundles mastracode at build time](https://github.com/asibilia/luca-framework/blob/main/packages/luca-framework/build.config.ts#L18-L42), model changes in mastracode should always trigger a framework release too.

## Changes

1. **Updated changeset** — added `'@alecsibilia/luca-framework': patch` so the automated release PR will version both:
   - `@alecsibilia/luca-mastracode@10.4.1`
   - `@alecsibilia/luca-framework@11.0.1`

2. **Added workspace devDependency** — `@alecsibilia/luca-mastracode: workspace:*` in `luca-framework/package.json` `devDependencies`. This makes the build-time coupling visible to the package manager and changesets. With `updateInternalDependencies: patch` in the changesets config, future mastracode-only changesets will automatically cascade a patch bump to luca-framework.

## After merge

Close or re-run PR #170 — the changesets action will regenerate it with both packages.
