### PR TITLE
fix(release): correct repository.url typo to match actual GitHub repo

### DIFF
--- a/.changeset/fix-oidc-npm-upgrade-and-repo-url.md
+++ b/.changeset/fix-oidc-npm-upgrade-and-repo-url.md
@@ -1,0 +1,9 @@
+---
+"@alecsibilia/luca-framework": patch
+---
+
+Republish to exercise the OIDC publish pipeline now that the npm-side configuration is correct.
+
+The OIDC publish job has been failing since v11.0.4. The most recent run (v11.0.6) made it through pack and provenance signing, then died with the misleading `npm error code ENEEDAUTH`. Root cause turned out to be on the npm side: the Trusted Publisher on `npmjs.com` was configured for `alecsibilia/luca-framework` (the npm scope name), but the actual GitHub repo is `asibilia/luca-framework`. The OIDC token from GitHub Actions carried `repository: asibilia/luca-framework` as a claim, which never matched the trusted-publisher config, so npm refused the token exchange. Per [npm/cli#9088](https://github.com/npm/cli/issues/9088), the npm CLI surfaces silent OIDC failures as `ENEEDAUTH`, which is what we kept seeing.
+
+This release also fixes a separate, smaller bug in `packages/luca-framework/package.json`: `repository.url` was pointing at `https://github.com/alecsibilia/luca-framework.git` (extra `lec`) when it should be `https://github.com/asibilia/luca-framework.git`. With the trusted-publisher config now matching the real repo, npm's provenance step would have validated the package's `repository.url` against that config on the next attempt and rejected it with a 422 — fixing the typo here pre-empts that.

--- a/packages/luca-framework/package.json
+++ b/packages/luca-framework/package.json
@@ -47,7 +47,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/alecsibilia/luca-framework.git",
+    "url": "https://github.com/asibilia/luca-framework.git",
     "directory": "packages/luca-framework"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

Root cause for the OIDC publish saga (v11.0.4 → v11.0.6 all failing) was on the npm side: the Trusted Publisher on `npmjs.com` was configured for `alecsibilia/luca-framework` (the npm scope name) instead of `asibilia/luca-framework` (the actual GitHub repo). The OIDC token from GitHub Actions carried `repository: asibilia/luca-framework` as a claim, never matched the trusted-publisher config, so npm refused the token exchange. The misleading `ENEEDAUTH` we kept seeing on v11.0.6 is [npm/cli#9088](https://github.com/npm/cli/issues/9088) — silent OIDC failures surface as a generic "you need to log in" error.

The trusted-publisher config has been corrected manually on npmjs.com. This PR fixes one related bug in the repo so the next publish doesn't hit a follow-on failure:

- `packages/luca-framework/package.json` had `repository.url` pointing at `https://github.com/alecsibilia/luca-framework.git` (with an extra `lec`). With the trusted-publisher config now correct, provenance signing would have validated the package's `repository.url` against it on the next publish and rejected it with a 422. Fix the typo to pre-empt that.

A no-op changeset is included so merging this opens a Version PR for 11.0.7, which will exercise the now-correct OIDC pipeline end-to-end.

## What's *not* in this PR

Earlier iteration of this branch added a `npm install -g npm@latest` step to the publish job, on the theory that Node 24's bundled npm 11.11/11.12 had OIDC bugs. That was a false lead — the bundled npm is fine; the failures were the trusted-publisher mismatch all along. Step removed.

## Test plan

- [ ] CI typecheck passes on this PR.
- [ ] Merging this PR opens a Version PR bumping both packages to 11.0.7.
- [ ] Merging the Version PR triggers a Release run; the publish job completes successfully.
- [ ] On npmjs.com, `@alecsibilia/luca-framework@11.0.7` shows **public** access and a **provenance** badge.
- [ ] If publish *still* fails with `ENEEDAUTH`, re-add the `npm install -g npm@latest` step (defensive against npm/cli#9088 surfacing some other silent OIDC failure).
- [ ] After confirmed working, delete the `NPM_TOKEN` repo secret. The unused v11.0.4 / v11.0.5 / v11.0.6 GitHub releases can also be deleted (optional — leaving them does no harm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)