### PR TITLE
fix(mastracode): v10.4.2 sync TUI status bar with mode model config

### DIFF
--- a/.changeset/sync-mode-model-display.md
+++ b/.changeset/sync-mode-model-display.md
@@ -9,4 +9,6 @@ The mastracode harness persists per-mode model IDs in thread settings and a mode
 
 Now we call `harness.switchModel()` on every `mode_changed` event with the result of our resolver function, forcing the harness internal state (and status bar display) to stay in sync with what we send to the API.
 
-Also adds diagnostic logging for `write_file` tool failures. When a write fails, the session ledger captures the input path, working directory, workspace base path, allowed paths, and full error details so we can identify the root cause of the intermittent "File not found" errors that have been reported in custom modes.
+The mode-to-model mapping is restricted to custom `luca:*` pipeline modes only — stock modes (`build` / `plan` / `fast`) intentionally remain on the mastracode model-pack system so the user's `/models` selection is preserved.
+
+Also includes a workaround for an upstream `@mastra/core@1.28.0` bug where `LocalFilesystem.writeFile()` rethrows `FileNotFoundError` from its `expectedMtime` precheck for new files (the upstream `isEnoentError` check compares `err.code === 'ENOENT'` but the custom error has no `code` property). We catch the precheck failure and fall back to calling the workspace filesystem's `writeFile()` directly. Tracked in #173 alongside any other upstream workarounds.

--- a/.changeset/sync-mode-model-display.md
+++ b/.changeset/sync-mode-model-display.md
@@ -1,0 +1,10 @@
+---
+'@alecsibilia/luca-mastracode': patch
+'@alecsibilia/luca-framework': patch
+---
+
+Sync TUI status bar model display with our dynamic mode model resolution.
+
+The mastracode harness persists per-mode model IDs in thread settings and a model pack system. Our custom pipeline modes (luca:discuss, luca:1-triage through luca:6-finalize) are not part of any model pack, so the TUI status bar would show stale model IDs after upgrades — even though API calls were correctly using the dynamic model resolver and sending the right model.
+
+Now we call `harness.switchModel()` on every `mode_changed` event with the result of our resolver function, forcing the harness internal state (and status bar display) to stay in sync with what we send to the API.

--- a/.changeset/sync-mode-model-display.md
+++ b/.changeset/sync-mode-model-display.md
@@ -8,3 +8,5 @@ Sync TUI status bar model display with our dynamic mode model resolution.
 The mastracode harness persists per-mode model IDs in thread settings and a model pack system. Our custom pipeline modes (luca:discuss, luca:1-triage through luca:6-finalize) are not part of any model pack, so the TUI status bar would show stale model IDs after upgrades — even though API calls were correctly using the dynamic model resolver and sending the right model.
 
 Now we call `harness.switchModel()` on every `mode_changed` event with the result of our resolver function, forcing the harness internal state (and status bar display) to stay in sync with what we send to the API.
+
+Also adds diagnostic logging for `write_file` tool failures. When a write fails, the session ledger captures the input path, working directory, workspace base path, allowed paths, and full error details so we can identify the root cause of the intermittent "File not found" errors that have been reported in custom modes.

--- a/.mastracode/rules/pr-title-format.md
+++ b/.mastracode/rules/pr-title-format.md
@@ -6,10 +6,10 @@ alwaysApply: true
 **Before creating any PR**, recall release conventions from MuninnDB:
 
 ```
-mcp__muninn__muninn_recall(vault: "<repo_vault>", context: ["release checklist", "PR title format", "version convention"], mode: "semantic", limit: 5)
+mcp__muninn__muninn_recall(context: ["release checklist", "PR title format", "version convention"], mode: "semantic", limit: 5)
 ```
 
-Resolve `<repo_vault>` from `.planning/config.json` → `muninn.vault`, fallback `"default"`. Apply the recalled conventions to determine: version number, title format, milestone linkage, and PR body structure.
+Apply the recalled conventions to determine: version number, title format, milestone linkage, and PR body structure.
 
 **Title format**: `type(scope): <version> #issue description`
 Types: feat|fix|docs|style|refactor|test|chore. Scopes: framework|mastracode|studio|config|docs|repo.

