### PR TITLE
docs: correct READMEs across the monorepo

### DIFF
--- a/.changeset/correct-readmes.md
+++ b/.changeset/correct-readmes.md
@@ -1,0 +1,11 @@
+---
+'@alecsibilia/luca-framework': patch
+'@alecsibilia/luca-mastracode': patch
+---
+
+docs: correct READMEs across the monorepo
+
+- Rewrite `packages/luca-framework/README.md` (the npm-facing README) — replace fake `bun x create-luca` install command with the real `bun add -g @alecsibilia/luca-framework`, align the description with what the CLI actually does, and add a complete CLI Reference (`init`, `vault:init`, `run`, `doctor`, `version`).
+- Fix root `README.md` tool count (10 → 11, added missing `confidenceJournal`), document the previously-missing `luca doctor` and `luca version` commands, and clarify the difference between global `luca run` and in-repo `bun run mastracode`.
+- Replace `docs/README.md` with an index that matches actual file contents (most prior links pointed to non-existent docs).
+- Update `packages/luca-studio/lib/README.md` to include the 6 files added since it was last updated (`compile-events.ts`, `file-watcher.ts`, `git-types.ts`, `muninn-helpers.ts`, `observation-helpers.ts`, `request-guards.ts`).

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ All subagents receive a shared behavioral prefix (~300-400 tokens) with core ope
 
 ### Tools
 
-10 custom tools power the pipeline:
+11 custom tools power the pipeline:
 
 | Tool | Purpose |
 |------|---------|
@@ -70,6 +70,7 @@ All subagents receive a shared behavioral prefix (~300-400 tokens) with core ope
 | `sessionLedger` | Structured audit trail for mode transitions and phase boundaries |
 | `pipelineLock` | Mutex to prevent concurrent pipeline runs |
 | `classifyComplexity` | TRIVIAL → CRITICAL complexity classification with file/concern estimation |
+| `confidenceJournal` | Tracks execution-time decision confidence and flags blocks needing human re-review |
 | `repoCleanup` | Shadow debt scanning and automated cleanup |
 | `writePlanningFile` | Writes artifacts to `.planning/` directory |
 
@@ -125,15 +126,34 @@ bun install
 ```bash
 luca init          # Set up MuninnDB
 luca vault:init    # Configure vault for your project
+luca doctor        # Run environment diagnostics and health checks
 ```
 
 ### 3. Launch the harness
+
+If you've installed `@alecsibilia/luca-framework` globally (or via `bun link`), run:
 
 ```bash
 luca run
 ```
 
+Inside this monorepo, the equivalent is:
+
+```bash
+bun run mastracode
+```
+
 Or use the `/lu` slash command within the TUI to execute pipeline workflows.
+
+### CLI Reference
+
+| Command | Purpose |
+|---------|---------|
+| `luca init` | Bootstrap MuninnDB |
+| `luca vault:init` | Configure the project vault |
+| `luca run` | Launch the Mastra Code harness |
+| `luca doctor` | Run environment diagnostics and health checks |
+| `luca version` | Print the installed CLI version |
 
 ## Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,72 +4,25 @@ Start here, then go deeper into the areas relevant to your work.
 
 ## Onboarding
 
