### PR TITLE
fix(release): publish luca-framework public + migrate to OIDC trusted publishing

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
     ["@alecsibilia/luca-framework", "@alecsibilia/luca-mastracode"]
   ],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/.changeset/fix-npm-public-access.md
+++ b/.changeset/fix-npm-public-access.md
@@ -1,0 +1,5 @@
+---
+"@alecsibilia/luca-framework": patch
+---
+
+Publish `@alecsibilia/luca-framework` with public access. The release workflow was passing `--access restricted` to `bun publish` and `.changeset/config.json` was set to `"access": "restricted"`, so every release re-marked the scoped package as private on npm even after a manual toggle in the npm UI. Switch both to `public` and add `publishConfig.access: "public"` to the package's `package.json` as a defense-in-depth default.

--- a/.changeset/fix-npm-public-access.md
+++ b/.changeset/fix-npm-public-access.md
@@ -2,4 +2,8 @@
 "@alecsibilia/luca-framework": patch
 ---
 
-Publish `@alecsibilia/luca-framework` with public access. The release workflow was passing `--access restricted` to `bun publish` and `.changeset/config.json` was set to `"access": "restricted"`, so every release re-marked the scoped package as private on npm even after a manual toggle in the npm UI. Switch both to `public` and add `publishConfig.access: "public"` to the package's `package.json` as a defense-in-depth default.
+Publish `@alecsibilia/luca-framework` with public access, and migrate the release pipeline to npm OIDC trusted publishing.
+
+- The package was being re-marked private on every release: `.github/workflows/release.yml` invoked `bun publish --access restricted` and `.changeset/config.json` had `"access": "restricted"`. Both flip to `public`, and `packages/luca-framework/package.json` now sets `publishConfig.access: "public"` as a defense-in-depth default.
+- The publish job no longer uses a long-lived `NPM_TOKEN` secret. It authenticates via GitHub Actions OIDC against the npm Trusted Publisher configured for this package, and emits signed provenance attestations on every release.
+- Because `bun publish` does not yet support npm OIDC ([oven-sh/bun#22423](https://github.com/oven-sh/bun/issues/22423)), the publish step packs the tarball with `bun pm pack` (which resolves `catalog:` and `workspace:*` protocols) and hands the resulting tarball to `npm publish --provenance`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,4 +111,4 @@ jobs:
         run: bunx --bun tsc --noEmit
 
       - name: Publish to npm
-        run: cd packages/luca-framework && bun publish --access restricted
+        run: cd packages/luca-framework && bun publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,11 @@
 # workflows (GitHub's recursion-prevention behavior).
 #
 # Requirements:
-#   - NPM_TOKEN repository secret with publish permission for
-#     @alecsibilia/luca-framework.
+#   - npm Trusted Publisher configured on npmjs.com for
+#     @alecsibilia/luca-framework, pointing at this repository and the
+#     `Release` workflow. No NPM_TOKEN secret is used — the publish job
+#     authenticates via OIDC, which also produces signed provenance
+#     attestations on each release.
 
 name: Release
 
@@ -90,8 +93,12 @@ jobs:
     needs: release
     if: needs.release.outputs.published == 'true'
     runs-on: ubuntu-latest
+    # id-token: write is required for npm trusted publishing (OIDC).
+    # No NPM_TOKEN is used — npm exchanges this OIDC token for a short-lived
+    # publish credential via the trusted publisher configured on npmjs.com.
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -101,8 +108,16 @@ jobs:
         with:
           bun-version: "1.3"
 
-      - name: Configure npm auth
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      # Trusted publishing requires npm CLI 11.5.1+. The Node 22 image ships
+      # with npm 10.x, so upgrade to the latest npm before publishing.
+      - name: Upgrade npm to support trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -110,5 +125,15 @@ jobs:
       - name: Typecheck
         run: bunx --bun tsc --noEmit
 
-      - name: Publish to npm
-        run: cd packages/luca-framework && bun publish --access public
+      - name: Build framework
+        run: cd packages/luca-framework && bun run build
+
+      # bun pm pack rewrites catalog: and workspace:* protocols to concrete
+      # semver ranges that npm understands; bun publish itself does the same
+      # rewrite, but bun publish doesn't yet support npm OIDC trusted
+      # publishing (oven-sh/bun#22423), so we hand the tarball to npm.
+      - name: Pack tarball (resolves catalog/workspace protocols)
+        run: cd packages/luca-framework && bun pm pack --destination ./.pack
+
+      - name: Publish to npm via OIDC trusted publishing
+        run: cd packages/luca-framework && npm publish ./.pack/*.tgz --access public --provenance

--- a/packages/luca-framework/package.json
+++ b/packages/luca-framework/package.json
@@ -42,6 +42,9 @@
     "muninndb"
   ],
   "module": "./dist/index.mjs",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/alecsibilia/luca-framework.git",


### PR DESCRIPTION
## Summary

Two release-pipeline fixes bundled together:

**1. Stop re-marking the package private on every release.**
- `.github/workflows/release.yml` invoked `bun publish --access restricted`, and `.changeset/config.json` had `"access": "restricted"`. Both flip to `public`, and `packages/luca-framework/package.json` now sets `publishConfig.access: "public"` as a defense-in-depth default.

**2. Replace the long-lived `NPM_TOKEN` secret with npm OIDC trusted publishing.**
- Add `permissions.id-token: write` to the publish job (required for OIDC token exchange).
- Drop the `.npmrc` token-injection step.
- Add `actions/setup-node@v4` + `npm install -g npm@latest` because trusted publishing requires npm CLI 11.5.1+ and the Node 22 image ships with npm 10.x.
- Pack with `bun pm pack` (which resolves Bun's `catalog:` and `workspace:*` protocols to concrete semver) and hand the tarball to `npm publish --provenance`. This split is required because `bun publish` doesn't yet support npm OIDC ([oven-sh/bun#22423](https://github.com/oven-sh/bun/issues/22423)). Verified locally that `bun pm pack` strips the protocols correctly.
- Get free signed provenance attestations on every release.

A patch changeset is included so the next release exercises the new pipeline end-to-end.

## Required pre-merge configuration (manual)

- [ ] Repository made public on GitHub (provenance attestations need a publicly verifiable source).
- [ ] On npmjs.com → `@alecsibilia/luca-framework` → Settings → Trusted Publisher: add a GitHub Actions trusted publisher pointing at `asibilia/luca-framework`, workflow file `.github/workflows/release.yml`. (Leave Environment blank unless we add one.)

## Post-merge cleanup

- [ ] Once the first OIDC-driven release succeeds, delete the `NPM_TOKEN` repository secret from GitHub.

## Test plan

- [ ] CI typecheck passes on this PR.
- [ ] After this PR merges, the Changesets workflow opens a Version PR bumping both packages (per the `fixed` group) by a patch.
- [ ] Merging the Version PR triggers the publish job; `npm publish ./.pack/*.tgz --access public --provenance` succeeds without `NPM_TOKEN`.
- [ ] On npmjs.com, the new version of `@alecsibilia/luca-framework` shows **public** access and a **provenance** badge.
- [ ] A subsequent release (any future changeset) does not flip the package back to private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)