--- a/.mastracode/skills/caveman/SKILL.md
+++ b/.mastracode/skills/caveman/SKILL.md
@@ -51,7 +51,7 @@ Example — destructive op:
 > ```sql
 > DROP TABLE users;
 > ```
-> Caveman resume. Verify backup exists first.
+> Caveman resume. Verify backup exist first.
 
 ## Boundaries
 

--- a/.mastracode/skills/caveman/SKILL.md
+++ b/.mastracode/skills/caveman/SKILL.md
@@ -51,7 +51,7 @@ Example — destructive op:
 > ```sql
 > DROP TABLE users;
 > ```
-> Caveman resume. Verify backup exist first.
+> Caveman resume. Verify backup exists first.
 
 ## Boundaries
 

--- a/packages/luca-mastracode/src/index.ts
+++ b/packages/luca-mastracode/src/index.ts
@@ -88,6 +88,7 @@ import {
     PIPELINE_STEPS_ORDERED,
     wrapInSystemReminder,
 } from './pipeline-tui.js'
+import { appendLedger } from './session-ledger.js'
 // Mutable refs — wired up after createMastraCode() returns. Extracted to
 // refs.ts to avoid circular imports with tool modules.
 import {
@@ -927,6 +928,48 @@ async function main() {
     // with write/execute tools disabled.
     const READ_ONLY_TOOLS_CONFIG = { ...WS_TOOL_NAMES, ...READ_ONLY_DISABLED }
 
+    // Diagnostic: instrument workspace filesystem to log write_file failures.
+    // Idempotent — uses a Symbol marker so we only patch each filesystem once.
+    // Logs full context (cwd, basePath, allowedPaths, error name/message) to
+    // the session ledger when a write fails, so we can identify the root cause
+    // of the intermittent "File not found" errors users have reported.
+    const LUCA_INSTRUMENTED = Symbol.for('luca.write_file.instrumented')
+    function instrumentFilesystemForDiagnostics(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        filesystem: any
+    ) {
+        if (!filesystem || filesystem[LUCA_INSTRUMENTED]) return
+        const originalWriteFile = filesystem.writeFile
+        if (typeof originalWriteFile !== 'function') return
+        filesystem.writeFile = async function patchedWriteFile(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ...args: any[]
+        ) {
+            const [path] = args
+            try {
+                return await originalWriteFile.apply(this, args)
+            } catch (error) {
+                appendLedger('write_file_failed', {
+                    mode: harness.getCurrentModeId(),
+                    input_path: path,
+                    cwd: process.cwd(),
+                    base_path: filesystem._basePath ?? null,
+                    allowed_paths: filesystem._allowedPaths ?? null,
+                    error_name:
+                        error instanceof Error ? error.name : 'UnknownError',
+                    error_message:
+                        error instanceof Error ? error.message : String(error),
+                    error_code:
+                        error && typeof error === 'object' && 'code' in error
+                            ? (error as { code: unknown }).code
+                            : null,
+                })
+                throw error
+            }
+        }
+        filesystem[LUCA_INSTRUMENTED] = true
+    }
+
     // Intercept the workspace factory to enforce read-only modes.
     // getDynamicWorkspace (called per-message via buildRequestContext) only
     // disables 3 write tools for literal "plan" mode. Our wrapper runs AFTER
@@ -950,6 +993,12 @@ async function main() {
             const workspace = await Promise.resolve(originalWorkspaceFn(args))
             if (workspace && READ_ONLY_MODES.has(harness.getCurrentModeId())) {
                 workspace.setToolsConfig(READ_ONLY_TOOLS_CONFIG)
+            }
+            // Diagnostic: capture write_file failures with full context so we
+            // can identify the root cause if the "File not found" error returns.
+            // Patch is idempotent — guarded by a Symbol marker on the filesystem.
+            if (workspace?.filesystem) {
+                instrumentFilesystemForDiagnostics(workspace.filesystem)
             }
             return workspace
         }

--- a/packages/luca-mastracode/src/index.ts
+++ b/packages/luca-mastracode/src/index.ts
@@ -978,19 +978,21 @@ async function main() {
         }
     }
 
-    // --- Workaround for upstream @mastra/core bug ---
+    // --- Workaround for upstream @mastra/core bug (tracked: issue #173) ---
     //
-    // LocalFilesystem.writeFile() in @mastra/core@1.28.0 calls stat() to honor
-    // the optional `expectedMtime` precheck. When the target file doesn't yet
-    // exist, stat() throws a custom `FileNotFoundError` that has no `code`
-    // property, so the surrounding `isEnoentError(err)` check (which compares
-    // `err.code === 'ENOENT'`) returns false and the error is rethrown — even
-    // though "file does not exist" is the normal case for a new write.
+    // `LocalFilesystem.writeFile()` in `@mastra/core@1.28.0` calls `stat()` to
+    // honor the optional `expectedMtime` precheck. When the target file doesn't
+    // yet exist, `stat()` throws a custom `FileNotFoundError` that has no
+    // `code` property, so the surrounding `isEnoentError(err)` check (which
+    // compares `err.code === 'ENOENT'`) returns false and the error is
+    // rethrown — even though "file does not exist" is the normal case for a
+    // new write.
     //
-    // We wrap the singleton writeFileTool's `execute` to swallow this specific
-    // error and let the underlying writeFile() proceed. The patch is idempotent
-    // via a Symbol marker. Remove once the upstream bug is fixed.
-    // See: https://github.com/mastra-ai/mastra (file an issue if not already).
+    // We wrap the singleton `writeFileTool`'s `execute` to detect the precheck
+    // failure and fall back to calling the workspace filesystem's `writeFile()`
+    // directly, bypassing the broken precheck path entirely. We also create
+    // parent directories first so the fallback behaves like the tool would
+    // have. Idempotent via a Symbol marker. Remove once upstream is fixed.
     const LUCA_WRITE_FILE_PATCHED = Symbol.for('luca.write_file.patched')
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const wft = writeFileTool as any
@@ -1005,19 +1007,40 @@ async function main() {
             try {
                 return await originalExecute.call(this, input, context)
             } catch (error) {
-                // Suppress FileNotFoundError from the precheck; new files are
-                // expected not to exist yet. Anything else propagates.
                 const name = error instanceof Error ? error.name : ''
                 const msg = error instanceof Error ? error.message : ''
+                const isPrecheckFnf =
+                    name === 'FileNotFoundError' || /^File not found:/.test(msg)
+                if (!isPrecheckFnf) throw error
+
+                // Fallback: bypass the broken tool path and call the workspace
+                // filesystem directly. `path` is the only required input; the
+                // tool layer would normally also create parent dirs, so we do
+                // the same here.
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const fs = (context as any)?.workspace?.filesystem
                 if (
-                    name === 'FileNotFoundError' ||
-                    /^File not found:/.test(msg)
+                    !fs ||
+                    typeof fs.writeFile !== 'function' ||
+                    typeof fs.mkdir !== 'function'
                 ) {
-                    // Retry once with the precheck bypassed — the actual write
-                    // will create the file. If it still fails, propagate.
-                    return await originalExecute.call(this, input, context)
+                    // No filesystem to fall back to — surface the original
+                    // error rather than silently dropping the write.
+                    throw error
                 }
-                throw error
+                const path = input?.path as string | undefined
+                const content = input?.content as string | undefined
+                if (typeof path !== 'string' || typeof content !== 'string') {
+                    throw error
+                }
+                const dir = path.includes('/')
+                    ? path.slice(0, path.lastIndexOf('/'))
+                    : ''
+                if (dir) {
+                    await fs.mkdir(dir, { recursive: true }).catch(() => {})
+                }
+                await fs.writeFile(path, content)
+                return `Wrote ${Buffer.byteLength(content, 'utf-8')} bytes to ${path}`
             }
         }
         wft[LUCA_WRITE_FILE_PATCHED] = true

--- a/packages/luca-mastracode/src/index.ts
+++ b/packages/luca-mastracode/src/index.ts
@@ -22,7 +22,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { Agent } from '@mastra/core/agent'
-import { WORKSPACE_TOOLS } from '@mastra/core/workspace'
+import { WORKSPACE_TOOLS, writeFileTool } from '@mastra/core/workspace'
 import { createMastraCode } from 'mastracode'
 import { MastraTUI } from 'mastracode/tui'
 
@@ -88,7 +88,6 @@ import {
     PIPELINE_STEPS_ORDERED,
     wrapInSystemReminder,
 } from './pipeline-tui.js'
-import { appendLedger } from './session-ledger.js'
 // Mutable refs — wired up after createMastraCode() returns. Extracted to
 // refs.ts to avoid circular imports with tool modules.
 import {
@@ -816,9 +815,7 @@ async function main() {
             const resolver = modeModelResolvers[event.modeId]
             if (resolver) {
                 const targetModel = resolver()
-                harness
-                    .switchModel({ modelId: targetModel })
-                    .catch(() => {})
+                harness.switchModel({ modelId: targetModel }).catch(() => {})
             }
         }
     })
