### PR TITLE
chore: fix changesets to release luca-framework + luca-mastracode together

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -6,3 +6,18 @@ find the full documentation for it [in our repository](https://github.com/change
 
 We have a quick list of common questions to get you started engaging with this project in
 [our documentation](https://github.com/changesets/changesets/blob/main/docs/common-questions.md).
+
+## Fixed packages
+
+`@alecsibilia/luca-framework` and `@alecsibilia/luca-mastracode` are configured as a **fixed** pair in
+`config.json`. Any changeset that targets one will release both at the same new version, even if the
+other package has no changesets of its own.
+
+This is intentional. `luca-mastracode` is `private: true` and is never published to npm — it is bundled
+into the framework tarball at build time (`dist/mastracode/`). Any change to mastracode is therefore a
+runtime change to the framework's published artifact, and the two packages always ship together as a
+single unit.
+
+In practice this means you can write a changeset against whichever package the change conceptually lives
+in, and the release tooling will keep both versions in lockstep. You do not need to remember to add the
+framework to every mastracode changeset.

--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -10,13 +10,13 @@ We have a quick list of common questions to get you started engaging with this p
 ## Fixed packages
 
 `@alecsibilia/luca-framework` and `@alecsibilia/luca-mastracode` are configured as a **fixed** pair in
-`config.json`. Any changeset that targets one will release both at the same new version, even if the
-other package has no changesets of its own.
+`config.json`. Any changeset that targets one will version both together at the same new version, even
+if the other package has no changesets of its own.
 
 This is intentional. `luca-mastracode` is `private: true` and is never published to npm — it is bundled
 into the framework tarball at build time (`dist/mastracode/`). Any change to mastracode is therefore a
-runtime change to the framework's published artifact, and the two packages always ship together as a
-single unit.
+runtime change to the framework's published artifact, so the two packages are kept in lockstep even
+though only `@alecsibilia/luca-framework` is published and `luca-mastracode` is bundled within it.
 
 In practice this means you can write a changeset against whichever package the change conceptually lives
 in, and the release tooling will keep both versions in lockstep. You do not need to remember to add the

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,9 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [
+    ["@alecsibilia/luca-framework", "@alecsibilia/luca-mastracode"]
+  ],
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",

--- a/.changeset/ship-dx-audit-framework.md
+++ b/.changeset/ship-dx-audit-framework.md
@@ -1,4 +1,5 @@
 ---
+"@alecsibilia/luca-framework": patch
 "@alecsibilia/luca-mastracode": patch
 ---
 

--- a/.changeset/ship-dx-audit-framework.md
+++ b/.changeset/ship-dx-audit-framework.md
@@ -1,0 +1,7 @@
+---
+"@alecsibilia/luca-mastracode": patch
+---
+
+Re-publish to ship the DX audit refactor of the bundled `luca-mastracode` harness — extraction of `index.ts` into focused modules (`branding`, `rules-loader`, `agent-constraints`, `create-static-agent`, `install-bundled-assets`, `continuation-messages`, `tui-text-helpers`, `mastracode-config`, `launch`), splits of `tools/run-checks.ts` and `tools/repo-cleanup.ts`, and review-feedback fixes for `applyGitignore` whole-line matching and `graphemeWidth` emoji coverage.
+
+The previous release of these changes only bumped `luca-mastracode`, but `luca-mastracode` is `private: true` and bundled into the framework tarball at build time, so the published `luca-framework` artifact never picked them up. With the new `fixed` config in `.changeset/config.json`, this changeset bumps both packages together so the framework actually ships the refactored harness.


### PR DESCRIPTION
## What

Switches `.changeset/config.json` from `linked: []` to `fixed: [["@alecsibilia/luca-framework", "@alecsibilia/luca-mastracode"]]` so both packages always release at the same version — regardless of which one a changeset targets.

Also includes a one-shot changeset to ship the DX audit refactor on the framework (PR #178 only bumped `luca-mastracode@10.5.0`; the published framework artifact never picked it up).

## Why

`luca-mastracode` is `private: true` and never published to npm. It is bundled into `luca-framework`'s tarball at build time at `dist/mastracode/`. Any change to mastracode is therefore a runtime change to the framework's published artifact, but changesets had no signal because:

1. The framework declares mastracode as a `devDependency` (changesets ignores devDeps for cascade bumps)
2. Even if it were a runtime dep, `workspace:*` against a `private: true` package has no published version to track

`fixed` is the correct primitive for "these packages ship as one unit." `linked` only enforces version equality *when both happen to be bumped*; it does not pull a sibling into a release on its own. Confirmed experimentally — `linked` left `luca-framework` at `11.0.2` while `luca-mastracode` went to `11.1.0`.

## Verification

`bunx changeset status` with this branch's changeset shows both packages bump to `11.0.3` together. `bunx changeset version` (run locally, then reverted) confirmed both `package.json` files updated to the same version.

## Notes

- `.changeset/README.md` documents the `fixed` configuration so future contributors understand the coupling
- A prior PR (#171) tried to fix this with `updateInternalDependencies` cascade — that approach can't work for `devDependencies` on private packages, which is why this lands a different fix
