### PR TITLE
fix(mastracode): #173 prevent TUI crashes from long ask_user option labels

### DIFF
--- a/.changeset/ask-user-label-truncate.md
+++ b/.changeset/ask-user-label-truncate.md
@@ -1,0 +1,11 @@
+---
+'@alecsibilia/luca-mastracode': patch
+---
+
+Workaround for upstream `mastracode@0.15.2` bug: long `ask_user` option labels crashed the TUI.
+
+The inline `AskQuestionInlineComponent` does not wrap or truncate option labels, so any caller-supplied label wider than the bordered box's inner width tripped pi-tui's `Rendered line N exceeds terminal width` assertion in `doRender()` and killed the entire `luca run` process. The question text on the same component IS wrapped via `wrapTextWithAnsi`, so this is just a missing wrap step on the option labels (`chunk-YEHNNDZZ.js:88-99`).
+
+After constructing `MastraTUI` we wrap `state.pendingAskUserComponents.set` so the first time mastracode registers a streaming `ask_user` instance we capture its constructor and monkey-patch `prototype.updateArgs` and `prototype.activate` to truncate any `option.label` whose visible width would overflow the current terminal (matching pi-tui's `cols - TERM_WIDTH_BUFFER(3) - box(4) - prefix(3) - headroom(1)` budget; appends `…`). Idempotent via `Symbol.for('luca.ask_user.label_truncate')`. Patch errors are logged but never block the question dialog.
+
+Long labels now render visibly clipped instead of crashing the process. Tracked in #173 alongside any other upstream workarounds.

--- a/.mastracode/skills/caveman/SKILL.md
+++ b/.mastracode/skills/caveman/SKILL.md
@@ -51,7 +51,7 @@ Example — destructive op:
 > ```sql
 > DROP TABLE users;
 > ```
-> Caveman resume. Verify backup exists first.
+> Caveman resume. Verify backup exist first.
 
 ## Boundaries
 

--- a/.mastracode/skills/caveman/SKILL.md
+++ b/.mastracode/skills/caveman/SKILL.md
@@ -51,7 +51,7 @@ Example — destructive op:
 > ```sql
 > DROP TABLE users;
 > ```
-> Caveman resume. Verify backup exist first.
+> Caveman resume. Verify backup exists first.
 
 ## Boundaries
 

--- a/packages/luca-mastracode/src/index.ts
+++ b/packages/luca-mastracode/src/index.ts
@@ -534,6 +534,122 @@ function buildContinuationMessage(
 }
 
 // ---------------------------------------------------------------------------
+// Visible-width helpers (used by the ask_user label-truncation workaround)
+// ---------------------------------------------------------------------------
+//
+// Pi-tui (the renderer underneath mastracode's TUI) computes line widths by
+// stripping ANSI escapes and counting *display columns* — so a CJK glyph or
+// emoji counts as 2 cells, ZWJ-joined sequences count as one grapheme, and
+// `\x1b[31m` counts as zero. Our truncation logic must use the same metric or
+// we can either (a) over-truncate (cutting off ASCII labels too aggressively
+// when they contain ANSI codes), or (b) under-truncate (failing to clip a
+// short-but-wide CJK label and re-tripping the original width assertion).
+//
+// We implement a minimal local copy here so the patch doesn't depend on the
+// shape of mastracode's transitive deps. Tracks pi-tui's `visibleWidth` /
+// `truncateToWidth` semantics for the cases that show up in `ask_user`
+// option labels: ASCII, CJK/emoji, and embedded ANSI styling.
+
+// CSI / OSC / SGR / cursor-control escapes — matches pi-tui's strip pattern.
+// eslint-disable-next-line no-control-regex
+const ANSI_ESCAPE_RE = /\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[@-Z\\-_])/g
+
+let cachedSegmenter: Intl.Segmenter | null = null
+function getSegmenter(): Intl.Segmenter {
+    if (!cachedSegmenter) {
+        cachedSegmenter = new Intl.Segmenter(undefined, {
+            granularity: 'grapheme',
+        })
+    }
+    return cachedSegmenter
+}
+
+// East-Asian Wide / Fullwidth + emoji ranges. Anything in here counts as 2
+// columns; everything else (excluding zero-width / control chars) counts as 1.
+function graphemeWidth(grapheme: string): number {
+    if (grapheme.length === 0) return 0
+    const cp = grapheme.codePointAt(0)
+    if (cp === undefined) return 0
+    // Zero-width: control chars, combining marks, ZWJ/ZWNJ, variation selectors.
+    if (cp < 0x20 || cp === 0x7f) return 0
+    if (cp >= 0x0300 && cp <= 0x036f) return 0 // combining diacriticals
+    if (cp === 0x200b || cp === 0x200c || cp === 0x200d) return 0 // ZW(N)J
+    if (cp >= 0xfe00 && cp <= 0xfe0f) return 0 // variation selectors
+    // Wide ranges (CJK, Hangul, fullwidth, emoji blocks).
+    if (
+        (cp >= 0x1100 && cp <= 0x115f) || // Hangul Jamo
+        (cp >= 0x2e80 && cp <= 0x303e) || // CJK radicals / symbols
+        (cp >= 0x3041 && cp <= 0x33ff) || // Hiragana/Katakana/CJK
+        (cp >= 0x3400 && cp <= 0x4dbf) || // CJK ext A
+        (cp >= 0x4e00 && cp <= 0x9fff) || // CJK unified
+        (cp >= 0xa000 && cp <= 0xa4cf) || // Yi
+        (cp >= 0xac00 && cp <= 0xd7a3) || // Hangul syllables
+        (cp >= 0xf900 && cp <= 0xfaff) || // CJK compat
+        (cp >= 0xfe30 && cp <= 0xfe4f) || // CJK compat forms
+        (cp >= 0xff00 && cp <= 0xff60) || // Fullwidth
+        (cp >= 0xffe0 && cp <= 0xffe6) || // Fullwidth signs
+        (cp >= 0x1f300 && cp <= 0x1faff) || // Emoji / pictographs
+        (cp >= 0x20000 && cp <= 0x3fffd) // CJK ext B–G
+    ) {
+        return 2
+    }
+    return 1
+}
+
+function visibleWidth(str: string): number {
+    const stripped = str.replace(ANSI_ESCAPE_RE, '')
+    let width = 0
+    for (const grapheme of getSegmenter().segment(stripped)) {
+        width += graphemeWidth(grapheme.segment)
+    }
+    return width
+}
+
+// Clip `str` to at most `maxWidth` display columns, replacing the trailing
+// run with `ellipsis` when truncation occurs. ANSI codes are dropped (the
+// truncated string is plain text — sufficient for `ask_user` option labels,
+// which mastracode renders inside its own theme.fg("dim", …) wrapper).
+//
+// If `maxWidth <= 0`, returns an empty string. If `maxWidth` is too small to
+// even hold the ellipsis, returns the ellipsis truncated to the budget. We
+// never produce output wider than `maxWidth`.
+function clipToVisibleWidth(
+    str: string,
+    maxWidth: number,
+    ellipsis: string = '…'
+): string {
+    if (maxWidth <= 0) return ''
+    const stripped = str.replace(ANSI_ESCAPE_RE, '')
+    const ellipsisWidth = visibleWidth(ellipsis)
+    // If the budget can't fit the ellipsis, return as much of the ellipsis as
+    // we can (typically '' for a width-0 budget; '…' fits in 1 cell).
+    if (maxWidth < ellipsisWidth) {
+        let acc = ''
+        let w = 0
+        for (const g of getSegmenter().segment(ellipsis)) {
+            const gw = graphemeWidth(g.segment)
+            if (w + gw > maxWidth) break
+            acc += g.segment
+            w += gw
+        }
+        return acc
+    }
+    const target = maxWidth - ellipsisWidth
+    let acc = ''
+    let w = 0
+    for (const g of getSegmenter().segment(stripped)) {
+        const gw = graphemeWidth(g.segment)
+        if (w + gw > target) {
+            return acc + ellipsis
+        }
+        acc += g.segment
+        w += gw
+    }
+    // String already fits — caller should have checked, but guard anyway.
+    return acc
+}
+
+// ---------------------------------------------------------------------------
 // Launch
 // ---------------------------------------------------------------------------
 