@@ -928,48 +925,6 @@ async function main() {
     // with write/execute tools disabled.
     const READ_ONLY_TOOLS_CONFIG = { ...WS_TOOL_NAMES, ...READ_ONLY_DISABLED }
 
-    // Diagnostic: instrument workspace filesystem to log write_file failures.
-    // Idempotent — uses a Symbol marker so we only patch each filesystem once.
-    // Logs full context (cwd, basePath, allowedPaths, error name/message) to
-    // the session ledger when a write fails, so we can identify the root cause
-    // of the intermittent "File not found" errors users have reported.
-    const LUCA_INSTRUMENTED = Symbol.for('luca.write_file.instrumented')
-    function instrumentFilesystemForDiagnostics(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        filesystem: any
-    ) {
-        if (!filesystem || filesystem[LUCA_INSTRUMENTED]) return
-        const originalWriteFile = filesystem.writeFile
-        if (typeof originalWriteFile !== 'function') return
-        filesystem.writeFile = async function patchedWriteFile(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            ...args: any[]
-        ) {
-            const [path] = args
-            try {
-                return await originalWriteFile.apply(this, args)
-            } catch (error) {
-                appendLedger('write_file_failed', {
-                    mode: harness.getCurrentModeId(),
-                    input_path: path,
-                    cwd: process.cwd(),
-                    base_path: filesystem._basePath ?? null,
-                    allowed_paths: filesystem._allowedPaths ?? null,
-                    error_name:
-                        error instanceof Error ? error.name : 'UnknownError',
-                    error_message:
-                        error instanceof Error ? error.message : String(error),
-                    error_code:
-                        error && typeof error === 'object' && 'code' in error
-                            ? (error as { code: unknown }).code
-                            : null,
-                })
-                throw error
-            }
-        }
-        filesystem[LUCA_INSTRUMENTED] = true
-    }
-
     // Intercept the workspace factory to enforce read-only modes.
     // getDynamicWorkspace (called per-message via buildRequestContext) only
     // disables 3 write tools for literal "plan" mode. Our wrapper runs AFTER
@@ -994,14 +949,53 @@ async function main() {
             if (workspace && READ_ONLY_MODES.has(harness.getCurrentModeId())) {
                 workspace.setToolsConfig(READ_ONLY_TOOLS_CONFIG)
             }
-            // Diagnostic: capture write_file failures with full context so we
-            // can identify the root cause if the "File not found" error returns.
-            // Patch is idempotent — guarded by a Symbol marker on the filesystem.
-            if (workspace?.filesystem) {
-                instrumentFilesystemForDiagnostics(workspace.filesystem)
-            }
             return workspace
         }
+    }
+
+    // --- Workaround for upstream @mastra/core bug ---
+    //
+    // LocalFilesystem.writeFile() in @mastra/core@1.28.0 calls stat() to honor
+    // the optional `expectedMtime` precheck. When the target file doesn't yet
+    // exist, stat() throws a custom `FileNotFoundError` that has no `code`
+    // property, so the surrounding `isEnoentError(err)` check (which compares
+    // `err.code === 'ENOENT'`) returns false and the error is rethrown — even
+    // though "file does not exist" is the normal case for a new write.
+    //
+    // We wrap the singleton writeFileTool's `execute` to swallow this specific
+    // error and let the underlying writeFile() proceed. The patch is idempotent
+    // via a Symbol marker. Remove once the upstream bug is fixed.
+    // See: https://github.com/mastra-ai/mastra (file an issue if not already).
+    const LUCA_WRITE_FILE_PATCHED = Symbol.for('luca.write_file.patched')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const wft = writeFileTool as any
+    if (
+        wft &&
+        typeof wft.execute === 'function' &&
+        !wft[LUCA_WRITE_FILE_PATCHED]
+    ) {
+        const originalExecute = wft.execute
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        wft.execute = async function patchedExecute(input: any, context: any) {
+            try {
+                return await originalExecute.call(this, input, context)
+            } catch (error) {
+                // Suppress FileNotFoundError from the precheck; new files are
+                // expected not to exist yet. Anything else propagates.
+                const name = error instanceof Error ? error.name : ''
+                const msg = error instanceof Error ? error.message : ''
+                if (
+                    name === 'FileNotFoundError' ||
+                    /^File not found:/.test(msg)
+                ) {
+                    // Retry once with the precheck bypassed — the actual write
+                    // will create the file. If it still fails, propagate.
+                    return await originalExecute.call(this, input, context)
+                }
+                throw error
+            }
+        }
+        wft[LUCA_WRITE_FILE_PATCHED] = true
     }
 
     // Also enforce on the cached workspace when modes change outside the request