-| Doc                                              | Purpose                                    |
-| ------------------------------------------------ | ------------------------------------------ |
-| [getting-started.md](getting-started.md)         | Prerequisites, installation, core concepts |
-| [global-installation.md](global-installation.md) | Global npm install and per-project setup   |
-| [troubleshooting.md](troubleshooting.md)         | Common issues and fixes                    |
-
-## Architecture
-
-[architecture-overview.md](architecture-overview.md) is the gateway document. For subsystem deep-dives:
-
-| Doc                                                                              | Purpose                                                          |
-| -------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| [architecture/agent-framework.md](architecture/agent-framework.md)               | Agent hierarchy, teams, orchestration flow                       |
-| [architecture/dag-engine.md](architecture/dag-engine.md)                         | DAG workflow engine design and schemas                           |
-| [architecture/adapter-architecture.md](architecture/adapter-architecture.md)     | Multi-IDE adapter system (Claude, Cursor, Windsurf, VSCode, API) |
-| [architecture/memory-system.md](architecture/memory-system.md)                   | MuninnDB integration, dual-vault model, context management       |
-| [architecture/workflow-orchestration.md](architecture/workflow-orchestration.md) | 10-step v2 pipeline (as-built)                                   |
-
-## Diagrams
-
-Visual references for key systems:
-
-| Doc                                                                | Purpose                                               |
-| ------------------------------------------------------------------ | ----------------------------------------------------- |
-| [diagrams/workflow-overview.md](diagrams/workflow-overview.md)     | Full lifecycle from project-new to milestone-complete |
-| [diagrams/agent-orchestration.md](diagrams/agent-orchestration.md) | How skills spawn agents and chain together            |
-| [diagrams/cognition-flow.md](diagrams/cognition-flow.md)           | Two-tier memory and cognitive pre-flight              |
-| [diagrams/complexity-gates.md](diagrams/complexity-gates.md)       | Complexity levels and model routing                   |
-
-## Decisions
-
-Architecture Decision Records (ADRs):
-
-| Doc                                                                                          | Date       | Summary                                               |
-| -------------------------------------------------------------------------------------------- | ---------- | ----------------------------------------------------- |
-| [decisions/orchestrator-context-pruning.md](decisions/orchestrator-context-pruning.md)       | 2026-03-06 | Prune sub-agent output to prevent context degradation |
-| [decisions/session-lock-bypass.md](decisions/session-lock-bypass.md)                         | 2026-03-06 | Sub-agents bypass session lock via env var            |
-| [decisions/backlog-integration-decisions.md](decisions/backlog-integration-decisions.md)     | 2026-03-24 | v2 phase ordering and DAG coexistence                 |
-| [decisions/behavioral-equivalence-criteria.md](decisions/behavioral-equivalence-criteria.md) | 2026-03-24 | Compiled prose must match hand-written behavior       |
-| [decisions/workflow-v2-canonical.md](decisions/workflow-v2-canonical.md)                     | 2026-03-22 | Cross-section conflict resolution for v2 design       |
+| Doc                                      | Purpose                                    |
+| ---------------------------------------- | ------------------------------------------ |
+| [getting-started.md](getting-started.md) | Prerequisites, installation, core concepts |
+| [troubleshooting.md](troubleshooting.md) | Common issues and fixes                    |
 
 ## Guides
 
 | Doc                                                      | Purpose                                                   |
 | -------------------------------------------------------- | --------------------------------------------------------- |
 | [guides/coding-standards.md](guides/coding-standards.md) | TypeScript conventions, build commands, project structure |
-| [guides/content-style.md](guides/content-style.md)       | Voice, tone, and content formatting                       |
-| [guides/skill-naming.md](guides/skill-naming.md)         | Skill naming conventions and domain patterns              |
 
 ## Research
 
 Foundational knowledge that informed Luca's design:
 
-| Doc                                                                          | Purpose                                   |
-| ---------------------------------------------------------------------------- | ----------------------------------------- |
-| [research/1.anti-slop.md](research/1.anti-slop.md)                           | Managing AI agents in production          |
-| [research/2.agent-design-patterns.md](research/2.agent-design-patterns.md)   | Agent orchestration patterns              |
-| [research/3.domain-specific-memory.md](research/3.domain-specific-memory.md) | Graph + vector hybrid memory              |
-| [research/anti-step-skipping.md](research/anti-step-skipping.md)             | Why LLMs skip steps and how to prevent it |
-
-## Other
-
-| Doc                                          | Purpose                                         |
-| -------------------------------------------- | ----------------------------------------------- |
-| [generation-system.md](generation-system.md) | Build pipeline and TypeScript-to-IDE conversion |
-| [scouting/README.md](scouting/README.md)     | Article intelligence pipeline overview          |
+| Doc                                                                                          | Purpose                                                       |
+| -------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| [research/claude-code-prompt-architecture.md](research/claude-code-prompt-architecture.md)   | Analysis of Claude Code's prompt architecture                 |
+| [research/prompt-architecture/](research/prompt-architecture/README.md)                      | Multi-part deep dive on prompt architecture and agent design  |
 
 ## Archive
 