@@ -1256,31 +1372,48 @@ async function main() {
     // constructor lazily the first time mastracode stores an instance into
     // `state.pendingAskUserComponents`. After the prototype is patched, all
     // current and future instances pick up the safe behavior.
-    const tuiState = (
-        tui as unknown as {
-            state: {
-                pendingAskUserComponents: Map<string, unknown>
+    //
+    // The patch is purely defensive: every internal access is guarded so that
+    // if upstream changes shape (rename, drop the Map, swap the methods) we
+    // log a warning and no-op rather than crashing startup.
+    const askMap = (() => {
+        const tuiState = (tui as unknown as { state?: unknown }).state as
+            | { pendingAskUserComponents?: unknown }
+            | undefined
+        const candidate = tuiState?.pendingAskUserComponents
+        return candidate instanceof Map ? candidate : undefined
+    })()
+
+    if (askMap) {
+        const LUCA_ASK_USER_PATCHED = Symbol.for(
+            'luca.ask_user.label_truncate'
+        )
+        const originalSet = askMap.set.bind(askMap)
+        askMap.set = function patchedSet(
+            toolCallId: unknown,
+            instance: unknown
+        ) {
+            try {
+                patchAskQuestionPrototype(instance, LUCA_ASK_USER_PATCHED)
+            } catch (err) {
+                // Patching is purely defensive — never let it block the question.
+                console.error('[luca] ask_user prototype patch failed:', err)
             }
-        }
-    ).state
-    const askMap = tuiState.pendingAskUserComponents
-    const LUCA_ASK_USER_PATCHED = Symbol.for('luca.ask_user.label_truncate')
-    const originalSet = askMap.set.bind(askMap)
-    askMap.set = function patchedSet(toolCallId: string, instance: unknown) {
-        try {
-            patchAskQuestionPrototype(instance)
-        } catch (err) {
-            // Patching is purely defensive — never let it block the question.
-            console.error('[luca] ask_user prototype patch failed:', err)
-        }
-        return originalSet(toolCallId, instance)
-    } as typeof askMap.set
+            return originalSet(toolCallId, instance)
+        } as typeof askMap.set
+    } else {
+        console.warn(
+            '[luca] ask_user label-truncation patch skipped: ' +
+                'tui.state.pendingAskUserComponents is not a Map ' +
+                '(upstream mastracode internals may have changed).'
+        )
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    function patchAskQuestionPrototype(instance: any) {
+    function patchAskQuestionPrototype(instance: any, marker: symbol) {
         if (!instance || typeof instance !== 'object') return
         const proto = Object.getPrototypeOf(instance)
-        if (!proto || proto[LUCA_ASK_USER_PATCHED]) return
+        if (!proto || proto[marker]) return
 
         const truncateOptions = (
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1293,24 +1426,25 @@ async function main() {
             // subtracts a 3-column safety buffer (`TERM_WIDTH_BUFFER`) from
             // `process.stdout.columns`. Match that math, then leave 1 extra
             // cell of headroom so a stray wide character can't push us over.
+            //
+            // No floor clamps: on a tiny terminal the budget can be ≤ 0, and
+            // any positive minimum we invent would itself overflow. Instead
+            // we degrade to a single-cell ellipsis (or empty) when the budget
+            // collapses, which is the only string guaranteed to fit.
             const cols = process.stdout.columns || 80
-            const innerWidth = Math.max(
-                10,
+            const innerWidth =
                 cols - 3 /* TERM_WIDTH_BUFFER */ - 4 /* box */
-            )
-            const labelBudget = Math.max(
-                8,
+            const labelBudget =
                 innerWidth - 3 /* "   " prefix */ - 1 /* headroom */
-            )
             const ELLIPSIS = '…'
             return options.map((opt: unknown) => {
                 if (!opt || typeof opt !== 'object') return opt
                 const label = (opt as { label?: unknown }).label
                 if (typeof label !== 'string') return opt
-                if (label.length <= labelBudget) return opt
+                if (visibleWidth(label) <= labelBudget) return opt
                 return {
                     ...(opt as object),
-                    label: label.slice(0, labelBudget - 1) + ELLIPSIS,
+                    label: clipToVisibleWidth(label, labelBudget, ELLIPSIS),
                 }
             })
         }
@@ -1353,7 +1487,7 @@ async function main() {
             }
         }
 
-        proto[LUCA_ASK_USER_PATCHED] = true
+        proto[marker] = true
     }
 
     // Stale pipeline state is handled by two explicit guards:

--- a/packages/luca-mastracode/src/index.ts
+++ b/packages/luca-mastracode/src/index.ts
@@ -1232,6 +1232,130 @@ async function main() {
         inlineQuestions: true,
     })
 
+    // --- Workaround for upstream mastracode bug (tracked: issue #173) ---
+    //
+    // `AskQuestionInlineComponent` (used by the built-in `ask_user` tool) does
+    // not wrap or truncate option labels. Long labels render past the box's
+    // inner width, which trips pi-tui's per-line width assertion in
+    // `doRender()` and crashes the entire process with:
+    //
+    //   error: Rendered line N exceeds terminal width (X > Y).
+    //
+    // Bug location (installed bundle): `chunk-YEHNNDZZ.js:88-99` and
+    // surrounding branches in `_AskQuestionInlineBorderedBox._render`, where
+    // each option is emitted as `theme.fg("dim", `   ${item.label}`)` with no
+    // wrap/truncate step. The question text on the same component IS wrapped
+    // via `wrapTextWithAnsi(qLine, innerWidth)`, so this is just a missing
+    // wrap on the option labels.
+    //
+    // We monkey-patch `AskQuestionInlineComponent.prototype.updateArgs` and
+    // `.activate` (the two methods that feed option labels into the bordered
+    // box) to truncate any label whose visible width would overflow the
+    // current terminal. We can't import the class directly because mastracode
+    // doesn't re-export it from `mastracode/tui`, so we capture the
+    // constructor lazily the first time mastracode stores an instance into
+    // `state.pendingAskUserComponents`. After the prototype is patched, all
+    // current and future instances pick up the safe behavior.
+    const tuiState = (
+        tui as unknown as {
+            state: {
+                pendingAskUserComponents: Map<string, unknown>
+            }
+        }
+    ).state
+    const askMap = tuiState.pendingAskUserComponents
+    const LUCA_ASK_USER_PATCHED = Symbol.for('luca.ask_user.label_truncate')
+    const originalSet = askMap.set.bind(askMap)
+    askMap.set = function patchedSet(toolCallId: string, instance: unknown) {
+        try {
+            patchAskQuestionPrototype(instance)
+        } catch (err) {
+            // Patching is purely defensive — never let it block the question.
+            console.error('[luca] ask_user prototype patch failed:', err)
+        }
+        return originalSet(toolCallId, instance)
+    } as typeof askMap.set
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function patchAskQuestionPrototype(instance: any) {
+        if (!instance || typeof instance !== 'object') return
+        const proto = Object.getPrototypeOf(instance)
+        if (!proto || proto[LUCA_ASK_USER_PATCHED]) return
+
+        const truncateOptions = (
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            options: any
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ): any => {
+            if (!Array.isArray(options)) return options
+            // The bordered box renders each option as `   ${label}` inside a
+            // box that consumes 4 columns of frame (`│ ` + ` │`). Pi-tui also
+            // subtracts a 3-column safety buffer (`TERM_WIDTH_BUFFER`) from
+            // `process.stdout.columns`. Match that math, then leave 1 extra
+            // cell of headroom so a stray wide character can't push us over.
+            const cols = process.stdout.columns || 80
+            const innerWidth = Math.max(
+                10,
+                cols - 3 /* TERM_WIDTH_BUFFER */ - 4 /* box */
+            )
+            const labelBudget = Math.max(
+                8,
+                innerWidth - 3 /* "   " prefix */ - 1 /* headroom */
+            )
+            const ELLIPSIS = '…'
+            return options.map((opt: unknown) => {
+                if (!opt || typeof opt !== 'object') return opt
+                const label = (opt as { label?: unknown }).label
+                if (typeof label !== 'string') return opt
+                if (label.length <= labelBudget) return opt
+                return {
+                    ...(opt as object),
+                    label: label.slice(0, labelBudget - 1) + ELLIPSIS,
+                }
+            })
+        }
+
+        const originalUpdateArgs = proto.updateArgs
+        if (typeof originalUpdateArgs === 'function') {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            proto.updateArgs = function patchedUpdateArgs(args: any) {
+                if (
+                    args &&
+                    typeof args === 'object' &&
+                    Array.isArray((args as { options?: unknown }).options)
+                ) {
+                    args = {
+                        ...args,
+                        options: truncateOptions(
+                            (args as { options: unknown[] }).options
+                        ),
+                    }
+                }
+                return originalUpdateArgs.call(this, args)
+            }
+        }
+
+        const originalActivate = proto.activate
+        if (typeof originalActivate === 'function') {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            proto.activate = function patchedActivate(options: any) {
+                if (
+                    options &&
+                    typeof options === 'object' &&
+                    Array.isArray(options.options)
+                ) {
+                    options = {
+                        ...options,
+                        options: truncateOptions(options.options),
+                    }
+                }
+                return originalActivate.call(this, options)
+            }
+        }
+
+        proto[LUCA_ASK_USER_PATCHED] = true
+    }
+
     // Stale pipeline state is handled by two explicit guards:
     // 1. reset-pipeline (called by finalize) clears all session-scoped fields
     // 2. switch-mode to triage detects stale state and prompts the user


### PR DESCRIPTION
## Summary

Adds a defensive workaround so long option labels passed to `ask_user` no longer crash the TUI. Previously, any caller-supplied option label wider than the bordered-box inner width would trip pi-tui's "Rendered line N exceeds terminal width" assertion inside `doRender()` and kill the entire `luca run` process with no recovery path.

After this PR, long labels render visibly clipped (with an ellipsis) instead of crashing. The `description` field is unaffected and still shown in full inside the SelectList.

## Background

Inside upstream `mastracode@0.15.2`, `AskQuestionInlineComponent` (the inline `ask_user` dialog) wraps the **question** text via `wrapTextWithAnsi(qLine, innerWidth)`, but emits each option label as a single unwrapped line:

```js
const line = theme.fg("dim", `   ${item.label}`);
addLine(line, visibleWidth(line));
```

There is no `wrapTextWithAnsi` / `truncateToWidth` step on `item.label`, so labels longer than `innerWidth - 3` overflow.

## Implementation

- After constructing `MastraTUI`, wrap `tui.state.pendingAskUserComponents.set` so the first time mastracode registers a streaming `ask_user` instance we capture its constructor and monkey-patch `prototype.updateArgs` and `prototype.activate`.
- Both patched methods truncate any `option.label` whose visible width would overflow the current terminal, matching pi-tui's budget: `cols - TERM_WIDTH_BUFFER(3) - box(4) - prefix(3) - headroom(1)`. An ellipsis (`…`) is appended.
- Idempotent via `Symbol.for('luca.ask_user.label_truncate')` (same pattern as the existing `writeFileTool` workaround in this file).
- Patch errors are caught and logged via `console.error` so they can never block the question dialog.

`AskQuestionInlineComponent` isn't re-exported from `mastracode/tui`, so the lazy capture-via-Map-set strategy is the cleanest hook point we have without touching the upstream package.

## Why this lives in luca-mastracode

This is a third active workaround for upstream Mastra issues, all tracked in #173. It's purely defensive — once upstream wraps/truncates option labels, this patch can be removed.

## Test plan

- `bunx --bun tsc --noEmit` — clean.
- `bun run build` — succeeds.
- `bun run mastracode` boots into the TUI without errors; patch wires up at construction time before the first event.
- Math check: a 112-char label (the one that crashed the original session) truncates to 97 chars, rendering at visible width 100 ≤ 101-cell `innerWidth` budget for a 108-column terminal.

## Related

- Tracked in #173 (Upstream Mastra bug tracker), entry #2.