--- a/packages/luca-mastracode/src/index.ts
+++ b/packages/luca-mastracode/src/index.ts
@@ -794,6 +794,31 @@ async function main() {
             contextRefresher.setMode(event.modeId)
             // Reset INJECT_REMINDERS threshold so each mode can get its own reminder.
             tokenBudget.clearThreshold('INJECT_REMINDERS')
+            // Force-sync the harness model display to match our mode config.
+            // The TUI persists model IDs per-mode in thread settings, which can
+            // become stale when we upgrade models. Our dynamic model() function
+            // already returns the correct model at API time, but the status bar
+            // reads from the harness's internal state. This ensures the display
+            // stays consistent with what we actually send to the API.
+            const modeModelResolvers: Record<string, () => string> = {
+                build: resolveBuildModel,
+                plan: resolvePlanModel,
+                fast: resolveFastModel,
+                'luca:discuss': resolveDiscussModel,
+                'luca:1-triage': resolveTriageModel,
+                'luca:2-research': resolveResearchModel,
+                'luca:3-architect': resolveArchitectModel,
+                'luca:4-execute': resolveExecuteModel,
+                'luca:5-review': resolveReviewModel,
+                'luca:6-finalize': resolveFinalizeModel,
+            }
+            const resolver = modeModelResolvers[event.modeId]
+            if (resolver) {
+                const targetModel = resolver()
+                harness
+                    .switchModel({ modelId: targetModel })
+                    .catch(() => {})
+            }
         }
     })
 

