### PR TITLE
fix(release): declare environment npm-publish on publish job for OIDC

### DIFF
--- a/.changeset/fix-oidc-environment.md
+++ b/.changeset/fix-oidc-environment.md
@@ -1,0 +1,9 @@
+---
+"@alecsibilia/luca-framework": patch
+---
+
+Republish to actually exercise OIDC trusted publishing end-to-end.
+
+Root cause for the long string of `ENEEDAUTH` failures (v11.0.4 through v11.0.7) was finally pinned down by comparing against another repo where OIDC publishing is known to work: the npm Trusted Publisher for `@alecsibilia/luca-framework` is configured with **Environment name: `npm-publish`**, but the publish job in `.github/workflows/release.yml` did not declare `environment: npm-publish`. Because the OIDC token GitHub Actions mints only carries an `environment` claim when the job declares an environment, the token had no environment claim, npm rejected the token exchange, and per [npm/cli#9088](https://github.com/npm/cli/issues/9088) the CLI surfaced that silent rejection as the misleading `ENEEDAUTH`.
+
+Add `environment: npm-publish` to the publish job. Single-line change. Everything else (Trusted Publisher repo, workflow filename, `id-token: write` permission, `repository.url` in `package.json`, removal of stale `.npmrc`) is already correct from earlier rounds.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,14 @@ jobs:
     needs: release
     if: needs.release.outputs.published == 'true'
     runs-on: ubuntu-latest
+    # The npm Trusted Publisher for @alecsibilia/luca-framework is
+    # configured with `Environment name: npm-publish`. That makes npm
+    # require the incoming OIDC token to carry an `environment` claim
+    # matching that value. Declaring `environment: npm-publish` here is
+    # what gets that claim onto the token GitHub mints for this job.
+    # Without it the npm token-exchange call fails silently and the npm
+    # CLI surfaces the failure as `ENEEDAUTH` (npm/cli#9088).
+    environment: npm-publish
     # id-token: write is required for npm trusted publishing (OIDC).
     # No NPM_TOKEN is used — npm exchanges this OIDC token for a short-lived
     # publish credential via the trusted publisher configured on npmjs.com.


### PR DESCRIPTION
## Summary

Final piece of the OIDC publish saga, identified by comparing against `@alecsibilia/joes-book-mcp` in `asibilia/joes-book--next` (where OIDC publishing works).

The npm Trusted Publisher for `@alecsibilia/luca-framework` is configured with **Environment name: `npm-publish`** (same as joes-book–next). That makes npm require the incoming OIDC token to carry an `environment` claim matching that value. The publish job in `release.yml` didn't declare an environment, so the OIDC token GitHub minted for it had no environment claim, npm rejected the token-exchange call, and per [npm/cli#9088](https://github.com/npm/cli/issues/9088) the npm CLI surfaced that silent rejection as the misleading `ENEEDAUTH` error we kept hitting on v11.0.4 → v11.0.7.

**Single-line change:** add `environment: npm-publish` to the `publish` job in `.github/workflows/release.yml`. The GitHub Environment of the same name already exists on the repo.

## Why this took 4 rounds to find

`ENEEDAUTH` from npm CLI is unconditional — it's surfaced for *any* silent OIDC failure, regardless of root cause. Each round I diagnosed a different plausible-but-wrong source of "no token configured":

| PR | Theory | What was actually wrong |
|----|--------|-------------------------|
| #181 | Package marked private on every release | True, but unrelated to ENEEDAUTH |
| #183 | Node 22's npm 10.x can't do OIDC | True, but bumping to Node 24 didn't fix ENEEDAUTH |
| #185 | `setup-node`'s `registry-url` injects placeholder `_authToken` | True for one earlier 404, but not the ENEEDAUTH |
| #187 | npm-side Trusted Publisher had wrong scope (`alecsibilia/*` vs `asibilia/*`) | True and a real bug, but not the *only* npm-side issue |
| **#this** | npm Trusted Publisher requires `environment: npm-publish` claim, workflow doesn't declare one | **Root cause** |

The npm CLI's lack of differentiated error reporting for OIDC failures (npm/cli#9088) is the meta-cause of the whack-a-mole.

## Test plan

- [ ] CI typecheck passes on this PR.
- [ ] Merging this PR opens a Version PR bumping both packages to 11.0.8.
- [ ] Merging the Version PR triggers a Release run; the publish job completes successfully on the first try.
- [ ] On npmjs.com, `@alecsibilia/luca-framework@11.0.8` shows **public** access and a **provenance** badge.
- [ ] After confirmed working: delete the unused `NPM_TOKEN` repo secret + (optional) clean up dangling v11.0.4–v11.0.7 GitHub releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)