--- a/packages/luca-framework/README.md
+++ b/packages/luca-framework/README.md
@@ -1,41 +1,48 @@
-# Luca Framework
+# @alecsibilia/luca-framework
 
-The AI-native developer productivity framework for structured, autonomous engineering.
+Luca CLI — bootstrap MuninnDB and launch the [Mastra Code](https://mastra.ai) harness for structured, autonomous AI engineering workflows.
 
-## Overview
+## What it does
 
-Luca Framework provides the scaffolding, state management, and cognitive patterns needed for AI agents to work autonomously within a repository. It bridges the gap between raw LLM capabilities and professional engineering workflows.
-
-## Key Features
-
-- **Structured Planning**: Hierarchical planning from Roadmap to atomic Tasks.
-- **State Management**: Persistent `STATE.md` and `WORKING.md` for session continuity.
-- **Autonomous Execution**: Atomic Git commits per task with automatic deviation handling.
-- **Enterprise Readiness**: Built-in security posture, audit trails, and procurement documentation.
+Luca turns AI coding assistants into structured multi-phase development pipelines. The CLI sets up [MuninnDB](https://github.com/asibilia/muninn) for long-term memory, configures a per-project vault, runs environment diagnostics, and launches the custom Mastra Code harness defined in [`@alecsibilia/luca-mastracode`](https://github.com/asibilia/luca-framework/tree/main/packages/luca-mastracode).
 
 ## Installation
 
 ```bash
-bun x create-luca
+bun add -g @alecsibilia/luca-framework
+# or
+npm install -g @alecsibilia/luca-framework
 ```
 
-## Core Workflow
+## Quickstart
 
-1. **Initialize**: `luca init`
-2. **Plan**: Create structured `PLAN.md` files in `.planning/phases/`
-3. **Execute**: Open a plan in your IDE and use the `/lu` command
-4. **Learn**: Automatic extraction of findings to `MEMORY.md`
+```bash
+luca init          # Bootstrap MuninnDB
+luca vault:init    # Configure vault for your project
+luca doctor        # Run environment diagnostics
+luca run           # Launch the Mastra Code harness
+```
 
-## Security
+Once the harness is running, use the `/lu` slash command to execute the autonomous pipeline.
 
-Security is a core pillar of the Luca Framework. We ensure that AI-driven development doesn't compromise your organization's security posture.
+## CLI Reference
 
-### Security Posture
+| Command | Purpose |
+|---------|---------|
+| `luca init` | Bootstrap MuninnDB |
+| `luca vault:init` | Configure the project vault |
+| `luca run` | Launch the Mastra Code harness |
+| `luca doctor` | Run environment diagnostics and health checks |
+| `luca version` | Print the installed CLI version |
 
-- **Local-First**: All core logic and state reside in your local repository.
-- **Auditability**: Every action is traceable through atomic Git commits and execution summaries.
-- **Supply Chain**: Minimal, pinned dependencies with automated vulnerability scanning.
-- **Transparency**: Clear documentation of data handling and privacy principles.
+## Prerequisites
+
+- [Bun](https://bun.sh) runtime
+- [MuninnDB](https://github.com/asibilia/muninn) (for long-term memory)
+
+## Documentation
+
+Full architecture, modes, subagents, and tools reference: [github.com/asibilia/luca-framework](https://github.com/asibilia/luca-framework).
 
 ## License
 

--- a/packages/luca-studio/lib/README.md
+++ b/packages/luca-studio/lib/README.md
@@ -8,19 +8,25 @@ individual modules directly to preserve Next.js tree-shaking.
 | File                        | Purpose                                                     |
 | --------------------------- | ----------------------------------------------------------- |
 | `atomic-write.ts`           | Atomic file writes with temp + rename                       |
+| `compile-events.ts`         | Compile-event helpers for the studio pipeline               |
 | `config-section-handler.ts` | Config section read/write helpers                           |
 | `config-section-schemas.ts` | Zod schemas for config.json sections (studio-local mirrors) |
 | `constants.ts`              | Event types, workflow states, nav groups, complexity levels |
 | `dag-validation.ts`         | DAG cycle detection for pipeline editor                     |
 | `entity-route-helpers.ts`   | CRUD route helpers for agents/skills/rules                  |
 | `etag.ts`                   | ETag generation and comparison                              |
+| `file-watcher.ts`           | File system watcher utilities                               |
 | `format.ts`                 | Date/number formatting utilities                            |
+| `git-types.ts`              | Git-related TypeScript types                                |
 | `graph-types.ts`            | Force-graph type definitions                                |
 | `muninn-config.ts`          | MuninnDB connection config                                  |
+| `muninn-helpers.ts`         | MuninnDB query and mutation helpers                         |
 | `muninn-route-helper.ts`    | MuninnDB API route helpers                                  |
 | `muninn-schemas.ts`         | MuninnDB Zod schemas                                        |
 | `muninn-types.ts`           | MuninnDB TypeScript types                                   |
+| `observation-helpers.ts`    | Observation/telemetry helper functions                      |
 | `project-root.ts`           | Project root directory resolution                           |
+| `request-guards.ts`         | Request validation and authorization guards                 |
 | `safe-json-parse.ts`        | Safe JSON parsing with error handling                       |
 | `semantic-validators.ts`    | Semantic validation pipeline functions                      |
 | `ts-round-trip.ts`          | TypeScript source round-trip editing                        |


### PR DESCRIPTION
## Summary

Audit of all non-archive READMEs surfaced inaccuracies in four files. This PR fixes them and includes a patch changeset so the corrected npm-facing README publishes on the next release.

### 🚨 `packages/luca-framework/README.md` (npm-facing)
- **Critical**: Replaced fake install command `bun x create-luca` (404 on registry) with the real `bun add -g @alecsibilia/luca-framework`.
- Aligned tagline and description with the actual CLI ("bootstrap MuninnDB and launch the Mastra Code harness") instead of generic "AI-native productivity framework" copy.
- Added a complete CLI Reference (`init`, `vault:init`, `run`, `doctor`, `version`) and links back to the monorepo for full architecture docs.
- Removed references to `STATE.md` / `WORKING.md` / `MEMORY.md` / `.planning/phases/` that no longer match the current architecture.

### 🚨 `docs/README.md`
- The doc index claimed 24 documents across architecture / diagrams / decisions / guides / research / "other" sections; only 3 of those files actually existed. Replaced with an index that matches what's on disk and surfaces the previously-unlisted `research/prompt-architecture/` sub-package.

### 🟡 `packages/luca-studio/lib/README.md`
- Directory contract was missing 6 files (`compile-events.ts`, `file-watcher.ts`, `git-types.ts`, `muninn-helpers.ts`, `observation-helpers.ts`, `request-guards.ts`). Added them.

### Root `README.md` (carried from initial commit)
- Bumped tool count 10 → 11 and added the missing `confidenceJournal` row.
- Added `luca doctor` to Quickstart and a new CLI Reference table.
- Clarified that `luca run` requires global install / `bun link`, with `bun run mastracode` as the in-repo alternative.

### Changeset
- Added `.changeset/correct-readmes.md` (patch). Bumps both `@alecsibilia/luca-framework` and `@alecsibilia/luca-mastracode` (locked together via `fixed`) so the next release publishes the corrected README to npm.

## Test plan

- [x] Verified `create-luca` does not exist on npm (registry returned 404).
- [x] Verified actual published package metadata via `npm view @alecsibilia/luca-framework`.
- [x] Verified docs file inventory by `find docs -name "*.md"`.
- [x] Verified studio lib file inventory by `ls packages/luca-studio/lib`.
- [x] Verified tool count (11) and CLI command list (5) directly from source.
- [ ] Render READMEs on GitHub to confirm tables and code blocks display correctly.
- [ ] Confirm Changesets workflow opens a Version Packages PR after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)