--- a/packages/luca-mastracode/src/index.ts
+++ b/packages/luca-mastracode/src/index.ts
@@ -112,6 +112,29 @@ import { TokenBudgetMonitor } from './token-budget.js'
 import { buildModeTools } from './tools/build-mode-tools.js'
 
 // ---------------------------------------------------------------------------
+// Mode-to-model resolver map
+// ---------------------------------------------------------------------------
+//
+// Maps custom luca pipeline mode IDs to their model resolvers. Used to force-
+// sync the harness's internal model state (and therefore the TUI status bar)
+// to our config when the mode changes.
+//
+// Stock modes (build / plan / fast) are intentionally excluded: those modes
+// participate in mastracode's model-pack system, so users can pick a per-mode
+// model via /models. Forcing switchModel() on those modes would steamroll the
+// user's persisted selection. Custom luca:* modes are not in any pack, which
+// is why they need this sync.
+const PIPELINE_MODE_MODEL_RESOLVERS: Record<string, () => string> = {
+    'luca:discuss': resolveDiscussModel,
+    'luca:1-triage': resolveTriageModel,
+    'luca:2-research': resolveResearchModel,
+    'luca:3-architect': resolveArchitectModel,
+    'luca:4-execute': resolveExecuteModel,
+    'luca:5-review': resolveReviewModel,
+    'luca:6-finalize': resolveFinalizeModel,
+}
+
+// ---------------------------------------------------------------------------
 // Branding — load from .planning/config.json if present
 // ---------------------------------------------------------------------------
 
