### PR TITLE
fix(release): bump publish runner to Node 24 (npm 11.12+)

### DIFF
--- a/.changeset/fix-npm-cli-upgrade.md
+++ b/.changeset/fix-npm-cli-upgrade.md
@@ -4,4 +4,4 @@
 
 Republish to fix the OIDC publish job, which failed on the previous release (v11.0.4 was tagged on GitHub but never reached npm).
 
-The publish job ran `npm install -g npm@latest` to satisfy npm's trusted-publishing minimum (11.5.1+), but the bundled npm replaces itself in place during the global install and the half-overwritten install fails with `Cannot find module 'promise-retry'`. Switch to installing npm into a separate prefix (`/tmp/npm-cli`) and invoke its bin directly, so the bundled npm isn't overwriting itself while it runs.
+The publish job was running on Node 22 and trying to globally upgrade the bundled npm (10.9.x) to satisfy trusted publishing's 11.5.1+ requirement. The in-place self-upgrade left module resolution in a broken state (`Cannot find module 'promise-retry'`). It turns out the entire Node 22 LTS line never crossed into npm 11.x — the highest bundled npm there is 10.9.7. Bump the runner to Node 24 LTS, which ships with npm 11.12.x out of the box, and drop the manual npm upgrade entirely.

--- a/.changeset/fix-npm-cli-upgrade.md
+++ b/.changeset/fix-npm-cli-upgrade.md
@@ -1,0 +1,7 @@
+---
+"@alecsibilia/luca-framework": patch
+---
+
+Republish to fix the OIDC publish job, which failed on the previous release (v11.0.4 was tagged on GitHub but never reached npm).
+
+The publish job ran `npm install -g npm@latest` to satisfy npm's trusted-publishing minimum (11.5.1+), but the bundled npm replaces itself in place during the global install and the half-overwritten install fails with `Cannot find module 'promise-retry'`. Switch to installing npm into a separate prefix (`/tmp/npm-cli`) and invoke its bin directly, so the bundled npm isn't overwriting itself while it runs.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,24 +108,14 @@ jobs:
         with:
           bun-version: "1.3"
 
+      # Node 24 is the active LTS and bundles npm >= 11.12, which clears
+      # the 11.5.1 floor required for npm trusted publishing. Node 22 LTS
+      # peaked at npm 10.9.7, so we can't use it without a manual upgrade.
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
-
-      # Trusted publishing requires npm CLI 11.5.1+. The Node 22 image ships
-      # with npm 10.x. We can't `npm install -g npm@latest` here — the
-      # bundled npm replaces itself in place during the install and the
-      # transient state breaks module resolution
-      # (`Cannot find module 'promise-retry'`). Install npm into a separate
-      # prefix instead, then call its bin directly. The bundled npm handles
-      # the install fine because it isn't overwriting itself.
-      - name: Install npm CLI 11.5.1+ for trusted publishing
-        run: |
-          mkdir -p /tmp/npm-cli
-          npm install --prefix /tmp/npm-cli npm@latest
-          /tmp/npm-cli/node_modules/.bin/npm --version
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -144,4 +134,4 @@ jobs:
         run: cd packages/luca-framework && bun pm pack --destination ./.pack
 
       - name: Publish to npm via OIDC trusted publishing
-        run: cd packages/luca-framework && /tmp/npm-cli/node_modules/.bin/npm publish ./.pack/*.tgz --access public --provenance
+        run: cd packages/luca-framework && npm publish ./.pack/*.tgz --access public --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,9 +115,17 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       # Trusted publishing requires npm CLI 11.5.1+. The Node 22 image ships
-      # with npm 10.x, so upgrade to the latest npm before publishing.
-      - name: Upgrade npm to support trusted publishing
-        run: npm install -g npm@latest
+      # with npm 10.x. We can't `npm install -g npm@latest` here — the
+      # bundled npm replaces itself in place during the install and the
+      # transient state breaks module resolution
+      # (`Cannot find module 'promise-retry'`). Install npm into a separate
+      # prefix instead, then call its bin directly. The bundled npm handles
+      # the install fine because it isn't overwriting itself.
+      - name: Install npm CLI 11.5.1+ for trusted publishing
+        run: |
+          mkdir -p /tmp/npm-cli
+          npm install --prefix /tmp/npm-cli npm@latest
+          /tmp/npm-cli/node_modules/.bin/npm --version
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -136,4 +144,4 @@ jobs:
         run: cd packages/luca-framework && bun pm pack --destination ./.pack
 
       - name: Publish to npm via OIDC trusted publishing
-        run: cd packages/luca-framework && npm publish ./.pack/*.tgz --access public --provenance
+        run: cd packages/luca-framework && /tmp/npm-cli/node_modules/.bin/npm publish ./.pack/*.tgz --access public --provenance


### PR DESCRIPTION
## Summary

The publish job from PR #181 / #182 failed: v11.0.4 was tagged on GitHub but never reached npm (registry latest is still 11.0.3). The failed run is [here](https://github.com/asibilia/luca-framework/actions/runs/25053687352/job/73388048779).

**Root cause.** The publish job ran on Node 22 and tried to `npm install -g npm@latest` to satisfy trusted publishing's npm 11.5.1+ minimum. The bundled npm 10.x replaces itself in place during the global install, and the new npm tries to load modules from the directory it's actively replacing → `Cannot find module 'promise-retry'`.

Crucially, **Node 22 LTS never crossed into npm 11.x** at all — the highest bundled npm in the v22 line is 10.9.7. So we either keep doing some kind of upgrade dance, or we move the runner to a Node line that already ships a recent enough npm.

**Fix.** Bump the publish-job runner to **Node 24 LTS** (active LTS as of Oct 2025), which ships with npm 11.12.x out of the box. Drop the manual `npm install` step entirely. No prefix-install hack, no bin path juggling — just plain `npm publish` against the bundled npm. Net diff is shorter than before.

A no-op changeset is included so the next Version PR bumps both packages to 11.0.5 and exercises the fixed publish job end-to-end. v11.0.4 stays as a dangling GitHub tag/release with no corresponding npm version — harmless, since npm doesn't require contiguous versions.

## Test plan

- [ ] CI typecheck passes on this PR.
- [ ] Merging this PR opens a Version PR bumping both packages to 11.0.5.
- [ ] Merging the Version PR triggers a Release run; the publish job completes successfully on Node 24.
- [ ] On npmjs.com, `@alecsibilia/luca-framework@11.0.5` shows **public** access and a **provenance** badge.
- [ ] After verification, the unused v11.0.4 GitHub release can be deleted (optional — leaving it does no harm).
- [ ] After the first successful OIDC publish, delete the `NPM_TOKEN` repo secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)