### PR TITLE
fix(release): drop setup-node registry-url so npm uses OIDC, not token

### DIFF
--- a/.changeset/fix-oidc-auth-token.md
+++ b/.changeset/fix-oidc-auth-token.md
@@ -4,6 +4,16 @@
 
 Republish to fix the OIDC publish job, which failed at the registry `PUT` on v11.0.5 (provenance was signed and pushed to sigstore, but the tarball never landed).
 
-The publish step's `actions/setup-node` config included `registry-url: https://registry.npmjs.org`. setup-node responds to that by writing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into an `.npmrc` it creates for the job. With no real `NPM_TOKEN` provided, `NODE_AUTH_TOKEN` resolves to setup-node's literal placeholder (`XXXXX-XXXXX-XXXXX-XXXXX`), and npm uses **any** configured `_authToken` in preference to OIDC trusted publishing — so it tried to authenticate with the placeholder and got back `404 Not Found - PUT https://registry.npmjs.org/@alecsibilia%2fluca-framework`.
+The publish step runs `cd packages/luca-framework && npm publish ./.pack/*.tgz`, and **two** sources were injecting `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into the npm config:
 
-Drop `registry-url` from setup-node so it doesn't write the auth-token line. With no `_authToken` configured, npm falls through to OIDC, exchanges the GitHub Actions ID token for a publish credential, and publishes normally. The default registry is `https://registry.npmjs.org/` anyway.
+1. `actions/setup-node` was configured with `registry-url: https://registry.npmjs.org`, which makes setup-node write that auth-token line into the runner-level `.npmrc`.
+2. `packages/luca-framework/.npmrc` was checked into the repo (a leftover from the original token-based publish workflow) with the same line.
+
+With no real `NPM_TOKEN` provided, `NODE_AUTH_TOKEN` resolved to setup-node's literal placeholder (`XXXXX-XXXXX-XXXXX-XXXXX`). npm uses **any** configured `_authToken` in preference to OIDC trusted publishing — so it tried to authenticate with the placeholder and got back `404 Not Found - PUT https://registry.npmjs.org/@alecsibilia%2fluca-framework`.
+
+The fix removes both sources:
+
+- Drop `registry-url` from `actions/setup-node` so it doesn't write the runner-level `.npmrc`.
+- Delete `packages/luca-framework/.npmrc`. It was added in 2024 to wire up token-based publishing in CI and is obsolete under OIDC trusted publishing — local development doesn't need it either.
+
+With no `_authToken` configured at publish time, npm falls through to OIDC: it exchanges the GitHub Actions ID token via the configured Trusted Publisher and publishes normally. npm's default registry is `https://registry.npmjs.org/` anyway.

--- a/.changeset/fix-oidc-auth-token.md
+++ b/.changeset/fix-oidc-auth-token.md
@@ -1,0 +1,9 @@
+---
+"@alecsibilia/luca-framework": patch
+---
+
+Republish to fix the OIDC publish job, which failed at the registry `PUT` on v11.0.5 (provenance was signed and pushed to sigstore, but the tarball never landed).
+
+The publish step's `actions/setup-node` config included `registry-url: https://registry.npmjs.org`. setup-node responds to that by writing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into an `.npmrc` it creates for the job. With no real `NPM_TOKEN` provided, `NODE_AUTH_TOKEN` resolves to setup-node's literal placeholder (`XXXXX-XXXXX-XXXXX-XXXXX`), and npm uses **any** configured `_authToken` in preference to OIDC trusted publishing — so it tried to authenticate with the placeholder and got back `404 Not Found - PUT https://registry.npmjs.org/@alecsibilia%2fluca-framework`.
+
+Drop `registry-url` from setup-node so it doesn't write the auth-token line. With no `_authToken` configured, npm falls through to OIDC, exchanges the GitHub Actions ID token for a publish credential, and publishes normally. The default registry is `https://registry.npmjs.org/` anyway.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,11 +111,18 @@ jobs:
       # Node 24 is the active LTS and bundles npm >= 11.12, which clears
       # the 11.5.1 floor required for npm trusted publishing. Node 22 LTS
       # peaked at npm 10.9.7, so we can't use it without a manual upgrade.
+      #
+      # NOTE: do NOT pass `registry-url` here. setup-node responds by
+      # writing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into
+      # an .npmrc, and npm uses any configured `_authToken` in preference
+      # to OIDC trusted publishing. Without a real NPM_TOKEN that resolves
+      # to setup-node's literal placeholder string and the registry returns
+      # 404. Leaving registry-url unset means no .npmrc, no token auth,
+      # and npm uses OIDC. The default registry is npmjs.org anyway.
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "24"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,8 +117,11 @@ jobs:
       # an .npmrc, and npm uses any configured `_authToken` in preference
       # to OIDC trusted publishing. Without a real NPM_TOKEN that resolves
       # to setup-node's literal placeholder string and the registry returns
-      # 404. Leaving registry-url unset means no .npmrc, no token auth,
-      # and npm uses OIDC. The default registry is npmjs.org anyway.
+      # 404. Leaving registry-url unset means setup-node writes no .npmrc.
+      # (We also deleted the obsolete `packages/luca-framework/.npmrc` that
+      # carried the same `_authToken=${NODE_AUTH_TOKEN}` line; it would
+      # otherwise be picked up when the publish step cd's into the package
+      # directory.) The default registry is npmjs.org anyway.
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/packages/luca-framework/.npmrc
+++ b/packages/luca-framework/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}


### PR DESCRIPTION
## Summary

The v11.0.5 publish job [failed at the registry `PUT`](https://github.com/asibilia/luca-framework/actions/runs/25053687352) with `404 Not Found - PUT https://registry.npmjs.org/@alecsibilia%2fluca-framework`. Pack succeeded, provenance was signed and pushed to sigstore, but the tarball never made it to the registry.

**Root cause.** `actions/setup-node` was configured with `registry-url: https://registry.npmjs.org`. setup-node responds to that flag by writing an `.npmrc` containing:

```
//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
```

With no real `NPM_TOKEN` in scope, `NODE_AUTH_TOKEN` resolved to setup-node's literal placeholder string (`XXXXX-XXXXX-XXXXX-XXXXX`). And npm uses **any** configured `_authToken` in preference to OIDC trusted publishing — so it authenticated with the placeholder, the registry rejected it, and npm surfaced the rejection as a 404.

The provenance step worked because sigstore signing uses the OIDC env vars directly, independent of `.npmrc`. The publish step's auth was hijacked by the bogus token.

**Fix.** Drop `registry-url` from setup-node. With nothing in `.npmrc`, npm has no token configured and falls through to OIDC: exchanges the GH Actions ID token via the configured Trusted Publisher and publishes normally. npm's default registry is `https://registry.npmjs.org/` anyway.

A no-op changeset is included so the next Version PR bumps to 11.0.6 and exercises the fixed path end-to-end. v11.0.4 and v11.0.5 stay as dangling GitHub tags with no corresponding npm versions — npm doesn't require contiguous versions, so this is harmless.

## Test plan

- [ ] CI typecheck passes on this PR.
- [ ] Merging this PR opens a Version PR bumping both packages to 11.0.6.
- [ ] Merging the Version PR triggers a Release run; the publish job completes successfully.
- [ ] On npmjs.com, `@alecsibilia/luca-framework@11.0.6` shows **public** access and a **provenance** badge.
- [ ] After verification, the unused v11.0.4 / v11.0.5 GitHub releases can be deleted (optional — leaving them does no harm).
- [ ] After the first successful OIDC publish, delete the `NPM_TOKEN` repo secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)