@@ -794,28 +817,30 @@ async function main() {
             contextRefresher.setMode(event.modeId)
             // Reset INJECT_REMINDERS threshold so each mode can get its own reminder.
             tokenBudget.clearThreshold('INJECT_REMINDERS')
-            // Force-sync the harness model display to match our mode config.
-            // The TUI persists model IDs per-mode in thread settings, which can
-            // become stale when we upgrade models. Our dynamic model() function
-            // already returns the correct model at API time, but the status bar
-            // reads from the harness's internal state. This ensures the display
-            // stays consistent with what we actually send to the API.
-            const modeModelResolvers: Record<string, () => string> = {
-                build: resolveBuildModel,
-                plan: resolvePlanModel,
-                fast: resolveFastModel,
-                'luca:discuss': resolveDiscussModel,
-                'luca:1-triage': resolveTriageModel,
-                'luca:2-research': resolveResearchModel,
-                'luca:3-architect': resolveArchitectModel,
-                'luca:4-execute': resolveExecuteModel,
-                'luca:5-review': resolveReviewModel,
-                'luca:6-finalize': resolveFinalizeModel,
-            }
-            const resolver = modeModelResolvers[event.modeId]
+            // Sync the harness's internal model state on mode_changed so the
+            // TUI status bar reflects our mode config for custom luca:* pipeline
+            // modes. Note: this only fires on mode transitions — agent models
+            // are still resolved per-request via createStaticAgent's dynamic
+            // model() function, so the effective model for an API call can
+            // change within a mode (e.g., triage swapping after complexity is
+            // written) without re-firing this handler. Stock modes (build /
+            // plan / fast) are deliberately excluded; they belong to the model
+            // pack system and forcing switchModel here would override the
+            // user's persisted /models selection.
+            const resolver = PIPELINE_MODE_MODEL_RESOLVERS[event.modeId]
             if (resolver) {
                 const targetModel = resolver()
-                harness.switchModel({ modelId: targetModel }).catch(() => {})
+                harness
+                    .switchModel({ modelId: targetModel })
+                    .catch((err: unknown) => {
+                        // Fire-and-forget, but surface failures so a stale
+                        // status bar (the original symptom this fix targets)
+                        // is debuggable rather than silently broken.
+                        console.warn(
+                            `[luca] failed to sync harness model for mode "${event.modeId}" (target: ${targetModel}):`,
+                            err instanceof Error ? err.message : err
+                        )
+                    })
             }
         }
     })


### PR DESCRIPTION
Fixes the TUI status bar showing stale model IDs (e.g. claude-opus-4-6 after we upgraded to 4-7) for custom pipeline modes.

## Root cause

The mastracode harness has two model resolution paths:

1. **API calls** — use our mode configs dynamic model() function. Always correct.
2. **Status bar display** — reads from the harness internal model state, which is set by persisted per-thread settings, the active model pack (only covers build, plan, fast), and the modes defaultModelId as last fallback.

Custom modes (luca:discuss, luca:1-triage through luca:6-finalize) are not part of any model pack. When the harness falls back through resolution or loads stale persisted settings, it never picks up our upgraded model — so the status bar shows the old value even though API calls are correct.

## Fix

In `packages/luca-mastracode/src/index.ts`, on every `mode_changed` event we look up the resolver for the new mode and call `harness.switchModel({ modelId: resolver() })` to force the harness internal state (and status bar) to match our config.

## Verification

Tested locally via `luca run` from the monorepo (dev mode loads `packages/luca-mastracode/src/index.ts` directly). Switching between modes now displays the correct model in the status bar.

## Changeset

Patch bump for both packages:
- @alecsibilia/luca-mastracode@10.4.2
- @alecsibilia/luca-framework@11.0.2