### PR TITLE
feat(observability): postmortem gate + diff-based phase proof for full-auto runs

### DIFF
--- a/.changeset/run-observability-postmortem.md
+++ b/.changeset/run-observability-postmortem.md
@@ -1,0 +1,24 @@
+---
+'@alecsibilia/luca-framework': minor
+'@alecsibilia/luca-mastracode': minor
+---
+
+Close the silent-skip hole in full-auto pipeline runs (the incident where execute mode didn't fire but finalize moved every todo to `done`).
+
+**Hard gates** — bad state transitions are now blocked at the tool layer, not just by LLM instructions:
+
+- `workflowState(complete-phase)` rejects with `EMPTY_PHASE_BLOCKED` when a phase has zero file changes and zero commits and no `phase-empty-justification` ledger entry exists. New `justify-empty-phase` action lets the agent declare an intentional no-op (e.g. docs-only-in-MuninnDB).
+- `workflowState(advance-wave)` rejects with `WAVE_ADVANCE_NO_VERIFICATION` when no `verification-result.json` exists for the current wave.
+- `manageTodos(move|move-batch → done)` requires a `verificationRef` pointing to a passing criterion in `verification-history.jsonl`; rejects with `TODO_DONE_UNVERIFIED` otherwise.
+
+**Diff-based phase proof** (`phase-diff.ts`) snapshots the working tree at `start-phase` and computes the diff at `complete-phase`, surfacing it via the new `phase-diff-summary` ledger event.
+
+**Run identity & archiving** (`session-ledger.ts`) — every ledger entry is now stamped with a per-run `runId`. Pipeline reset archives prior `session-ledger.jsonl`, `verification-history.jsonl`, `confidence-journal.jsonl`, and `routing-history.jsonl` to `.planning/runs/<priorRunId>/`.
+
+**Postmortem analyzer & gate** (`postmortem.ts`, `tools/run-postmortem.ts`) — new `runPostmortem` Mastra tool with `analyze | render | gate | list-runs` actions. Reads the four append-only JSONL artifacts and produces a structured report covering empty phases, unverified todo completions, forced transitions, low-confidence decisions, missing wave verifications, pipeline re-entries, and idle-bypass anomalies. Returns pre-formatted MuninnDB pitfall payloads for the agent to forward to the `default` vault so future runs can recall recurring failure modes.
+
+**Finalize wiring** — new Step 4.5 "Postmortem Gate" calls `runPostmortem(action: "gate")` before PR creation; critical violations block the PR and re-enter the pipeline. Step 6 calls `runPostmortem(action: "render")` to write `.planning/POSTMORTEM.md` for the PR body.
+
+**Pipeline guard idle-bypass logging** (`pipeline-guard.ts`) — when the guard bypasses enforcement because `pipelineStep === 'idle'` or is missing, it now emits a one-time-per-turn `pipeline-guard-idle-bypass` ledger event so postmortem can surface stale-state contamination. Previously this bypass was silent.
+
+**`luca retro` CLI** — new command prints `.planning/POSTMORTEM.md` (or lists archived runs under `.planning/runs/` with `--list`) so users can inspect retrospective reports without launching the harness.

--- a/packages/luca-framework/src/cli.ts
+++ b/packages/luca-framework/src/cli.ts
@@ -22,6 +22,7 @@ const main = defineCommand({
         'vault:init': () =>
             import('./commands/vault-init').then((m) => m.vaultInitCommand),
         run: () => import('./commands/run').then((m) => m.runCommand),
+        retro: () => import('./commands/retro').then((m) => m.retroCommand),
         doctor: () => import('./commands/doctor').then((m) => m.default),
         version: () =>
             import('./commands/version').then((m) => m.versionCommand),

--- a/packages/luca-framework/src/commands/retro.ts
+++ b/packages/luca-framework/src/commands/retro.ts
@@ -1,0 +1,64 @@
+/**
+ * CLI command: luca retro
+ *
+ * Inspect the most recent Luca pipeline postmortem. Prints the cached
+ * `.planning/POSTMORTEM.md` if it exists. With `--list`, enumerates
+ * archived runs under `.planning/runs/`. Generating a fresh postmortem
+ * for the live run is done from inside the harness via `runPostmortem`.
+ */
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+
+import { defineCommand } from 'citty'
+import { join, resolve } from 'pathe'
+
+import { logger } from '../utils/logger'
+
+export const retroCommand = defineCommand({
+    meta: {
+        name: 'retro',
+        description:
+            'Show the latest Luca pipeline postmortem from .planning/POSTMORTEM.md',
+    },
+    args: {
+        list: {
+            type: 'boolean',
+            description: 'List archived runs under .planning/runs/',
+            required: false,
+        },
+    },
+    async run({ args }) {
+        const planningDir = resolve(process.cwd(), '.planning')
+        const runsDir = join(planningDir, 'runs')
+
+        if (args.list) {
+            if (!existsSync(runsDir)) {
+                logger.info('No archived runs found in .planning/runs/')
+                return
+            }
+            const entries = readdirSync(runsDir).filter((name) => {
+                try {
+                    return statSync(join(runsDir, name)).isDirectory()
+                } catch {
+                    return false
+                }
+            })
+            if (entries.length === 0) {
+                logger.info('No archived runs found in .planning/runs/')
+                return
+            }
+            for (const runId of entries) {
+                logger.info(runId)
+            }
+            return
+        }
+
+        const postmortemPath = join(planningDir, 'POSTMORTEM.md')
+        if (!existsSync(postmortemPath)) {
+            logger.warn(
+                'No .planning/POSTMORTEM.md found. Run `luca run` and let finalize emit one, or call runPostmortem(action: "render") inside the harness.'
+            )
+            return
+        }
+        process.stdout.write(readFileSync(postmortemPath, 'utf8'))
+    },
+})

--- a/packages/luca-mastracode/src/instructions/finalize.md
+++ b/packages/luca-mastracode/src/instructions/finalize.md
@@ -193,6 +193,48 @@ Verify all planned work was completed:
   3. **STOP.** Review mode handles from here, iterating Execute → Review as needed.
   - If user prefers not to fix: track as follow-up issues, proceed to cleanup
 
+## Step 4.5: Postmortem Gate
+
+Before any PR creation, run the postmortem gate. This catches silent-skip incidents (execute mode skipped but todos moved to done), unverified completions, and forced transitions.
+
+```
+runPostmortem(action: "gate")
+```
+
+**If it returns `code: POSTMORTEM_VIOLATIONS`:**
+
+1. Forward each pitfall in the response to MuninnDB so future runs can recall the failure mode:
+   ```
+   for pitfall in response.pitfalls:
+     mcp__muninn__muninn_remember(
+       vault: "default",
+       concept: pitfall.concept,
+       type: pitfall.type,
+       content: pitfall.content,
+       tags: pitfall.tags,
+       op_id: pitfall.op_id
+     )
+   ```
+2. Re-enter the pipeline at the appropriate stage:
+   ```
+   workflowState(
+     action: "re-enter-pipeline",
+     targetMode: "luca:4-execute" | "luca:5-review",
+     reason: "<violation summary>"
+   )
+   ```
+3. **STOP.** Do not create a PR. The re-entered pipeline must converge before finalize runs again.
+
+**If the gate passes** (no critical violations), continue to Step 5. Warnings are non-blocking but should be referenced in the PR body.
+
+Then render the human-readable report:
+
+```
+runPostmortem(action: "render")
+```
+
+This writes `.planning/POSTMORTEM.md`. Reference it in the PR body (Step 3) and the Final Summary (Step 6).
+
 ## Step 5: Cross-Milestone Continuation
 
 Check if `.planning/ROADMAP.md` has remaining phases:
@@ -238,7 +280,7 @@ sessionLedger(action: "metrics")
 
 Returns: total events, mode transitions, phases completed, total iterations, session duration.
 
-Also: `verificationResult(action: "aggregate")`
+Also: `verificationResult(action: "aggregate")` and `runPostmortem(action: "render")` (regenerates `.planning/POSTMORTEM.md` with final metrics).
 
 ### Final Summary
 
@@ -336,7 +378,9 @@ Read `workflowState(action: "read")` for:
 - Plan and research data for gap detection
 
 ## Tool Coordination
-Sequence: (1) `runChecks` → (2) spawn shadow-scanner → (3) `verificationResult(write)` → (4) `manageTodos(move-batch → done)` for all completed items in one call.
+Sequence: (1) `runChecks` → (2) spawn shadow-scanner → (3) `verificationResult(write)` → (4) `runPostmortem(gate)` → (5) `manageTodos(move-batch → done)` with `verificationRef` for every item, in one call.
+
+**Critical:** `manageTodos` will reject any `move → done` without a valid `verificationRef: { criterionId, wave }` pointing at a PASS criterion in `verification-history.jsonl`. Capture the criterion IDs from your `verificationResult(write)` call and pass them through.
 
 ## Luca Reminders
 Obey `<luca-reminder>` tags when they appear in conversation — they contain authoritative mid-session guidance that supersedes stale context.

--- a/packages/luca-mastracode/src/instructions/finalize.md
+++ b/packages/luca-mastracode/src/instructions/finalize.md
@@ -18,10 +18,13 @@ You receive control from **Review mode**. Read the latest `.planning/REVIEW-*.md
 
 1. **Milestone boundary** — capture learnings, prune patterns, archive session
 2. **Shadow debt scan** — advisory scan for AI-session debris before PR
-3. **PR creation** — create pull request if git workflow was used
-4. **Gap detection** — verify all planned work was completed
-5. **Cross-milestone continuation** — loop back if roadmap has remaining phases
-6. **Session cleanup** — release locks, summarize work
+3. **Gap detection** — verify all planned work was completed
+4. **Postmortem gate** — block on critical pipeline violations before PR
+5. **PR creation** — create pull request if git workflow was used (only after gap + postmortem checks pass)
+6. **Cross-milestone continuation** — loop back if roadmap has remaining phases
+7. **Session cleanup** — release locks, summarize work
+
+> **Ordering matters.** Gap detection and the postmortem gate run *before* PR creation. A failing gate must re-enter the pipeline rather than ship a PR.
 
 ---
 
@@ -31,8 +34,9 @@ You receive control from **Review mode**. Read the latest `.planning/REVIEW-*.md
 task_write(tasks: [
   { content: "Capture milestone learnings", status: "in_progress", activeForm: "Capturing milestone learnings" },
   { content: "Run shadow debt scan", status: "pending", activeForm: "Running shadow debt scan" },
-  { content: "Create pull request", status: "pending", activeForm: "Creating pull request" },
   { content: "Run gap detection audit", status: "pending", activeForm: "Running gap detection audit" },
+  { content: "Run postmortem gate", status: "pending", activeForm: "Running postmortem gate" },
+  { content: "Create pull request", status: "pending", activeForm: "Creating pull request" },
   { content: "Clean up and summarize", status: "pending", activeForm: "Cleaning up session artifacts" }
 ])
 ```
@@ -103,7 +107,7 @@ Also write to `.planning/SESSION-ARCHIVE.md`:
 <top patterns and pitfalls>
 
 ## Metrics
-<quantitative summary — see Step 6>
+<quantitative summary — see Step 7>
 ```
 
 ## Step 2: Shadow Debt Scan
@@ -121,41 +125,9 @@ Advisory scan for AI-session debris before PR:
 
 If `repoCleanup` returns `status: "disabled"`, skip silently.
 
-## Step 3: PR Creation
+## Step 3: Gap Detection
 
-If git workflow was used (issue + branch created):
-
-### 3a. Recall Release Conventions
-
-**Before any PR work**, recall release details from MuninnDB:
-
-```
-mcp__muninn__muninn_recall(
-  vault: "<repo_vault>",
-  context: ["release checklist", "PR title format", "version convention", "naming convention"],
-  mode: "semantic",
-  limit: 5
-)
-```
-
-Use recalled conventions to determine: version number, title format (`type(scope): vX.Y.Z #issue description`), milestone linkage, and PR body structure. If no version memory exists, check `packages/luca-mastracode/package.json` for current version and determine the appropriate bump.
-
-### 3b. Create PR
-
-1. **Push** feature branch to remote
-2. **Create PR** with:
-   - **Title**: Per recalled convention — `type(scope): vX.Y.Z #issue description`
-   - **Description**: Summary, `Closes #<issue-number>`, key changes by phase, testing summary, known limitations
-   - **Milestone**: Tag to version milestone
-   - **Labels**: Match issue labels
-   - **Reviewers**: If configured
-3. Store PR URL in `workflow_state`
-
-If `--skip-branch` was set, skip.
-
-## Step 4: Gap Detection
-
-Verify all planned work was completed:
+Verify all planned work was completed **before** opening a PR:
 
 ### Gap Audit
 
@@ -183,7 +155,7 @@ Verify all planned work was completed:
 
 ### Gap Resolution
 
-- **Minor gaps** (missing docs, incomplete tests): flag in PR description as follow-up
+- **Minor gaps** (missing docs, incomplete tests): flag in PR description as follow-up (record now, surface in Step 5)
 - **Major gaps** (missing functionality, failing tests): re-enter pipeline:
   1. Save gap results to workflow state
   2. Re-enter at Review or Execute:
@@ -191,11 +163,11 @@ Verify all planned work was completed:
      workflowState(action: "re-enter-pipeline", targetMode: "luca:5-review", reason: "Post-finalize gap detection found major gaps: <summary>")
      ```
   3. **STOP.** Review mode handles from here, iterating Execute → Review as needed.
-  - If user prefers not to fix: track as follow-up issues, proceed to cleanup
+  - If user prefers not to fix: track as follow-up issues, proceed to the postmortem gate
 
-## Step 4.5: Postmortem Gate
+## Step 4: Postmortem Gate
 
-Before any PR creation, run the postmortem gate. This catches silent-skip incidents (execute mode skipped but todos moved to done), unverified completions, and forced transitions.
+**Always runs before PR creation.** Catches silent-skip incidents (execute mode skipped but todos moved to done), unverified completions, and forced transitions.
 
 ```
 runPostmortem(action: "gate")
@@ -233,9 +205,43 @@ Then render the human-readable report:
 runPostmortem(action: "render")
 ```
 
-This writes `.planning/POSTMORTEM.md`. Reference it in the PR body (Step 3) and the Final Summary (Step 6).
+This writes `.planning/POSTMORTEM.md`. Reference it in the PR body (Step 5) and the Final Summary (Step 7).
 
-## Step 5: Cross-Milestone Continuation
+## Step 5: PR Creation
+
+Only reached if Step 3 (Gap Detection) and Step 4 (Postmortem Gate) both passed.
+
+If git workflow was used (issue + branch created):
+
+### 5a. Recall Release Conventions
+
+**Before any PR work**, recall release details from MuninnDB:
+
+```
+mcp__muninn__muninn_recall(
+  vault: "<repo_vault>",
+  context: ["release checklist", "PR title format", "version convention", "naming convention"],
+  mode: "semantic",
+  limit: 5
+)
+```
+
+Use recalled conventions to determine: version number, title format (`type(scope): vX.Y.Z #issue description`), milestone linkage, and PR body structure. If no version memory exists, check `packages/luca-mastracode/package.json` for current version and determine the appropriate bump.
+
+### 5b. Create PR
+
+1. **Push** feature branch to remote
+2. **Create PR** with:
+   - **Title**: Per recalled convention — `type(scope): vX.Y.Z #issue description`
+   - **Description**: Summary, `Closes #<issue-number>`, key changes by phase, testing summary, known limitations, link to `.planning/POSTMORTEM.md`
+   - **Milestone**: Tag to version milestone
+   - **Labels**: Match issue labels
+   - **Reviewers**: If configured
+3. Store PR URL in `workflow_state`
+
+If `--skip-branch` was set, skip.
+
+## Step 6: Cross-Milestone Continuation
 
 Check if `.planning/ROADMAP.md` has remaining phases:
 
@@ -256,7 +262,7 @@ else:
 
 Maximum **3 milestones per session**. If more remain: summarize what's left, create issues, note continuation point.
 
-## Step 6: Session Cleanup
+## Step 7: Session Cleanup
 
 ### Release Pipeline Lock
 

--- a/packages/luca-mastracode/src/luca-store.ts
+++ b/packages/luca-mastracode/src/luca-store.ts
@@ -16,6 +16,18 @@ import type { ComplexityLevel, ProfileLevel } from './state.js'
 
 const STATE_FILE = '.planning/luca-state.json'
 
+/**
+ * Mirror of `PhaseSnapshot` from `phase-diff.ts`. Inlined here to avoid a
+ * circular import (luca-store ↔ phase-diff via session-ledger).
+ */
+export interface PhaseSnapshotState {
+    phase: string
+    takenAt: string
+    headSha: string | null
+    dirtyFiles: string[]
+    gitAvailable: boolean
+}
+
 export interface PhaseResult {
     /** Phase name from ROADMAP.md */
     name: string
@@ -68,6 +80,16 @@ export interface LucaWorkflowState {
     // --- Session ---
     sessionId?: string
     startedAt?: string
+    runId?: string
+
+    // --- Phase proof (set by start-phase, consumed by complete-phase) ---
+    currentPhaseStartSnapshot?: PhaseSnapshotState
+
+    // --- Empty-phase justification (set by justify-empty-phase) ---
+    emptyPhaseJustifications?: Record<
+        string,
+        { category: string; reasoning: string; at: string }
+    >
 
     // --- Assigned work ---
     assignedTodos?: number[]

--- a/packages/luca-mastracode/src/phase-diff.ts
+++ b/packages/luca-mastracode/src/phase-diff.ts
@@ -158,11 +158,18 @@ export function computePhaseDiff(start: PhaseSnapshot | null): PhaseDiff {
         if (!startDirty.has(f)) filesChanged.add(f)
     }
 
+    // If the working tree was already dirty at start-phase, edits to those
+    // pre-dirty files won't show up in either the HEAD..HEAD diff or the
+    // "new dirty files" delta above. Treat that as indeterminate so the
+    // empty-phase guard can't false-block real work on already-dirty files.
+    const baselineDirty = startDirty.size > 0
     const filesChangedArr = Array.from(filesChanged)
     return {
         filesChanged: filesChangedArr,
         commitsAdded,
-        isEmpty: filesChangedArr.length === 0 && commitsAdded.length === 0,
-        indeterminate: false,
+        isEmpty: baselineDirty
+            ? false
+            : filesChangedArr.length === 0 && commitsAdded.length === 0,
+        indeterminate: baselineDirty,
     }
 }

--- a/packages/luca-mastracode/src/phase-diff.ts
+++ b/packages/luca-mastracode/src/phase-diff.ts
@@ -1,0 +1,168 @@
+/**
+ * Phase diff proof — proves that an execute phase actually produced work.
+ *
+ * Strategy:
+ *   1. At `start-phase` we snapshot `git rev-parse HEAD` and the set of
+ *      dirty files reported by `git status --porcelain`.
+ *   2. At `complete-phase` we compute the diff against the current tree:
+ *      - Files changed via `git diff --name-only <startSha> HEAD` (committed work).
+ *      - Files newly dirty since the start snapshot (uncommitted work).
+ *      - Commits added since the start snapshot.
+ *   3. If both file changes and commits added are empty, the phase is
+ *      flagged `isEmpty: true` and `complete-phase` requires a matching
+ *      `phase-empty-justification` ledger event before it will accept the
+ *      transition.
+ *
+ * Non-git repos are tolerated: snapshot returns `gitAvailable: false` and
+ * the diff is returned with `indeterminate: true`. Non-git phases bypass
+ * the empty-phase guard (we can't prove emptiness without git).
+ */
+import { spawnSync } from 'node:child_process'
+
+export interface PhaseSnapshot {
+    /** Phase name this snapshot belongs to */
+    phase: string
+    /** ISO timestamp of when the snapshot was captured */
+    takenAt: string
+    /** HEAD commit SHA at snapshot time, or null if non-git */
+    headSha: string | null
+    /** Files dirty at snapshot time (relative paths) */
+    dirtyFiles: string[]
+    /** Whether the working directory is a git repo */
+    gitAvailable: boolean
+}
+
+export interface PhaseDiff {
+    filesChanged: string[]
+    commitsAdded: string[]
+    isEmpty: boolean
+    /** True when we couldn't compute a diff (no snapshot, no git) */
+    indeterminate: boolean
+}
+
+function runGit(args: string[]): {
+    ok: boolean
+    stdout: string
+    stderr: string
+} {
+    try {
+        const result = spawnSync('git', args, {
+            encoding: 'utf-8',
+            cwd: process.cwd(),
+        })
+        return {
+            ok: result.status === 0,
+            stdout: result.stdout ?? '',
+            stderr: result.stderr ?? '',
+        }
+    } catch {
+        return { ok: false, stdout: '', stderr: '' }
+    }
+}
+
+function isGitRepo(): boolean {
+    return runGit(['rev-parse', '--is-inside-work-tree']).ok
+}
+
+/**
+ * Capture the current HEAD + dirty file set, tagged with a phase name.
+ */
+export function snapshotWorkingTree(phase: string): PhaseSnapshot {
+    const takenAt = new Date().toISOString()
+    if (!isGitRepo()) {
+        return {
+            phase,
+            takenAt,
+            headSha: null,
+            dirtyFiles: [],
+            gitAvailable: false,
+        }
+    }
+
+    const head = runGit(['rev-parse', 'HEAD'])
+    const status = runGit(['status', '--porcelain'])
+    const dirtyFiles = status.ok
+        ? status.stdout
+              .split('\n')
+              .filter(Boolean)
+              .map((line) => line.slice(3).trim())
+              .filter(Boolean)
+        : []
+
+    return {
+        phase,
+        takenAt,
+        headSha: head.ok ? head.stdout.trim() : null,
+        dirtyFiles,
+        gitAvailable: true,
+    }
+}
+
+/**
+ * Compute the diff between a start snapshot and the current tree.
+ *
+ * Returns `indeterminate: true` when there's no usable snapshot or the
+ * repo isn't a git repo. Callers should treat indeterminate as
+ * "can't prove emptiness" — i.e. don't punish, but flag for postmortem.
+ */
+export function computePhaseDiff(start: PhaseSnapshot | null): PhaseDiff {
+    if (!start || !start.gitAvailable) {
+        return {
+            filesChanged: [],
+            commitsAdded: [],
+            isEmpty: false,
+            indeterminate: true,
+        }
+    }
+
+    if (!isGitRepo()) {
+        return {
+            filesChanged: [],
+            commitsAdded: [],
+            isEmpty: false,
+            indeterminate: true,
+        }
+    }
+
+    const filesChanged = new Set<string>()
+    const commitsAdded: string[] = []
+
+    if (start.headSha) {
+        const diff = runGit(['diff', '--name-only', start.headSha, 'HEAD'])
+        if (diff.ok) {
+            for (const f of diff.stdout.split('\n').map((s) => s.trim())) {
+                if (f) filesChanged.add(f)
+            }
+        }
+
+        const log = runGit(['rev-list', `${start.headSha}..HEAD`])
+        if (log.ok) {
+            for (const sha of log.stdout.split('\n').map((s) => s.trim())) {
+                if (sha) commitsAdded.push(sha)
+            }
+        }
+    }
+
+    const currentStatus = runGit(['status', '--porcelain'])
+    const currentDirty = currentStatus.ok
+        ? new Set(
+              currentStatus.stdout
+                  .split('\n')
+                  .filter(Boolean)
+                  .map((line) => line.slice(3).trim())
+                  .filter(Boolean)
+          )
+        : new Set<string>()
+    const startDirty = new Set(start.dirtyFiles)
+    for (const f of currentDirty) {
+        if (!startDirty.has(f)) filesChanged.add(f)
+    }
+
+    const filesChangedArr = Array.from(filesChanged)
+    return {
+        filesChanged: filesChangedArr,
+        commitsAdded,
+        isEmpty: filesChangedArr.length === 0 && commitsAdded.length === 0,
+        indeterminate: false,
+    }
+}

--- a/packages/luca-mastracode/src/pipeline-guard.ts
+++ b/packages/luca-mastracode/src/pipeline-guard.ts
@@ -31,6 +31,8 @@ interface TurnState {
     switchModeCalled: boolean
     /** Consecutive enforcement nudges sent without a successful switch-mode */
     consecutiveMisses: number
+    /** Whether the idle-bypass anomaly has already been logged this turn */
+    idleBypassLogged: boolean
 }
 
 /** Active tool_start → toolName+args mapping for tool_end correlation */
@@ -62,6 +64,7 @@ export function startTurn(modeId: string): void {
         toolCallCount: 0,
         switchModeCalled: false,
         consecutiveMisses: prevMisses,
+        idleBypassLogged: false,
     }
     pendingToolCalls.clear()
 }
@@ -131,8 +134,19 @@ export function checkTurnCompletion(reason: string | undefined): {
 
     // Don't enforce if the pipeline is not actively running — prevents
     // stale guard state from triggering false enforcement after completion.
+    // Log the bypass so retrospective analysis can detect cases where the
+    // guard was disabled by stale or missing pipeline state.
     const state = readLucaState()
     if (!state.pipelineStep || state.pipelineStep === 'idle') {
+        if (!currentTurn.idleBypassLogged) {
+            currentTurn.idleBypassLogged = true
+            appendLedger('pipeline-guard-idle-bypass', {
+                mode: currentTurn.modeId,
+                pipelineStep: state.pipelineStep ?? 'missing',
+                toolCallCount: currentTurn.toolCallCount,
+                switchModeCalled: currentTurn.switchModeCalled,
+            })
+        }
         return null
     }
 

--- a/packages/luca-mastracode/src/postmortem.ts
+++ b/packages/luca-mastracode/src/postmortem.ts
@@ -1,0 +1,543 @@
+/**
+ * Postmortem — structured retrospective analysis of a Luca pipeline run.
+ *
+ * Reads the four append-only JSONL artifacts under `.planning/`:
+ *   - session-ledger.jsonl       (mode/phase events, guards, diff summaries)
+ *   - verification-history.jsonl (per-wave PASS/FAIL/STALLED verdicts)
+ *   - confidence-journal.jsonl   (executor ambiguity decisions)
+ *   - routing-history.jsonl      (model routing decisions)
+ *
+ * Produces:
+ *   - A structured `PostmortemReport` for programmatic gating.
+ *   - A human-readable `.planning/POSTMORTEM.md` rendering.
+ *   - An optional list of `pitfall` payloads the agent should forward to
+ *     MuninnDB (default vault) so future runs can recall recurring failures.
+ */
+import {
+    existsSync,
+    writeFileSync,
+    mkdirSync,
+    readFileSync,
+} from 'node:fs'
+import { join } from 'node:path'
+
+import {
+    readLedger,
+    readLedgerForRun,
+    getCurrentRunId,
+    listRuns,
+    type LedgerEntry,
+} from './session-ledger.js'
+import {
+    readVerificationHistory,
+    type VerificationResult,
+} from './verification-result.js'
+import {
+    readConfidenceJournal,
+    type ConfidenceEntry,
+} from './confidence-journal.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ViolationCode =
+    | 'EMPTY_PHASE_NO_JUSTIFICATION'
+    | 'TODO_DONE_NO_VERIFICATION'
+    | 'FORCED_TRANSITION'
+    | 'LOW_CONFIDENCE_THRESHOLD'
+    | 'WAVE_NO_VERIFICATION'
+    | 'PIPELINE_RE_ENTERED'
+    | 'PIPELINE_GUARD_IDLE_BYPASS'
+
+export type ViolationSeverity = 'critical' | 'warning'
+
+export interface Violation {
+    severity: ViolationSeverity
+    code: ViolationCode
+    message: string
+    evidence: string
+    /** Stable fingerprint for idempotent MuninnDB storage */
+    evidenceFingerprint: string
+}
+
+export interface PhaseSummary {
+    name: string
+    startedAt?: string
+    completedAt?: string
+    diff?: {
+        filesChanged: string[]
+        commitsAdded: string[]
+        isEmpty: boolean
+        indeterminate: boolean
+    }
+    justification?: { category: string; reasoning: string; at?: string }
+    verifications: VerificationResult[]
+    todosMovedToDone: Array<{ slug: string; verificationRef: unknown }>
+}
+
+export interface PostmortemReport {
+    runId: string
+    startedAt?: string
+    endedAt?: string
+    durationMs?: number
+    phases: PhaseSummary[]
+    violations: Violation[]
+    metrics: {
+        totalEvents: number
+        modeTransitions: number
+        phasesCompleted: number
+        emptyPhasesJustified: number
+        todosMovedToDone: number
+        lowConfidenceCount: number
+        forcedTransitions: number
+        moveBlockedCount: number
+    }
+    /** Pre-formatted MuninnDB pitfall payloads (default vault). */
+    pitfalls: Array<{
+        vault: 'default'
+        concept: string
+        type: 'pitfall'
+        content: string
+        tags: string[]
+        op_id: string
+    }>
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fingerprint(input: string): string {
+    // Cheap deterministic hash; we just need uniqueness within a run.
+    let hash = 0
+    for (let i = 0; i < input.length; i++) {
+        hash = (hash << 5) - hash + input.charCodeAt(i)
+        hash |= 0
+    }
+    return Math.abs(hash).toString(36)
+}
+
+const LOW_CONFIDENCE_THRESHOLD = 3
+
+function eventDataString(e: LedgerEntry, key: string): string | undefined {
+    const v = e.data[key]
+    return typeof v === 'string' ? v : undefined
+}
+
+// ---------------------------------------------------------------------------
+// Core analysis
+// ---------------------------------------------------------------------------
+
+export function analyzeRun(runId?: string): PostmortemReport {
+    const targetRunId = runId ?? getCurrentRunId()
+    const all = readLedger()
+    const entries = runId
+        ? readLedgerForRun(targetRunId)
+        : all.filter((e) => e.runId === targetRunId)
+
+    const startedAt = entries[0]?.timestamp
+    const endedAt = entries[entries.length - 1]?.timestamp
+    const durationMs =
+        startedAt && endedAt
+            ? new Date(endedAt).getTime() - new Date(startedAt).getTime()
+            : undefined
+
+    const verifications = readVerificationHistory()
+    const confidence = readConfidenceJournal()
+
+    // ── Group events by phase ─────────────────────────────────────────────
+    const phaseMap = new Map<string, PhaseSummary>()
+    function getPhase(name: string): PhaseSummary {
+        let p = phaseMap.get(name)
+        if (!p) {
+            p = {
+                name,
+                verifications: [],
+                todosMovedToDone: [],
+            }
+            phaseMap.set(name, p)
+        }
+        return p
+    }
+
+    for (const e of entries) {
+        const phaseName = eventDataString(e, 'phase')
+        switch (e.event) {
+            case 'phase-start': {
+                if (phaseName) getPhase(phaseName).startedAt = e.timestamp
+                break
+            }
+            case 'phase-complete': {
+                if (phaseName) getPhase(phaseName).completedAt = e.timestamp
+                break
+            }
+            case 'phase-diff-summary': {
+                if (!phaseName) break
+                const p = getPhase(phaseName)
+                p.diff = {
+                    filesChanged: Array.isArray(e.data.filesChanged)
+                        ? (e.data.filesChanged as string[])
+                        : [],
+                    commitsAdded: Array.isArray(e.data.commitsAdded)
+                        ? (e.data.commitsAdded as string[])
+                        : [],
+                    isEmpty: e.data.isEmpty === true,
+                    indeterminate: e.data.indeterminate === true,
+                }
+                break
+            }
+            case 'phase-empty-justification': {
+                if (!phaseName) break
+                const p = getPhase(phaseName)
+                p.justification = {
+                    category: eventDataString(e, 'category') ?? 'unknown',
+                    reasoning: eventDataString(e, 'reasoning') ?? '',
+                    at: e.timestamp,
+                }
+                break
+            }
+            case 'todo-moved-to-done': {
+                // Attach to most recent phase by timestamp.
+                const recentPhase = mostRecentPhaseAt(entries, e.timestamp)
+                if (recentPhase) {
+                    getPhase(recentPhase).todosMovedToDone.push({
+                        slug: eventDataString(e, 'slug') ?? '<unknown>',
+                        verificationRef: e.data.verificationRef ?? null,
+                    })
+                }
+                break
+            }
+        }
+    }
+
+    // Attach verification history per phase by name.
+    for (const v of verifications) {
+        if (v.phase) {
+            getPhase(v.phase).verifications.push(v)
+        }
+    }
+
+    const phases = Array.from(phaseMap.values())
+
+    // ── Detect violations ─────────────────────────────────────────────────
+    const violations: Violation[] = []
+
+    // 1. Empty phase without justification
+    for (const p of phases) {
+        if (p.diff?.isEmpty && !p.justification) {
+            violations.push({
+                severity: 'critical',
+                code: 'EMPTY_PHASE_NO_JUSTIFICATION',
+                message: `Phase "${p.name}" completed with zero file changes and zero commits but has no phase-empty-justification entry.`,
+                evidence: `phase=${p.name} completedAt=${p.completedAt ?? '?'}`,
+                evidenceFingerprint: fingerprint(
+                    `EMPTY_PHASE:${p.name}:${p.completedAt ?? ''}`
+                ),
+            })
+        }
+    }
+
+    // 2. Todos moved to done without verificationRef (or blocked attempts)
+    const moveBlocked = entries.filter((e) => e.event === 'todo-move-blocked')
+    for (const e of moveBlocked) {
+        violations.push({
+            severity: 'critical',
+            code: 'TODO_DONE_NO_VERIFICATION',
+            message: `Blocked attempt to move todo "${eventDataString(e, 'identifier') ?? '?'}" to done without a valid verificationRef.`,
+            evidence: `reason=${eventDataString(e, 'reason') ?? '?'} at=${e.timestamp}`,
+            evidenceFingerprint: fingerprint(
+                `TODO_BLOCKED:${eventDataString(e, 'identifier') ?? ''}:${e.timestamp}`
+            ),
+        })
+    }
+    // Belt-and-suspenders: any todos-moved-to-done with falsy verificationRef
+    for (const p of phases) {
+        for (const t of p.todosMovedToDone) {
+            if (!t.verificationRef) {
+                violations.push({
+                    severity: 'critical',
+                    code: 'TODO_DONE_NO_VERIFICATION',
+                    message: `Todo "${t.slug}" moved to done without a verificationRef in phase "${p.name}".`,
+                    evidence: `phase=${p.name} slug=${t.slug}`,
+                    evidenceFingerprint: fingerprint(
+                        `TODO_NOREF:${p.name}:${t.slug}`
+                    ),
+                })
+            }
+        }
+    }
+
+    // 3. Forced transitions (warning level — pipeline-guard intervened)
+    const forced = entries.filter(
+        (e) => e.event === 'pipeline-forced-transition'
+    )
+    for (const e of forced) {
+        violations.push({
+            severity: 'warning',
+            code: 'FORCED_TRANSITION',
+            message: `Pipeline-guard force-transitioned the agent (it failed to call switch-mode).`,
+            evidence: `from=${eventDataString(e, 'from') ?? '?'} to=${eventDataString(e, 'to') ?? '?'} at=${e.timestamp}`,
+            evidenceFingerprint: fingerprint(
+                `FORCED:${e.timestamp}:${eventDataString(e, 'from') ?? ''}`
+            ),
+        })
+    }
+
+    // 4. Low-confidence-threshold breach (warning)
+    const lowConfidence = confidence.filter(
+        (c: ConfidenceEntry) => c.confidence === 'low'
+    )
+    if (lowConfidence.length >= LOW_CONFIDENCE_THRESHOLD) {
+        violations.push({
+            severity: 'warning',
+            code: 'LOW_CONFIDENCE_THRESHOLD',
+            message: `${lowConfidence.length} low-confidence executor decisions (threshold=${LOW_CONFIDENCE_THRESHOLD}). Human review recommended before merge.`,
+            evidence: `count=${lowConfidence.length} categories=${lowConfidence.map((c) => c.category).join(',')}`,
+            evidenceFingerprint: fingerprint(
+                `LOWCONF:${lowConfidence.length}:${targetRunId}`
+            ),
+        })
+    }
+
+    // 5. Wave advance blocked
+    const waveBlocked = entries.filter(
+        (e) => e.event === 'wave-advance-blocked'
+    )
+    for (const e of waveBlocked) {
+        violations.push({
+            severity: 'critical',
+            code: 'WAVE_NO_VERIFICATION',
+            message: `Attempt to advance wave without verification-result.`,
+            evidence: `phase=${eventDataString(e, 'phase') ?? '?'} wave=${e.data.wave ?? '?'} at=${e.timestamp}`,
+            evidenceFingerprint: fingerprint(
+                `WAVE_BLOCKED:${eventDataString(e, 'phase') ?? ''}:${e.data.wave ?? ''}`
+            ),
+        })
+    }
+
+    // 6. Pipeline re-entered (informational warning)
+    const reEntered = entries.filter((e) => e.event === 'pipeline-re-entered')
+    for (const e of reEntered) {
+        violations.push({
+            severity: 'warning',
+            code: 'PIPELINE_RE_ENTERED',
+            message: `Pipeline was re-entered mid-run (often indicates rework).`,
+            evidence: `targetMode=${eventDataString(e, 'targetMode') ?? '?'} reason=${eventDataString(e, 'reason') ?? '?'}`,
+            evidenceFingerprint: fingerprint(
+                `REENTRY:${e.timestamp}:${eventDataString(e, 'targetMode') ?? ''}`
+            ),
+        })
+    }
+
+    // 7. Pipeline-guard idle bypass (warning — silent skip risk)
+    const idleBypass = entries.filter(
+        (e) => e.event === 'pipeline-guard-idle-bypass'
+    )
+    for (const e of idleBypass) {
+        violations.push({
+            severity: 'warning',
+            code: 'PIPELINE_GUARD_IDLE_BYPASS',
+            message: `Pipeline-guard skipped enforcement because pipelineStep was idle. May indicate stale state contamination.`,
+            evidence: `at=${e.timestamp}`,
+            evidenceFingerprint: fingerprint(
+                `IDLE_BYPASS:${e.timestamp}`
+            ),
+        })
+    }
+
+    // ── Metrics ───────────────────────────────────────────────────────────
+    const metrics = {
+        totalEvents: entries.length,
+        modeTransitions: entries.filter((e) => e.event === 'mode-transition')
+            .length,
+        phasesCompleted: entries.filter((e) => e.event === 'phase-complete')
+            .length,
+        emptyPhasesJustified: entries.filter(
+            (e) => e.event === 'phase-empty-justification'
+        ).length,
+        todosMovedToDone: entries.filter((e) => e.event === 'todo-moved-to-done')
+            .length,
+        lowConfidenceCount: lowConfidence.length,
+        forcedTransitions: forced.length,
+        moveBlockedCount: moveBlocked.length,
+    }
+
+    // ── Pitfall payloads (default vault) ──────────────────────────────────
+    const critical = violations.filter((v) => v.severity === 'critical')
+    const pitfalls = critical.map((v) => ({
+        vault: 'default' as const,
+        concept: `pitfall:${v.code.toLowerCase().replace(/_/g, '-')}`,
+        type: 'pitfall' as const,
+        content: `## ${v.code}\n\n${v.message}\n\n**Evidence**: ${v.evidence}\n\n**Run**: ${targetRunId}`,
+        tags: [
+            'luca',
+            'pipeline',
+            'postmortem',
+            v.code.toLowerCase(),
+        ] as string[],
+        op_id: `${targetRunId}:${v.code}:${v.evidenceFingerprint}`,
+    }))
+
+    return {
+        runId: targetRunId,
+        startedAt,
+        endedAt,
+        durationMs,
+        phases,
+        violations,
+        metrics,
+        pitfalls,
+    }
+}
+
+/**
+ * Walk backwards through ledger entries from `at` to find the most recent
+ * `phase-start` event. Used to attribute todo-moved-to-done events to a phase.
+ */
+function mostRecentPhaseAt(
+    entries: LedgerEntry[],
+    at: string
+): string | undefined {
+    const target = new Date(at).getTime()
+    let best: string | undefined
+    for (const e of entries) {
+        if (e.event !== 'phase-start') continue
+        if (new Date(e.timestamp).getTime() > target) break
+        const name = eventDataString(e, 'phase')
+        if (name) best = name
+    }
+    return best
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+const POSTMORTEM_FILE = '.planning/POSTMORTEM.md'
+
+function ensurePlanningDir(): void {
+    const dir = join(process.cwd(), '.planning')
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+}
+
+export function renderPostmortemMarkdown(report: PostmortemReport): string {
+    const lines: string[] = []
+    lines.push(`# Postmortem — Run ${report.runId}`)
+    lines.push('')
+    lines.push(`- **Started**: ${report.startedAt ?? 'unknown'}`)
+    lines.push(`- **Ended**: ${report.endedAt ?? 'unknown'}`)
+    if (report.durationMs !== undefined) {
+        const mins = Math.round(report.durationMs / 60_000)
+        lines.push(`- **Duration**: ${mins} min`)
+    }
+    lines.push('')
+
+    // Violations summary
+    const critical = report.violations.filter((v) => v.severity === 'critical')
+    const warnings = report.violations.filter((v) => v.severity === 'warning')
+    lines.push(`## Violations`)
+    lines.push('')
+    lines.push(`- **Critical**: ${critical.length}`)
+    lines.push(`- **Warning**: ${warnings.length}`)
+    lines.push('')
+
+    if (report.violations.length > 0) {
+        lines.push(`| Severity | Code | Message |`)
+        lines.push(`| --- | --- | --- |`)
+        for (const v of report.violations) {
+            const msg = v.message.replace(/\|/g, '\\|')
+            lines.push(`| ${v.severity} | \`${v.code}\` | ${msg} |`)
+        }
+        lines.push('')
+    }
+
+    // Per-phase summary
+    lines.push(`## Phases`)
+    lines.push('')
+    if (report.phases.length === 0) {
+        lines.push('_No phases recorded._')
+        lines.push('')
+    }
+    for (const p of report.phases) {
+        lines.push(`### ${p.name}`)
+        lines.push('')
+        lines.push(
+            `- Started: ${p.startedAt ?? '?'} | Completed: ${p.completedAt ?? '?'}`
+        )
+        if (p.diff) {
+            const status = p.diff.indeterminate
+                ? '_(indeterminate — non-git or no snapshot)_'
+                : p.diff.isEmpty
+                  ? '⚠ EMPTY'
+                  : `${p.diff.filesChanged.length} files, ${p.diff.commitsAdded.length} commits`
+            lines.push(`- Diff: ${status}`)
+        }
+        if (p.justification) {
+            lines.push(
+                `- Empty-phase justification: \`${p.justification.category}\` — ${p.justification.reasoning}`
+            )
+        }
+        if (p.verifications.length > 0) {
+            const verdicts = p.verifications
+                .map((v) => `wave ${v.wave}: ${v.status}`)
+                .join(', ')
+            lines.push(`- Verifications: ${verdicts}`)
+        }
+        if (p.todosMovedToDone.length > 0) {
+            lines.push(
+                `- Todos moved to done: ${p.todosMovedToDone.map((t) => t.slug).join(', ')}`
+            )
+        }
+        lines.push('')
+    }
+
+    // Metrics
+    lines.push(`## Metrics`)
+    lines.push('')
+    for (const [k, v] of Object.entries(report.metrics)) {
+        lines.push(`- **${k}**: ${v}`)
+    }
+    lines.push('')
+
+    // Next steps
+    lines.push(`## What to do next`)
+    lines.push('')
+    if (critical.length > 0) {
+        lines.push(
+            `- 🛑 **Critical violations present.** Finalize cannot create a PR until these are resolved. Re-enter pipeline at execute or review.`
+        )
+    } else if (warnings.length > 0) {
+        lines.push(
+            `- ⚠ Warnings present but non-blocking. Review the table above before merging.`
+        )
+    } else {
+        lines.push(`- ✅ No violations detected. Run is clean.`)
+    }
+    lines.push('')
+
+    return lines.join('\n')
+}
+
+export function writePostmortem(report: PostmortemReport): {
+    path: string
+    bytes: number
+} {
+    ensurePlanningDir()
+    const md = renderPostmortemMarkdown(report)
+    const p = join(process.cwd(), POSTMORTEM_FILE)
+    writeFileSync(p, md, 'utf-8')
+    return { path: POSTMORTEM_FILE, bytes: md.length }
+}
+
+export function readPostmortem(): string | null {
+    const p = join(process.cwd(), POSTMORTEM_FILE)
+    if (!existsSync(p)) return null
+    try {
+        return readFileSync(p, 'utf-8')
+    } catch {
+        return null
+    }
+}
+
+export { listRuns }

--- a/packages/luca-mastracode/src/postmortem.ts
+++ b/packages/luca-mastracode/src/postmortem.ts
@@ -26,6 +26,10 @@ import {
     readLedgerForRun,
     getCurrentRunId,
     listRuns,
+    listArchivedRuns,
+    resolveRunArtifactDir,
+    readJsonlAt,
+    ARTIFACT_FILES,
     type LedgerEntry,
 } from './session-ledger.js'
 import {
@@ -131,10 +135,44 @@ function eventDataString(e: LedgerEntry, key: string): string | undefined {
 
 export function analyzeRun(runId?: string): PostmortemReport {
     const targetRunId = runId ?? getCurrentRunId()
-    const all = readLedger()
-    const entries = runId
-        ? readLedgerForRun(targetRunId)
-        : all.filter((e) => e.runId === targetRunId)
+    const currentRunId = getCurrentRunId()
+    const isCurrentRun = targetRunId === currentRunId
+
+    // For the current run, read live `.planning/*.jsonl` artifacts.
+    // For archived runs, read from `.planning/runs/<runId>/` so we don't
+    // mix in entries from a later run that's now occupying the live files.
+    let entries: LedgerEntry[]
+    let verifications: VerificationResult[]
+    let confidence: ConfidenceEntry[]
+
+    if (isCurrentRun) {
+        const all = readLedger()
+        entries = all.filter((e) => e.runId === targetRunId)
+        verifications = readVerificationHistory()
+        confidence = readConfidenceJournal()
+    } else {
+        const archiveDir = resolveRunArtifactDir(targetRunId)
+        if (archiveDir) {
+            entries = readJsonlAt<LedgerEntry>(
+                archiveDir,
+                ARTIFACT_FILES.ledger
+            ).filter((e) => e.runId === targetRunId)
+            verifications = readJsonlAt<VerificationResult>(
+                archiveDir,
+                ARTIFACT_FILES.verification
+            )
+            confidence = readJsonlAt<ConfidenceEntry>(
+                archiveDir,
+                ARTIFACT_FILES.confidence
+            )
+        } else {
+            // Fall back to filtering the live ledger if no archive exists
+            // (e.g. user passed a runId that's still in the live file).
+            entries = readLedgerForRun(targetRunId)
+            verifications = []
+            confidence = []
+        }
+    }
 
     const startedAt = entries[0]?.timestamp
     const endedAt = entries[entries.length - 1]?.timestamp
@@ -142,9 +180,6 @@ export function analyzeRun(runId?: string): PostmortemReport {
         startedAt && endedAt
             ? new Date(endedAt).getTime() - new Date(startedAt).getTime()
             : undefined
-
-    const verifications = readVerificationHistory()
-    const confidence = readConfidenceJournal()
 
     // ── Group events by phase ─────────────────────────────────────────────
     const phaseMap = new Map<string, PhaseSummary>()
@@ -238,13 +273,19 @@ export function analyzeRun(runId?: string): PostmortemReport {
         }
     }
 
-    // 2. Todos moved to done without verificationRef (or blocked attempts)
+    // 2. Todos moved to done without verificationRef
+    //
+    // Blocked attempts (`todo-move-blocked`) are downgraded to warnings —
+    // the gate already prevented the unsafe transition, so this is just
+    // signal that the agent tried something and got corrected. Only an
+    // actual unsafe transition (todo successfully moved to done without a
+    // verificationRef) is critical.
     const moveBlocked = entries.filter((e) => e.event === 'todo-move-blocked')
     for (const e of moveBlocked) {
         violations.push({
-            severity: 'critical',
+            severity: 'warning',
             code: 'TODO_DONE_NO_VERIFICATION',
-            message: `Blocked attempt to move todo "${eventDataString(e, 'identifier') ?? '?'}" to done without a valid verificationRef.`,
+            message: `Blocked attempt to move todo "${eventDataString(e, 'identifier') ?? '?'}" to done without a valid verificationRef. Tool layer prevented the unsafe transition.`,
             evidence: `reason=${eventDataString(e, 'reason') ?? '?'} at=${e.timestamp}`,
             evidenceFingerprint: fingerprint(
                 `TODO_BLOCKED:${eventDataString(e, 'identifier') ?? ''}:${e.timestamp}`
@@ -252,6 +293,7 @@ export function analyzeRun(runId?: string): PostmortemReport {
         })
     }
     // Belt-and-suspenders: any todos-moved-to-done with falsy verificationRef
+    // are real unsafe transitions and must remain critical.
     for (const p of phases) {
         for (const t of p.todosMovedToDone) {
             if (!t.verificationRef) {
@@ -300,15 +342,17 @@ export function analyzeRun(runId?: string): PostmortemReport {
         })
     }
 
-    // 5. Wave advance blocked
+    // 5. Wave advance blocked — downgraded to warning because the tool
+    // layer already prevented the unsafe transition. The presence of a
+    // block tells us the agent tried, but it didn't actually advance.
     const waveBlocked = entries.filter(
         (e) => e.event === 'wave-advance-blocked'
     )
     for (const e of waveBlocked) {
         violations.push({
-            severity: 'critical',
+            severity: 'warning',
             code: 'WAVE_NO_VERIFICATION',
-            message: `Attempt to advance wave without verification-result.`,
+            message: `Blocked attempt to advance wave without verification-result. Tool layer prevented the unsafe transition.`,
             evidence: `phase=${eventDataString(e, 'phase') ?? '?'} wave=${e.data.wave ?? '?'} at=${e.timestamp}`,
             evidenceFingerprint: fingerprint(
                 `WAVE_BLOCKED:${eventDataString(e, 'phase') ?? ''}:${e.data.wave ?? ''}`

--- a/packages/luca-mastracode/src/retro.ts
+++ b/packages/luca-mastracode/src/retro.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env bun
+/**
+ * Luca retro — retrospective inspection CLI for a Luca pipeline run.
+ *
+ * Reads `.planning/` artifacts in the current working directory and prints
+ * either:
+ *   • the rendered POSTMORTEM.md (default), or
+ *   • a list of archived runs (`--list`), or
+ *   • a structured JSON report (`--json`).
+ *
+ * This entrypoint is intentionally separate from `launch.ts` so that
+ * `luca retro` can run without booting the full Mastra harness.
+ *
+ * Usage:
+ *   bun run packages/luca-mastracode/src/retro.ts            # current run
+ *   bun run packages/luca-mastracode/src/retro.ts --list     # list runs
+ *   bun run packages/luca-mastracode/src/retro.ts --run <id> # specific run
+ *   bun run packages/luca-mastracode/src/retro.ts --json     # JSON report
+ */
+import { analyzeRun, renderPostmortemMarkdown } from './postmortem.js'
+import { listRuns } from './session-ledger.js'
+
+interface ParsedArgs {
+    list: boolean
+    json: boolean
+    runId?: string
+    help: boolean
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+    const out: ParsedArgs = { list: false, json: false, help: false }
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i]
+        if (a === '--list') out.list = true
+        else if (a === '--json') out.json = true
+        else if (a === '--help' || a === '-h') out.help = true
+        else if (a === '--run' || a === '--run-id') {
+            const next = argv[i + 1]
+            if (next && !next.startsWith('--')) {
+                out.runId = next
+                i++
+            }
+        }
+    }
+    return out
+}
+
+function printHelp(): void {
+    console.log(
+        [
+            'luca retro — inspect a Luca pipeline run',
+            '',
+            'Reads `.planning/` artifacts in the current working directory.',
+            '',
+            'Usage:',
+            '  luca retro                 Render the current run as Markdown',
+            '  luca retro --list          List archived runs in the ledger',
+            '  luca retro --run <id>      Render a specific run',
+            '  luca retro --json          Emit the structured report as JSON',
+            '  luca retro --help          Show this help',
+        ].join('\n')
+    )
+}
+
+const args = parseArgs(process.argv.slice(2))
+
+if (args.help) {
+    printHelp()
+    process.exit(0)
+}
+
+if (args.list) {
+    const runs = listRuns()
+    if (runs.length === 0) {
+        console.log('No runs recorded in .planning/session-ledger.jsonl.')
+        process.exit(0)
+    }
+    const sorted = [...runs].sort((a, b) =>
+        a.firstEvent.localeCompare(b.firstEvent)
+    )
+    console.log('Runs:')
+    for (const r of sorted) {
+        console.log(
+            `  ${r.runId}  events=${r.eventCount}  ${r.firstEvent} → ${r.lastEvent}`
+        )
+    }
+    process.exit(0)
+}
+
+const report = analyzeRun(args.runId)
+
+if (args.json) {
+    console.log(JSON.stringify(report, null, 2))
+    process.exit(0)
+}
+
+console.log(renderPostmortemMarkdown(report))
+const critical = report.violations.filter((v) => v.severity === 'critical')
+process.exit(critical.length > 0 ? 1 : 0)

--- a/packages/luca-mastracode/src/retro.ts
+++ b/packages/luca-mastracode/src/retro.ts
@@ -18,7 +18,7 @@
  *   bun run packages/luca-mastracode/src/retro.ts --json     # JSON report
  */
 import { analyzeRun, renderPostmortemMarkdown } from './postmortem.js'
-import { listRuns } from './session-ledger.js'
+import { listRuns, listArchivedRuns } from './session-ledger.js'
 
 interface ParsedArgs {
     list: boolean
@@ -70,19 +70,38 @@ if (args.help) {
 }
 
 if (args.list) {
-    const runs = listRuns()
-    if (runs.length === 0) {
-        console.log('No runs recorded in .planning/session-ledger.jsonl.')
+    // Live runs: present in the current `.planning/session-ledger.jsonl`.
+    // Archived runs: directories under `.planning/runs/` from previous
+    // pipeline-reset archival. Both are valid targets for `--run <id>`.
+    const liveRuns = listRuns()
+    const liveIds = new Set(liveRuns.map((r) => r.runId))
+    const archivedOnly = listArchivedRuns().filter((id) => !liveIds.has(id))
+
+    if (liveRuns.length === 0 && archivedOnly.length === 0) {
+        console.log(
+            'No runs recorded in .planning/session-ledger.jsonl or .planning/runs/.'
+        )
         process.exit(0)
     }
-    const sorted = [...runs].sort((a, b) =>
-        a.firstEvent.localeCompare(b.firstEvent)
-    )
-    console.log('Runs:')
-    for (const r of sorted) {
-        console.log(
-            `  ${r.runId}  events=${r.eventCount}  ${r.firstEvent} → ${r.lastEvent}`
+
+    if (liveRuns.length > 0) {
+        const sorted = [...liveRuns].sort((a, b) =>
+            a.firstEvent.localeCompare(b.firstEvent)
         )
+        console.log('Live runs (in current ledger):')
+        for (const r of sorted) {
+            console.log(
+                `  ${r.runId}  events=${r.eventCount}  ${r.firstEvent} → ${r.lastEvent}`
+            )
+        }
+    }
+
+    if (archivedOnly.length > 0) {
+        if (liveRuns.length > 0) console.log('')
+        console.log('Archived runs (in .planning/runs/):')
+        for (const id of [...archivedOnly].sort()) {
+            console.log(`  ${id}`)
+        }
     }
     process.exit(0)
 }

--- a/packages/luca-mastracode/src/session-ledger.ts
+++ b/packages/luca-mastracode/src/session-ledger.ts
@@ -32,8 +32,10 @@ const RUNS_DIR = '.planning/runs'
 // ---------------------------------------------------------------------------
 
 /**
- * Crockford-base32 ULID-style identifier (sufficient for run uniqueness;
- * we don't need true ULID monotonicity here).
+ * Generate a base36 (lowercase a-z + 0-9) run identifier of the form
+ * `run_<timestamp36>_<random36>`. This is intentionally not a real ULID —
+ * we only need uniqueness within a `.planning/` directory, not lexicographic
+ * monotonicity or 128-bit collision resistance.
  */
 function generateRunId(): string {
     const ts = Date.now().toString(36)
@@ -167,6 +169,71 @@ export function listRuns(): Array<{
         eventCount: v.count,
     }))
 }
+
+/**
+ * List runIds for which `.planning/runs/<runId>/` archive directories exist
+ * on disk. Returns an empty array if no archives exist or `.planning/` is
+ * missing. Sort order is unspecified — callers should sort if needed.
+ */
+export function listArchivedRuns(): string[] {
+    const archiveRoot = join(process.cwd(), RUNS_DIR)
+    if (!existsSync(archiveRoot)) return []
+    try {
+        // `readdirSync` is synchronous and good enough here — archive
+        // directories are small (one entry per run).
+        const { readdirSync, statSync } = require('node:fs') as typeof import('node:fs')
+        return readdirSync(archiveRoot).filter((name: string) => {
+            try {
+                return statSync(join(archiveRoot, name)).isDirectory()
+            } catch {
+                return false
+            }
+        })
+    } catch {
+        return []
+    }
+}
+
+/**
+ * Resolve the directory holding JSONL artifacts for a given runId. Returns
+ * `.planning/` if `runId` matches the current run, otherwise
+ * `.planning/runs/<runId>/` if that archive exists, else null.
+ */
+export function resolveRunArtifactDir(runId: string): string | null {
+    const planningRoot = join(process.cwd(), '.planning')
+    const current = readLucaState().runId
+    if (current === runId) {
+        return existsSync(planningRoot) ? planningRoot : null
+    }
+    const archiveDir = join(process.cwd(), RUNS_DIR, runId)
+    return existsSync(archiveDir) ? archiveDir : null
+}
+
+/**
+ * Read JSONL entries from a specific file inside an arbitrary directory.
+ * Used by postmortem to load artifacts from archived run directories.
+ */
+export function readJsonlAt<T>(dir: string, basename: string): T[] {
+    const p = join(dir, basename)
+    if (!existsSync(p)) return []
+    try {
+        return readFileSync(p, 'utf-8')
+            .trim()
+            .split('\n')
+            .filter(Boolean)
+            .map((line) => JSON.parse(line) as T)
+    } catch {
+        return []
+    }
+}
+
+/** Filenames used inside both `.planning/` and `.planning/runs/<id>/` */
+export const ARTIFACT_FILES = {
+    ledger: 'session-ledger.jsonl',
+    routing: 'routing-history.jsonl',
+    verification: 'verification-history.jsonl',
+    confidence: 'confidence-journal.jsonl',
+} as const
 
 /**
  * Compute session metrics from the ledger.

--- a/packages/luca-mastracode/src/session-ledger.ts
+++ b/packages/luca-mastracode/src/session-ledger.ts
@@ -6,12 +6,63 @@
  *
  * The ledger captures every significant event: mode transitions, phase
  * start/complete, verification results, convergence state, and timing.
+ *
+ * Each entry is stamped with a `runId` so postmortem tools can isolate a
+ * single pipeline run even when multiple runs share a `.planning/` directory.
  */
-import { existsSync, readFileSync, mkdirSync, appendFileSync } from 'node:fs'
+import {
+    existsSync,
+    readFileSync,
+    mkdirSync,
+    appendFileSync,
+    renameSync,
+} from 'node:fs'
 import { join } from 'node:path'
+
+import { readLucaState, writeLucaState } from './luca-store.js'
 
 const LEDGER_FILE = '.planning/session-ledger.jsonl'
 const ROUTING_HISTORY_FILE = '.planning/routing-history.jsonl'
+const VERIFICATION_HISTORY_FILE = '.planning/verification-history.jsonl'
+const CONFIDENCE_JOURNAL_FILE = '.planning/confidence-journal.jsonl'
+const RUNS_DIR = '.planning/runs'
+
+// ---------------------------------------------------------------------------
+// Run identity
+// ---------------------------------------------------------------------------
+
+/**
+ * Crockford-base32 ULID-style identifier (sufficient for run uniqueness;
+ * we don't need true ULID monotonicity here).
+ */
+function generateRunId(): string {
+    const ts = Date.now().toString(36)
+    const rand = Math.random().toString(36).slice(2, 10)
+    return `run_${ts}_${rand}`
+}
+
+/**
+ * Resolve the current run ID. If `luca-state.json` doesn't have one yet,
+ * mint a new one and persist it.
+ */
+export function getCurrentRunId(): string {
+    const state = readLucaState()
+    if (typeof state.runId === 'string' && state.runId.length > 0) {
+        return state.runId
+    }
+    const runId = generateRunId()
+    writeLucaState({ runId })
+    return runId
+}
+
+/**
+ * Force a new run ID. Returns the new ID. Use at pipeline-reset.
+ */
+export function startNewRun(): string {
+    const runId = generateRunId()
+    writeLucaState({ runId })
+    return runId
+}
 
 // ---------------------------------------------------------------------------
 // Session ledger
@@ -19,6 +70,7 @@ const ROUTING_HISTORY_FILE = '.planning/routing-history.jsonl'
 
 export interface LedgerEntry {
     timestamp: string
+    runId: string
     event: string
     data: Record<string, unknown>
 }
@@ -38,6 +90,7 @@ export function appendLedger(
     ensurePlanningDir()
     const entry: LedgerEntry = {
         timestamp: new Date().toISOString(),
+        runId: getCurrentRunId(),
         event,
         data,
     }
@@ -66,16 +119,60 @@ export function readLedger(): LedgerEntry[] {
 }
 
 /**
- * Get ledger entries filtered by event type.
+ * Read ledger entries scoped to a single run.
  */
-export function getLedgerByEvent(event: string): LedgerEntry[] {
-    return readLedger().filter((e) => e.event === event)
+export function readLedgerForRun(runId: string): LedgerEntry[] {
+    return readLedger().filter((e) => e.runId === runId)
+}
+
+/**
+ * Get ledger entries filtered by event type (optionally scoped to a run).
+ */
+export function getLedgerByEvent(
+    event: string,
+    runId?: string
+): LedgerEntry[] {
+    const entries = readLedger().filter((e) => e.event === event)
+    return runId ? entries.filter((e) => e.runId === runId) : entries
+}
+
+/**
+ * List distinct runs present in the ledger, oldest first.
+ */
+export function listRuns(): Array<{
+    runId: string
+    firstEvent: string
+    lastEvent: string
+    eventCount: number
+}> {
+    const entries = readLedger()
+    const byRun = new Map<
+        string,
+        { first: string; last: string; count: number }
+    >()
+    for (const e of entries) {
+        const id = e.runId ?? 'unknown'
+        const existing = byRun.get(id)
+        if (!existing) {
+            byRun.set(id, { first: e.timestamp, last: e.timestamp, count: 1 })
+        } else {
+            existing.last = e.timestamp
+            existing.count += 1
+        }
+    }
+    return Array.from(byRun.entries()).map(([runId, v]) => ({
+        runId,
+        firstEvent: v.first,
+        lastEvent: v.last,
+        eventCount: v.count,
+    }))
 }
 
 /**
  * Compute session metrics from the ledger.
  */
-export function computeSessionMetrics(): {
+export function computeSessionMetrics(runId?: string): {
+    runId?: string
     totalEvents: number
     modeTransitions: number
     phasesCompleted: number
@@ -84,9 +181,10 @@ export function computeSessionMetrics(): {
     lastEvent?: string
     durationMs?: number
 } {
-    const entries = readLedger()
+    const entries = runId ? readLedgerForRun(runId) : readLedger()
     if (entries.length === 0) {
         return {
+            runId,
             totalEvents: 0,
             modeTransitions: 0,
             phasesCompleted: 0,
@@ -107,6 +205,7 @@ export function computeSessionMetrics(): {
             : undefined
 
     return {
+        runId: runId ?? first?.runId,
         totalEvents: entries.length,
         modeTransitions: transitions.length,
         phasesCompleted: phaseCompletions.length,
@@ -118,11 +217,48 @@ export function computeSessionMetrics(): {
 }
 
 // ---------------------------------------------------------------------------
+// Run archival
+// ---------------------------------------------------------------------------
+
+/**
+ * Move the current run's JSONL artifacts into `.planning/runs/<runId>/`
+ * so the new run starts with empty ledger files. Best-effort: missing
+ * source files are silently skipped.
+ */
+export function archivePriorRun(runId: string): void {
+    if (!runId) return
+    const planningRoot = join(process.cwd(), '.planning')
+    if (!existsSync(planningRoot)) return
+
+    const targetDir = join(process.cwd(), RUNS_DIR, runId)
+    if (!existsSync(targetDir)) mkdirSync(targetDir, { recursive: true })
+
+    const candidates = [
+        LEDGER_FILE,
+        ROUTING_HISTORY_FILE,
+        VERIFICATION_HISTORY_FILE,
+        CONFIDENCE_JOURNAL_FILE,
+    ]
+    for (const rel of candidates) {
+        const src = join(process.cwd(), rel)
+        if (!existsSync(src)) continue
+        const base = rel.split('/').pop() ?? rel
+        const dest = join(targetDir, base)
+        try {
+            renameSync(src, dest)
+        } catch {
+            // Cross-device or permission failure — best-effort archival.
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Routing history
 // ---------------------------------------------------------------------------
 
 export interface RoutingEntry {
     timestamp: string
+    runId: string
     agentType: string
     complexity: string
     profile: string
@@ -134,10 +270,14 @@ export interface RoutingEntry {
  * Append a routing decision to the routing history.
  */
 export function appendRoutingHistory(
-    entry: Omit<RoutingEntry, 'timestamp'>
+    entry: Omit<RoutingEntry, 'timestamp' | 'runId'>
 ): void {
     ensurePlanningDir()
-    const full: RoutingEntry = { ...entry, timestamp: new Date().toISOString() }
+    const full: RoutingEntry = {
+        ...entry,
+        runId: getCurrentRunId(),
+        timestamp: new Date().toISOString(),
+    }
     appendFileSync(
         join(process.cwd(), ROUTING_HISTORY_FILE),
         JSON.stringify(full) + '\n',
@@ -150,7 +290,8 @@ export function appendRoutingHistory(
  */
 export function readRoutingHistory({
     limit = 20,
-}: { limit?: number } = {}): RoutingEntry[] {
+    runId,
+}: { limit?: number; runId?: string } = {}): RoutingEntry[] {
     const p = join(process.cwd(), ROUTING_HISTORY_FILE)
     if (!existsSync(p)) return []
     try {
@@ -159,7 +300,8 @@ export function readRoutingHistory({
             .split('\n')
             .filter(Boolean)
             .map((line) => JSON.parse(line) as RoutingEntry)
-        return entries.slice(-limit)
+        const scoped = runId ? entries.filter((e) => e.runId === runId) : entries
+        return scoped.slice(-limit)
     } catch {
         return []
     }

--- a/packages/luca-mastracode/src/tools/build-mode-tools.ts
+++ b/packages/luca-mastracode/src/tools/build-mode-tools.ts
@@ -9,6 +9,7 @@ import { MODE_PERMISSIONS } from './mode-permissions.js'
 import { pipelineLockTool } from './pipeline-lock.js'
 import { repoCleanupTool } from './repo-cleanup.js'
 import { runChecksTool } from './run-checks.js'
+import { runPostmortemTool } from './run-postmortem.js'
 import { sessionLedgerTool } from './session-ledger.js'
 import { verificationResultTool } from './verification-result.js'
 import { workflowStateTool } from './workflow-state.js'
@@ -52,6 +53,10 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
     confidence_journal: {
         tool: confidenceJournalTool,
         record_key: 'confidenceJournal',
+    },
+    run_postmortem: {
+        tool: runPostmortemTool,
+        record_key: 'runPostmortem',
     },
 }
 

--- a/packages/luca-mastracode/src/tools/index.ts
+++ b/packages/luca-mastracode/src/tools/index.ts
@@ -10,6 +10,7 @@ export { verificationResultTool } from './verification-result.js'
 export { repoCleanupTool } from './repo-cleanup.js'
 export { writePlanningFileTool } from './write-planning-file.js'
 export { confidenceJournalTool } from './confidence-journal.js'
+export { runPostmortemTool } from './run-postmortem.js'
 
 // Permission system
 export { createScopedTool } from './create-scoped-tool.js'

--- a/packages/luca-mastracode/src/tools/manage-todos.ts
+++ b/packages/luca-mastracode/src/tools/manage-todos.ts
@@ -1,6 +1,7 @@
 import { createTool } from '@mastra/core/tools'
 import { z } from 'zod'
 
+import { appendLedger } from '../session-ledger.js'
 import {
     addTodo,
     listTodos,
@@ -11,6 +12,56 @@ import {
     readTodoContent,
     type TodoStatus,
 } from '../todos.js'
+import { findCriterion } from '../verification-result.js'
+
+const verificationRefSchema = z.object({
+    criterionId: z
+        .string()
+        .describe('Stable criterion ID from verification-result.json'),
+    wave: z
+        .number()
+        .int()
+        .describe('Wave number whose verification result contains the criterion'),
+})
+
+type VerificationRef = z.infer<typeof verificationRefSchema>
+
+/**
+ * Validate a verificationRef points at a real, met, evidence-backed criterion.
+ * Returns null on success, or a structured error payload to return to the caller.
+ */
+function validateVerificationRef(ref: VerificationRef | undefined): {
+    code: string
+    message: string
+} | null {
+    if (!ref) {
+        return {
+            code: 'TODO_DONE_UNVERIFIED',
+            message:
+                'verificationRef is required when moving a todo to "done". Provide { criterionId, wave } pointing at a PASS criterion in verification-history.jsonl.',
+        }
+    }
+    const found = findCriterion(ref)
+    if (!found) {
+        return {
+            code: 'TODO_DONE_UNVERIFIED',
+            message: `verificationRef { criterionId: "${ref.criterionId}", wave: ${ref.wave} } not found in verification-history.jsonl. Write a verification-result with this criterion before moving the todo.`,
+        }
+    }
+    if (!found.criterion.met) {
+        return {
+            code: 'TODO_DONE_UNVERIFIED',
+            message: `Criterion "${ref.criterionId}" (wave ${ref.wave}) is recorded as NOT met. Cannot move the todo to done.`,
+        }
+    }
+    if (!found.criterion.evidence || !found.criterion.evidence.trim()) {
+        return {
+            code: 'TODO_DONE_UNVERIFIED',
+            message: `Criterion "${ref.criterionId}" (wave ${ref.wave}) has empty evidence. Move blocked — re-run verification with concrete evidence (file/line/test).`,
+        }
+    }
+    return null
+}
 
 export const manageTodosTool = createTool({
     id: 'manage-todos',
@@ -82,14 +133,22 @@ export const manageTodosTool = createTool({
                 z.object({
                     identifier: z.union([z.number(), z.string()]),
                     targetStatus: z.enum(['pending', 'backlog', 'done']),
+                    verificationRef: verificationRefSchema.optional(),
                 })
             )
             .optional()
             .describe(
-                'Array of {identifier, targetStatus} for batch status changes (required for move-batch). ' +
+                'Array of {identifier, targetStatus, verificationRef?} for batch status changes (required for move-batch). ' +
                     'Identifiers may be numeric indices or slug strings; mixing is allowed. ' +
                     'All identifiers are resolved against a single backlog snapshot before any moves run, ' +
-                    'so indices captured from a prior `list` call remain valid for the entire batch.'
+                    'so indices captured from a prior `list` call remain valid for the entire batch. ' +
+                    'verificationRef is REQUIRED for any item whose targetStatus is "done"; the batch is rejected atomically if any done item lacks a valid ref.'
+            ),
+        verificationRef: verificationRefSchema
+            .optional()
+            .describe(
+                'Required when moving a single todo to "done". Points at a PASS criterion in verification-history.jsonl. ' +
+                    'Format: { criterionId: string, wave: number }. The criterion must exist, be met, and have non-empty evidence.'
             ),
         filterStatus: z
             .enum(['pending', 'backlog', 'done'])
@@ -109,7 +168,10 @@ export const manageTodosTool = createTool({
             indices,
             items,
             filterStatus,
-        } = inputData
+            verificationRef,
+        } = inputData as typeof inputData & {
+            verificationRef?: VerificationRef
+        }
 
         switch (action) {
             case 'list': {
@@ -145,11 +207,33 @@ export const manageTodosTool = createTool({
                     return {
                         error: 'identifier and targetStatus are required for move',
                     }
+                if (targetStatus === 'done') {
+                    const violation = validateVerificationRef(verificationRef)
+                    if (violation) {
+                        appendLedger('todo-move-blocked', {
+                            identifier: String(identifier),
+                            targetStatus,
+                            reason: violation.code,
+                            message: violation.message,
+                        })
+                        return {
+                            error: violation.message,
+                            code: violation.code,
+                        }
+                    }
+                }
                 const moved = moveTodo({
                     identifier,
                     targetStatus: targetStatus as TodoStatus,
                 })
                 if (!moved) return { error: `Todo not found: ${identifier}` }
+                if (targetStatus === 'done' && verificationRef) {
+                    appendLedger('todo-moved-to-done', {
+                        slug: moved.slug,
+                        title: moved.title,
+                        verificationRef,
+                    })
+                }
                 return {
                     moved: `#${moved.index} ${moved.title} → ${moved.status}`,
                 }
@@ -159,7 +243,69 @@ export const manageTodosTool = createTool({
                     return {
                         error: 'items array is required for move-batch',
                     }
+                // Atomic guard: validate every done item BEFORE any move runs.
+                const blocked: Array<{
+                    identifier: string
+                    code: string
+                    message: string
+                }> = []
+                for (const it of items) {
+                    if (it.targetStatus === 'done') {
+                        const violation = validateVerificationRef(
+                            it.verificationRef
+                        )
+                        if (violation) {
+                            blocked.push({
+                                identifier: String(it.identifier),
+                                code: violation.code,
+                                message: violation.message,
+                            })
+                        }
+                    }
+                }
+                if (blocked.length > 0) {
+                    for (const b of blocked) {
+                        appendLedger('todo-move-blocked', {
+                            identifier: b.identifier,
+                            targetStatus: 'done',
+                            reason: b.code,
+                            message: b.message,
+                        })
+                    }
+                    return {
+                        error: `move-batch rejected: ${blocked.length} done-move(s) lack a valid verificationRef. The whole batch was atomic; no todos were moved.`,
+                        code: 'TODO_DONE_UNVERIFIED',
+                        blocked,
+                    }
+                }
+
                 const result = moveBatch({ items })
+
+                // Log each successful done move with its ref so postmortem can correlate.
+                const refByIdentifier = new Map<string, VerificationRef>()
+                for (const it of items) {
+                    if (it.targetStatus === 'done' && it.verificationRef) {
+                        refByIdentifier.set(
+                            String(it.identifier),
+                            it.verificationRef
+                        )
+                    }
+                }
+                for (const t of result.moved) {
+                    if (t.status === 'done') {
+                        const ref =
+                            refByIdentifier.get(String(t.index)) ??
+                            refByIdentifier.get(t.slug)
+                        if (ref) {
+                            appendLedger('todo-moved-to-done', {
+                                slug: t.slug,
+                                title: t.title,
+                                verificationRef: ref,
+                            })
+                        }
+                    }
+                }
+
                 return {
                     moved: result.moved.map(
                         (t) => `#${t.index} ${t.title} → ${t.status}`

--- a/packages/luca-mastracode/src/tools/manage-todos.ts
+++ b/packages/luca-mastracode/src/tools/manage-todos.ts
@@ -60,6 +60,12 @@ function validateVerificationRef(ref: VerificationRef | undefined): {
             message: `Criterion "${ref.criterionId}" (wave ${ref.wave}) has empty evidence. Move blocked — re-run verification with concrete evidence (file/line/test).`,
         }
     }
+    if (found.result.status !== 'PASS') {
+        return {
+            code: 'TODO_DONE_UNVERIFIED',
+            message: `Criterion "${ref.criterionId}" (wave ${ref.wave}) belongs to a verification result with status "${found.result.status}", not PASS. Cannot move the todo to done — fix the failing/stalled wave first.`,
+        }
+    }
     return null
 }
 

--- a/packages/luca-mastracode/src/tools/mode-permissions.ts
+++ b/packages/luca-mastracode/src/tools/mode-permissions.ts
@@ -36,6 +36,7 @@ export const MODE_PERMISSIONS: Record<
         session_ledger: '*',
         manage_todos: ['list', 'read'],
         workflow_state: ['read'],
+        run_postmortem: ['analyze', 'list-runs'],
     },
     'luca:1-triage': {
         classify_complexity: '*',
@@ -60,6 +61,7 @@ export const MODE_PERMISSIONS: Record<
             'record-iteration',
             'advance-wave',
             'complete-phase',
+            'justify-empty-phase',
             'switch-mode',
         ],
         manage_todos: ['list', 'read', 'move', 'move-batch'],
@@ -83,6 +85,7 @@ export const MODE_PERMISSIONS: Record<
             'reset-pipeline',
             'switch-mode',
             're-enter-pipeline',
+            'justify-empty-phase',
         ],
         run_checks: '*',
         pipeline_lock: ['release'],
@@ -91,5 +94,6 @@ export const MODE_PERMISSIONS: Record<
         manage_todos: ['list', 'read', 'move', 'move-batch'],
         repo_cleanup: '*',
         confidence_journal: ['read', 'summary', 'render'],
+        run_postmortem: '*',
     },
 } as const

--- a/packages/luca-mastracode/src/tools/run-postmortem.ts
+++ b/packages/luca-mastracode/src/tools/run-postmortem.ts
@@ -1,0 +1,105 @@
+/**
+ * run-postmortem (tool) — Mastra tool wrapper for the postmortem analyzer.
+ *
+ * Three actions:
+ *   - analyze: return the structured PostmortemReport.
+ *   - render:  write `.planning/POSTMORTEM.md` and return the path + violation count.
+ *   - gate:    same as analyze, but returns success=false with code POSTMORTEM_VIOLATIONS
+ *              if any critical violations exist. Used by finalize as the last
+ *              gate before PR creation.
+ *
+ * The tool returns a `pitfalls` array of pre-formatted MuninnDB payloads
+ * (default vault, type=pitfall) that the calling agent should forward via
+ * `mcp__muninn__muninn_remember` so future runs can recall recurring failures.
+ */
+import { createTool } from '@mastra/core/tools'
+import { z } from 'zod'
+
+import {
+    analyzeRun,
+    writePostmortem,
+    listRuns,
+} from '../postmortem.js'
+
+export const runPostmortemTool = createTool({
+    id: 'run-postmortem',
+    description:
+        'Analyze a Luca pipeline run for silent skips, unverified todo completions, and other gaps. ' +
+        "Use 'gate' as the last call in finalize before PR creation — critical violations block the PR. " +
+        "Use 'render' to write a human-readable .planning/POSTMORTEM.md report. " +
+        "Use 'analyze' for read-only inspection. " +
+        "Use 'list-runs' to enumerate archived runs in the ledger. " +
+        'The tool returns a `pitfalls` array of pre-formatted MuninnDB payloads (default vault) — forward each via mcp__muninn__muninn_remember.',
+    inputSchema: z.object({
+        action: z
+            .enum(['analyze', 'render', 'gate', 'list-runs'])
+            .describe(
+                'analyze: structured report | render: write .planning/POSTMORTEM.md | gate: block on critical violations | list-runs: enumerate archived runs'
+            ),
+        runId: z
+            .string()
+            .optional()
+            .describe(
+                'Optional run ID to analyze. Defaults to the current run.'
+            ),
+    }),
+    execute: async (inputData) => {
+        const { action, runId } = inputData
+
+        switch (action) {
+            case 'analyze': {
+                const report = analyzeRun(runId)
+                return {
+                    success: true,
+                    message: `Run ${report.runId}: ${report.violations.length} violation(s) (${report.violations.filter((v) => v.severity === 'critical').length} critical)`,
+                    report,
+                }
+            }
+            case 'render': {
+                const report = analyzeRun(runId)
+                const { path, bytes } = writePostmortem(report)
+                return {
+                    success: true,
+                    message: `Wrote ${path} (${bytes} bytes). ${report.violations.length} violation(s).`,
+                    path,
+                    violationCount: report.violations.length,
+                    pitfalls: report.pitfalls,
+                }
+            }
+            case 'gate': {
+                const report = analyzeRun(runId)
+                const critical = report.violations.filter(
+                    (v) => v.severity === 'critical'
+                )
+                if (critical.length > 0) {
+                    return {
+                        success: false,
+                        code: 'POSTMORTEM_VIOLATIONS',
+                        message: `Postmortem gate failed: ${critical.length} critical violation(s). Re-enter pipeline at execute or review and resolve before finalizing.`,
+                        violations: report.violations,
+                        pitfalls: report.pitfalls,
+                    }
+                }
+                return {
+                    success: true,
+                    message: `Postmortem gate passed. ${report.violations.length} warning(s) (no criticals).`,
+                    violations: report.violations,
+                    pitfalls: report.pitfalls,
+                }
+            }
+            case 'list-runs': {
+                const runs = listRuns()
+                return {
+                    success: true,
+                    message: `${runs.length} run(s) in ledger`,
+                    runs,
+                }
+            }
+            default:
+                return {
+                    success: false,
+                    message: `Unknown action: ${String(action)}`,
+                }
+        }
+    },
+})

--- a/packages/luca-mastracode/src/tools/run-postmortem.ts
+++ b/packages/luca-mastracode/src/tools/run-postmortem.ts
@@ -20,6 +20,7 @@ import {
     writePostmortem,
     listRuns,
 } from '../postmortem.js'
+import { listArchivedRuns } from '../session-ledger.js'
 
 export const runPostmortemTool = createTool({
     id: 'run-postmortem',
@@ -53,6 +54,7 @@ export const runPostmortemTool = createTool({
                     success: true,
                     message: `Run ${report.runId}: ${report.violations.length} violation(s) (${report.violations.filter((v) => v.severity === 'critical').length} critical)`,
                     report,
+                    pitfalls: report.pitfalls,
                 }
             }
             case 'render': {
@@ -88,10 +90,25 @@ export const runPostmortemTool = createTool({
                 }
             }
             case 'list-runs': {
-                const runs = listRuns()
+                const liveRuns = listRuns()
+                const liveIds = new Set(liveRuns.map((r) => r.runId))
+                const archivedOnly = listArchivedRuns()
+                    .filter((id) => !liveIds.has(id))
+                    .map((runId) => ({
+                        runId,
+                        firstEvent: '',
+                        lastEvent: '',
+                        eventCount: 0,
+                        archived: true as const,
+                    }))
+                const live = liveRuns.map((r) => ({
+                    ...r,
+                    archived: false as const,
+                }))
+                const runs = [...live, ...archivedOnly]
                 return {
                     success: true,
-                    message: `${runs.length} run(s) in ledger`,
+                    message: `${runs.length} run(s) (live: ${live.length}, archived-only: ${archivedOnly.length})`,
                     runs,
                 }
             }

--- a/packages/luca-mastracode/src/tools/workflow-state.ts
+++ b/packages/luca-mastracode/src/tools/workflow-state.ts
@@ -776,6 +776,21 @@ export const workflowStateTool = createTool({
                         raw
                     )
                     const justState = readLucaState()
+                    const currentPhaseName = justState.currentPhaseName
+                    if (!currentPhaseName) {
+                        return {
+                            success: false,
+                            code: 'NO_PHASE_IN_PROGRESS',
+                            message: `Cannot justify empty phase: no phase is currently in progress. Call workflowState(action: "start-phase", ...) first.`,
+                        }
+                    }
+                    if (phase !== currentPhaseName) {
+                        return {
+                            success: false,
+                            code: 'PHASE_MISMATCH',
+                            message: `Cannot justify empty phase: provided phase "${phase}" does not match the in-progress phase "${currentPhaseName}". Justifications can only be recorded for the active phase.`,
+                        }
+                    }
                     const existing = justState.emptyPhaseJustifications ?? {}
                     const merged = {
                         ...existing,
@@ -836,6 +851,9 @@ export const workflowStateTool = createTool({
                         phaseResults: undefined,
                         // Phase-diff snapshots (Step 2 of the postmortem plan)
                         currentPhaseStartSnapshot: undefined,
+                        // Empty-phase justifications — must clear so prior-run
+                        // justifications can't unblock complete-phase in a new run
+                        emptyPhaseJustifications: undefined,
                         // Run identity — clear so startNewRun mints a fresh ID
                         runId: undefined,
                     })

--- a/packages/luca-mastracode/src/tools/workflow-state.ts
+++ b/packages/luca-mastracode/src/tools/workflow-state.ts
@@ -13,7 +13,17 @@ import {
     type LucaWorkflowState,
 } from '../luca-store.js'
 import { switchModeRef, contextRefresherRef } from '../refs.js'
-import { appendLedger } from '../session-ledger.js'
+import {
+    appendLedger,
+    archivePriorRun,
+    startNewRun,
+} from '../session-ledger.js'
+import {
+    snapshotWorkingTree,
+    computePhaseDiff,
+    type PhaseSnapshot,
+} from '../phase-diff.js'
+import { readVerificationResult } from '../verification-result.js'
 
 const VALID_MODES = Object.keys(MODE_PERMISSIONS)
 
@@ -148,6 +158,30 @@ const saveReviewResultsAction = z.object({
     reviewIteration: z.number().optional().describe('Review iteration number'),
 })
 
+const EMPTY_PHASE_CATEGORIES = [
+    'docs-only-in-muninn',
+    'investigation-confirmed-no-change-needed',
+    'config-only-no-tracked-files',
+    'dependency-bump-via-lockfile-only',
+    'no-op-by-design',
+] as const
+
+const justifyEmptyPhaseAction = z.object({
+    action: z.literal('justify-empty-phase'),
+    phase: z.string().describe('Phase name (must match the in-progress phase).'),
+    category: z
+        .enum(EMPTY_PHASE_CATEGORIES)
+        .describe(
+            'Why this phase legitimately has no diff. Used to unblock the empty-phase guard on complete-phase.'
+        ),
+    reasoning: z
+        .string()
+        .min(20, 'Reasoning must be at least 20 characters')
+        .describe(
+            'Concrete explanation of why no code changed. Surfaces in the postmortem report for human review.'
+        ),
+})
+
 const RE_ENTER_TARGETS = ['luca:4-execute', 'luca:5-review'] as const
 
 const reEnterPipelineAction = z.object({
@@ -173,6 +207,7 @@ export const WORKFLOW_STATE_ACTIONS = [
     'record-iteration',
     'advance-wave',
     'complete-phase',
+    'justify-empty-phase',
     'save-triage-results',
     'save-plan-artifacts',
     'save-review-results',
@@ -301,6 +336,26 @@ const workflowStateInputSchema = z.object({
         .optional()
         .describe(
             "Why the pipeline is being re-entered (required for 're-enter-pipeline'). Stored in state as reEntryReason."
+        ),
+
+    // justify-empty-phase
+    phase: z
+        .string()
+        .optional()
+        .describe(
+            "Phase name (required for 'justify-empty-phase'). Must match the in-progress phase."
+        ),
+    category: z
+        .enum(EMPTY_PHASE_CATEGORIES)
+        .optional()
+        .describe(
+            "Empty-phase category (required for 'justify-empty-phase'). One of: docs-only-in-muninn | investigation-confirmed-no-change-needed | config-only-no-tracked-files | dependency-bump-via-lockfile-only | no-op-by-design."
+        ),
+    reasoning: z
+        .string()
+        .optional()
+        .describe(
+            "Concrete reasoning for why no code changed (required for 'justify-empty-phase'). Surfaces in postmortem report."
         ),
 })
 
@@ -494,6 +549,18 @@ export const workflowStateTool = createTool({
                     const { phaseName } = parseAction(startPhaseAction, raw)
                     const phaseState = startPhase({ name: phaseName })
                     appendLedger('phase-start', { phase: phaseName })
+
+                    // Snapshot working tree as proof-of-work baseline.
+                    const snapshot: PhaseSnapshot =
+                        snapshotWorkingTree(phaseName)
+                    writeLucaState({ currentPhaseStartSnapshot: snapshot })
+                    appendLedger('phase-snapshot', {
+                        phase: phaseName,
+                        headSha: snapshot.headSha,
+                        dirtyFileCount: snapshot.dirtyFiles.length,
+                        gitAvailable: snapshot.gitAvailable,
+                    })
+
                     return {
                         success: true,
                         message: `Started phase "${phaseName}" (wave 1, iteration 0)`,
@@ -524,6 +591,28 @@ export const workflowStateTool = createTool({
                     }
                 }
                 case 'advance-wave': {
+                    // Guard: refuse to advance unless the current wave has a
+                    // verification result on file. Prevents waves from being
+                    // closed silently without proof of work.
+                    const preWaveState = readLucaState()
+                    const currentWave = preWaveState.currentWave ?? 1
+                    const verification = readVerificationResult()
+                    if (
+                        !verification ||
+                        verification.wave !== currentWave
+                    ) {
+                        appendLedger('wave-advance-blocked', {
+                            phase: preWaveState.currentPhaseName,
+                            wave: currentWave,
+                            reason: 'no verification-result for current wave',
+                        })
+                        return {
+                            success: false,
+                            code: 'WAVE_ADVANCE_NO_VERIFICATION',
+                            message: `Cannot advance wave: no verification-result.json for wave ${currentWave}. Call verificationResult(action: "write", ...) before advance-wave.`,
+                        }
+                    }
+
                     const waveState = advanceWave()
                     appendLedger('wave-advance', {
                         phase: waveState.currentPhaseName,
@@ -550,18 +639,68 @@ export const workflowStateTool = createTool({
                         completePhaseAction,
                         raw
                     )
+
+                    // ── Guard 1: diff-based phase proof ─────────────────────
+                    const preState = readLucaState()
+                    const phaseName = preState.currentPhaseName ?? '<unknown>'
+                    const startSnapshot =
+                        preState.currentPhaseStartSnapshot ?? null
+                    const diff = computePhaseDiff(startSnapshot)
+                    appendLedger('phase-diff-summary', {
+                        phase: phaseName,
+                        filesChanged: diff.filesChanged,
+                        commitsAdded: diff.commitsAdded,
+                        isEmpty: diff.isEmpty,
+                        indeterminate: diff.indeterminate,
+                    })
+
+                    if (diff.isEmpty) {
+                        const justifications =
+                            preState.emptyPhaseJustifications ?? {}
+                        const j = justifications[phaseName]
+                        if (!j) {
+                            return {
+                                success: false,
+                                code: 'EMPTY_PHASE_BLOCKED',
+                                message: `Phase "${phaseName}" has zero file changes and zero commits. Either (a) call workflowState(action: "justify-empty-phase", phase: "${phaseName}", category: <category>, reasoning: "<why>") if this is intentional, or (b) re-enter execute mode to do the work.`,
+                            }
+                        }
+                    }
+
+                    // ── Guard 2: verification result must exist for current wave ──
+                    const verification = readVerificationResult()
+                    const currentWave = preState.currentWave ?? 1
+                    if (
+                        verificationPassed !== false &&
+                        (!verification ||
+                            verification.wave !== currentWave ||
+                            verification.status !== 'PASS')
+                    ) {
+                        return {
+                            success: false,
+                            code: 'PHASE_COMPLETE_NO_VERIFICATION',
+                            message: `Phase "${phaseName}" cannot be completed: no PASS verification-result.json for wave ${currentWave}. Call verificationResult(action: "write", ...) with a PASS verdict before complete-phase, or pass verificationPassed: false to record a failed completion.`,
+                        }
+                    }
+
                     const phaseResult = completePhase({
                         verificationPassed,
                         reviewPassed,
                     })
+
+                    // Clear snapshot now that the phase is closed.
+                    writeLucaState({ currentPhaseStartSnapshot: undefined })
+
                     appendLedger('phase-complete', {
-                        phase: phaseResult.completedPhaseName,
+                        phase: phaseName,
                         verificationPassed: verificationPassed ?? null,
                         reviewPassed: reviewPassed ?? null,
+                        filesChanged: diff.filesChanged.length,
+                        commitsAdded: diff.commitsAdded.length,
                     })
                     return {
                         success: true,
-                        message: `Completed phase "${phaseResult.completedPhaseName}" (${phaseResult.completedPhases}/${phaseResult.totalPhases} phases done)`,
+                        message: `Completed phase "${phaseName}" (${diff.filesChanged.length} files changed, ${diff.commitsAdded.length} commits)`,
                         state: phaseResult,
                     }
                 }
@@ -631,7 +770,44 @@ export const workflowStateTool = createTool({
                         state: reviewState,
                     }
                 }
+                case 'justify-empty-phase': {
+                    const { phase, category, reasoning } = parseAction(
+                        justifyEmptyPhaseAction,
+                        raw
+                    )
+                    const justState = readLucaState()
+                    const existing = justState.emptyPhaseJustifications ?? {}
+                    const merged = {
+                        ...existing,
+                        [phase]: {
+                            category,
+                            reasoning,
+                            at: new Date().toISOString(),
+                        },
+                    }
+                    const updatedState = writeLucaState({
+                        emptyPhaseJustifications: merged,
+                    })
+                    appendLedger('phase-empty-justification', {
+                        phase,
+                        category,
+                        reasoning,
+                    })
+                    return {
+                        success: true,
+                        message: `Recorded empty-phase justification for "${phase}" (category: ${category}). complete-phase will now accept this phase.`,
+                        state: updatedState,
+                    }
+                }
                 case 'reset-pipeline': {
+                    // Archive the prior run's ledger artifacts BEFORE wiping
+                    // state, so we don't lose audit trail when starting fresh.
+                    const priorRunId = readLucaState().runId as
+                        | string
+                        | undefined
+                    if (priorRunId) {
+                        archivePriorRun(priorRunId)
+                    }
                     const freshState = writeLucaState({
                         pipelineStep: 'idle',
                         // Triage output — stale intent is the #1 cause of session hijack
@@ -658,12 +834,20 @@ export const workflowStateTool = createTool({
                         startedAt: undefined,
                         assignedTodos: undefined,
                         phaseResults: undefined,
+                        // Phase-diff snapshots (Step 2 of the postmortem plan)
+                        currentPhaseStartSnapshot: undefined,
+                        // Run identity — clear so startNewRun mints a fresh ID
+                        runId: undefined,
                     })
-                    appendLedger('pipeline-reset', {})
+                    const newRunId = startNewRun()
+                    appendLedger('pipeline-reset', {
+                        priorRunId: priorRunId ?? null,
+                        newRunId,
+                    })
                     return {
                         success: true,
-                        message: 'Pipeline reset to idle state',
-                        state: freshState,
+                        message: `Pipeline reset to idle state (run ${newRunId})`,
+                        state: { ...freshState, runId: newRunId },
                     }
                 }
                 case 're-enter-pipeline': {

--- a/packages/luca-mastracode/src/verification-result.ts
+++ b/packages/luca-mastracode/src/verification-result.ts
@@ -134,6 +134,34 @@ export function readVerificationHistory(): VerificationResult[] {
 }
 
 /**
+ * Find a specific criterion in the verification history by wave + criterionId.
+ * Returns the matching criterion (with the result it belongs to) or null.
+ *
+ * Used by `manageTodos(move → done)` to verify that a todo's claimed
+ * verification reference actually exists and was met.
+ */
+export function findCriterion({
+    criterionId,
+    wave,
+}: {
+    criterionId: string
+    wave: number
+}): {
+    criterion: VerificationCriterion
+    result: VerificationResult
+} | null {
+    const history = readVerificationHistory()
+    // Iterate newest → oldest so the most recent verdict wins.
+    for (let i = history.length - 1; i >= 0; i--) {
+        const r = history[i]
+        if (!r || r.wave !== wave) continue
+        const c = r.criteria.find((cc) => cc.criterionId === criterionId)
+        if (c) return { criterion: c, result: r }
+    }
+    return null
+}
+
+/**
  * Aggregate verification results for milestone validation.
  * Returns overall pass/fail and summary stats.
  */


### PR DESCRIPTION
## Summary

Hardens Luca's full-auto pipeline against silent-skip incidents by replacing LLM-only enforcement with **hard tool-layer gates** and adding a **postmortem analyzer** that runs as the last step before PR creation. Motivated by an incident in another repo where execute mode never fired but finalize advanced every todo to `done`.

## What changed

### Hard gates (block bad transitions at the tool layer)

| Tool / action | New behavior |
| --- | --- |
| `workflowState(complete-phase)` | Rejects with `EMPTY_PHASE_BLOCKED` if the phase has zero file changes / commits and no `phase-empty-justification` exists. New `justify-empty-phase` action lets the agent declare an intentional no-op. |
| `workflowState(advance-wave)` | Rejects with `WAVE_ADVANCE_NO_VERIFICATION` if no verification result exists for the current wave. |
| `manageTodos(move \| move-batch → done)` | Requires a `verificationRef` pointing to a passing criterion in `verification-history.jsonl`; rejects with `TODO_DONE_UNVERIFIED` otherwise. |

### Diff-based phase proof

`phase-diff.ts` snapshots the working tree at `start-phase` and computes the diff at `complete-phase`. The result is logged as a new `phase-diff-summary` ledger event and feeds the empty-phase gate.

### Run identity & archiving

Every ledger entry is now stamped with a per-run `runId`. Pipeline reset archives prior `session-ledger.jsonl`, `verification-history.jsonl`, `confidence-journal.jsonl`, and `routing-history.jsonl` to `.planning/runs/<priorRunId>/`.

### Postmortem analyzer + gate

`postmortem.ts` reads the four append-only JSONL artifacts and produces a structured report. New `runPostmortem` Mastra tool exposes four actions:

- `analyze` — structured `PostmortemReport`
- `render` — write `.planning/POSTMORTEM.md`
- `gate` — block with `POSTMORTEM_VIOLATIONS` on critical findings (called from finalize before PR)
- `list-runs` — enumerate runs in the ledger

Detects 7 violation codes: `EMPTY_PHASE_NO_JUSTIFICATION`, `TODO_DONE_NO_VERIFICATION`, `FORCED_TRANSITION`, `LOW_CONFIDENCE_THRESHOLD`, `WAVE_NO_VERIFICATION`, `PIPELINE_RE_ENTERED`, `PIPELINE_GUARD_IDLE_BYPASS`. Returns pre-formatted MuninnDB pitfall payloads for the agent to forward to the `default` vault so future runs can recall recurring failure modes.

### Finalize wiring

- New **Step 4.5: Postmortem Gate** between gap detection and cross-milestone continuation. Critical violations block PR creation and re-enter the pipeline.
- **Step 6** calls `runPostmortem(action: "render")` so the final report is referenced from the PR body.

### Pipeline-guard idle-bypass logging

When the guard bypasses enforcement because `pipelineStep === 'idle'` or is missing, it now emits a one-time-per-turn `pipeline-guard-idle-bypass` ledger event. Previously this bypass was silent — exactly the failure path that hid the original incident.

### `luca retro` CLI

New CLI command prints `.planning/POSTMORTEM.md` (or `--list` archived runs under `.planning/runs/`) so users can inspect retrospective reports without launching the harness. A standalone `luca-mastracode/src/retro.ts` entrypoint also runs the analyzer ad-hoc without booting the full Mastra harness.

## Files

```
M  packages/luca-framework/src/cli.ts
A  packages/luca-framework/src/commands/retro.ts
A  packages/luca-mastracode/src/phase-diff.ts
A  packages/luca-mastracode/src/postmortem.ts
A  packages/luca-mastracode/src/retro.ts
A  packages/luca-mastracode/src/tools/run-postmortem.ts
M  packages/luca-mastracode/src/instructions/finalize.md
M  packages/luca-mastracode/src/luca-store.ts
M  packages/luca-mastracode/src/pipeline-guard.ts
M  packages/luca-mastracode/src/session-ledger.ts
M  packages/luca-mastracode/src/tools/build-mode-tools.ts
M  packages/luca-mastracode/src/tools/index.ts
M  packages/luca-mastracode/src/tools/manage-todos.ts
M  packages/luca-mastracode/src/tools/mode-permissions.ts
M  packages/luca-mastracode/src/tools/workflow-state.ts
M  packages/luca-mastracode/src/verification-result.ts
A  .changeset/run-observability-postmortem.md
```

## Test plan

- ✅ `bunx --bun tsc --noEmit` clean
- ✅ `bun run build` succeeds (`dist/index.mjs`, total 53.8 kB)
- ✅ `luca retro --help` and `luca retro --list` smoke-tested

Manual smoke test recommendations (from the plan's Verification section):

1. Trigger `complete-phase` with no diff and no justification → expect `EMPTY_PHASE_BLOCKED`.
2. Call `justify-empty-phase` then re-run `complete-phase` → expect success.
3. Call `manageTodos(move → done)` without `verificationRef` → expect `TODO_DONE_UNVERIFIED`.
4. Run a clean pipeline end-to-end → confirm `runPostmortem(gate)` returns success and `POSTMORTEM.md` is written.
5. Force a violation, run `runPostmortem(gate)`, then `mcp__muninn__muninn_recall(vault: "default", tags: ["luca", "pipeline", "postmortem"])` → confirm pitfall is recallable.
6. Replay the original incident (skip execute work, advance to finalize) → confirm finalize is now blocked at the postmortem gate.

## Out of scope

- `luca-studio` UI panel for browsing archived runs.
- Per-task expected-artifact declarations in PLAN.md (replaced by justification-on-empty).
- Semantic pipeline-guard signal beyond the diff-based proof.
