### PR TITLE
feat(harness): observability + doc-drift defense + review hardening + rule-pack engine + hygiene

### DIFF
--- a/.changeset/claim-verifier-doc-drift.md
+++ b/.changeset/claim-verifier-doc-drift.md
@@ -1,0 +1,37 @@
+---
+'@alecsibilia/luca-mastracode': minor
+'@alecsibilia/luca-framework': patch
+---
+
+Defend against doc-claim drift — when changesets, PR bodies, and PLAN.md cite symbols, file paths, or quantitative counts that don't match the shipped code.
+
+**New `claimVerifier` tool** (`tools/claim-verifier.ts`, `claim-verifier.ts`) — extracts factual claims from any text artifact:
+
+- `symbol` — backtick-wrapped identifiers (`` `myFunction` ``)
+- `file-path` — repo-relative paths matching common project layouts
+- `quantitative` — `<N> <countable-noun>` patterns from a small allow-list of countable nouns
+
+For each claim, it greps the working tree (`git grep --untracked` for tracked + new files; filesystem fallback for non-git repos) and reports failures with stable evidence strings. Tolerance ±1 on quantitative counts. 30s total budget, 5s per claim, with timeout failures explicit.
+
+Three actions:
+
+- `verify-text` — verify an inline string (e.g. PR body draft).
+- `verify-file` — verify a file on disk (resolves to repo root, then `.planning/`).
+- `gate` — verify multiple inputs; returns `code: "CLAIM_VERIFICATION_FAILED"` if any input has unverifiable claims.
+
+Every call appends a `claim-verifier-run` ledger event for postmortem visibility.
+
+**Finalize integration** (`instructions/finalize.md`):
+
+- **Step 3c** (PLAN.md reconciliation) — runs `claimVerifier(action: "verify-file", path: ".planning/PLAN.md")` during gap detection; failures attached to *complete* tasks block re-entry to execute, failures on incomplete tasks are allowed.
+- **Step 5b.1** (write release artifacts AFTER review iteration converged) — moves changeset/release-note authoring to *after* the final review iteration. Writing release artifacts before this point is the upstream cause of doc-drift; only the post-convergence tree is a trustworthy source for descriptions of shipped work.
+- **Step 5b.2** (verify artifact claims) — runs `claimVerifier(action: "gate", paths: [...], texts: [...])` over the changeset and PR body draft before `gh pr create`. The gate blocks the PR until every cited symbol, path, and count is verified against the working tree.
+
+**Review-mode advisory** (`instructions/review.md`) — non-blocking self-check: reviewers may run `claimVerifier(action: "verify-text", ...)` over their own MUST-FIX/SHOULD-FIX entries to catch hallucinated symbols early.
+
+**Mode permissions** (`tools/mode-permissions.ts`):
+
+- `luca:5-review`: `verify-text`, `verify-file` (advisory).
+- `luca:6-finalize`: full access (gate before PR).
+
+Catches the failure class where changesets cite renamed/removed symbols, design docs drift from shipped code, or PR bodies describe quantities that don't match the diff — failure modes that previously were only caught post-merge by reviewers.

--- a/.changeset/pr-review-hardening.md
+++ b/.changeset/pr-review-hardening.md
@@ -1,0 +1,49 @@
+---
+'@alecsibilia/luca-mastracode': minor
+---
+
+Harden the `/pr-address` command loop against three measured failure modes: stale Copilot comments, missed cross-perspective convergence, and fixes that introduce new regressions.
+
+**Stale-comment filter** (`pr-review/stale-filter.ts`)
+
+Across the PR-review corpus, ~57% of inline comments on iterated PRs are stale — they cite code that has already been changed by an earlier fix iteration. Treating them as still-actionable burns iteration cycles and produces confused replies.
+
+The filter classifies each comment by re-reading the cited file, parsing the `diff_hunk`, and locating the post-state anchor lines in the current working tree. A comment is stale when:
+
+- The cited file no longer exists.
+- The diff hunk's anchor lines (context + added) cannot be found within ±50 lines of the cited line.
+- The anchor location has drifted by more than 5 lines.
+- The cited commit_id is older than HEAD AND the path was modified between commit_id and HEAD AND fewer than 85% of anchors match.
+
+Verified on PR #195 (which had fixes pushed after Copilot's review): correctly classified 9 of 10 comments as stale and left 1 still-actionable.
+
+**Cross-perspective convergence** (`pr-review/convergence.ts`)
+
+Today, when Copilot, the reviewer agent, and the project's claim verifier each flag the same line, the harness treats the three findings as independent SHOULD-FIX items. They should be MUST-FIX.
+
+The detector groups findings by `(path, line ± lineTolerance)`. Findings authored by ≥2 distinct perspectives in the same group get severity promoted to `must-fix`. Findings already at must-fix are tagged with `must-fix-converged` for evidence rendering. Single-perspective groups are pass-through.
+
+**Iteration-N regression check** (`pr-review/regression.ts`)
+
+Catches the case where a fix commit introduces a new finding — currently, that's only detected on the *next* review pass, costing another iteration cycle.
+
+Given pre-iteration findings, post-iteration findings, and the list of paths the iteration touched (or `fromSha`/`toSha` to compute it), the check returns:
+
+- `regressions` — new findings on touched paths, or severity escalations of persistent findings
+- `resolved` — findings present before, gone after (the iteration's wins)
+- `unchanged` — present in both
+- `newButUntouched` — new findings on paths the iteration didn't modify (likely external; not blocking)
+
+Any regressions block iteration completion and re-enter the fix loop.
+
+**Tool surface** (`tools/pr-review.ts`)
+
+New `prReview` Mastra tool with three actions: `filter-stale`, `detect-convergence`, `regression-check`. Every call appends a `pr-review-run` ledger event for postmortem visibility. Available in `build` and `fast` modes (where slash commands run).
+
+**`/pr-address` integration** (`commands/pr-address.md`)
+
+- Step 1.5: filter stale comments before categorization.
+- Step 2.5: detect convergence and promote severity before planning fixes.
+- Step 7: regression check after push, blocking iteration completion if fixes introduced new findings. Bounded retry (3 iterations) before escalating to user.
+
+The command also now snapshots the iteration-start SHA at Step 1 so the regression check can compute the precise iteration delta.

--- a/.changeset/repo-local-rule-pack-engine.md
+++ b/.changeset/repo-local-rule-pack-engine.md
@@ -1,0 +1,62 @@
+---
+'@alecsibilia/luca-mastracode': minor
+---
+
+Add a repo-local rule-pack engine plus recurrence-driven rule suggestion. Closes the gap between "we keep flagging this in PR review" and "we have a machine-checkable invariant."
+
+**Why**
+
+Repos accumulate "house rules" that exist only in PR-review folklore — Convex anti-patterns, auth invariants, internal RPC conventions, naming rules. These get caught manually in every PR review, forever, because there is no encoding for them outside of human memory.
+
+This phase ships the engine. Zero domain rules ship in `luca-mastracode` itself — every rule is repo-local in `.luca/rules/*.ts`.
+
+**Engine: `defineRule` + runner**
+
+- `rules/define-rule.ts` — author API. `defineRule({ id, severity, description, scope, category, exclude, check })`. Schema validates id and check function at definition time.
+- `rules/runner.ts` — discovery and execution.
+  - Walks `.luca/rules/` recursively for `*.ts`/`*.mts`/`*.js`/`*.mjs` files (skips `.test.ts`, `.spec.ts`, dotfiles, `node_modules`).
+  - Dynamically imports each file and pulls every `RuleDefinition` from default + named exports + arrays.
+  - Resolves `scope` globs via `Bun.Glob`, applies `exclude`, builds one `RuleFile` per candidate.
+  - Calls `rule.check(file)` and collects `RuleFinding[]`.
+- Hybrid `RuleFile` API: `content: string` for cheap regex checks, lazy `ast(): ts.SourceFile | null` for AST-level matching.
+  - AST parse is cached per file across rules (multiple rules processing the same file pay parse cost once).
+  - `typescript` is loaded via `createRequire` at call time — repos without `typescript` installed get `ast() === null` and regex-only rules keep working.
+- Resilience: rule throws are caught and reported as `RuleExecutionError`; rule-file syntax errors are caught and reported as `RuleLoadError`. A single broken rule never crashes the run.
+- Findings are typed compatibly with `pr-review/convergence.ts`'s `ReviewFinding`, so rule output flows through the existing convergence detector as a first-class reviewer perspective.
+
+**Tool: `runRules`**
+
+Four actions:
+- `list` — discover rules and return their metadata without executing them.
+- `run` — execute all rules; non-blocking; returns the full report.
+- `gate` — execute and block (`success: false`, `code: RULE_VIOLATIONS_DETECTED`) when any finding has severity `must-fix`.
+- `suggest` — see "Recurrence-driven promotion" below.
+
+Every call appends a `rules-run` ledger event. Available in `build`, `fast`, `luca:4-execute`, `luca:5-review`, `luca:6-finalize` modes.
+
+**Recurrence-driven promotion: `rules/recurrence.ts`**
+
+The hard part of a rule engine is not running rules — it's deciding what rules to write. This module surfaces candidates.
+
+- Iterates every available run (current + archived) via `listRuns()`/`listArchivedRuns()` + `analyzeRun()`.
+- Groups violations by `ViolationCode`, counts the number of *distinct runs* each code appeared in (not total occurrences — a single noisy run shouldn't promote a rule).
+- Codes meeting `threshold` (default 3) are flagged as recurring.
+- For each, renders a draft `.luca/rules/<slug>.ts` template with the rule scaffolding, sample violation message in a comment, and TODO matcher body.
+- Renders the full set to a `SUGGESTED-RULES.md` artifact under the planning directory for human review.
+
+Drafts are **never** auto-applied. Generated rules are inevitably approximate; auto-applying would produce false-positive overload. The user reads the rendered file, decides which patterns are mechanically detectable, fills in the matcher, and commits.
+
+**Mode integration**
+
+- `instructions/execute.md` — new Step 2.5 runs `runRules(gate)` after `runChecks` reports `resolved`, before `Verify`. Must-fix rule findings block wave advance. Tool Coordination updated to reflect the new gate.
+- `instructions/finalize.md` — new Step 4.5 runs `runRules` with the `suggest` action after the postmortem gate, advisory only. The Tool Coordination sequence numbers up by one.
+
+**Verification**
+
+- Type check clean.
+- Build clean.
+- Smoke tests pass:
+  - Two-rule fixture (regex `no-todo`, AST `no-any`): correctly identified findings on dirty fixture, none on clean.
+  - Throwing rule: surfaced in `executionErrors`, did not affect other rules.
+  - Syntax-broken rule file: surfaced in `loadErrors`, runner continued.
+  - Recurrence detection on the framework's own ledger: 0 recurring pitfalls (expected — postmortem is clean), markdown renderer correctly returned the empty-state message.

--- a/.changeset/run-observability-postmortem.md
+++ b/.changeset/run-observability-postmortem.md
@@ -1,0 +1,24 @@
+---
+'@alecsibilia/luca-framework': minor
+'@alecsibilia/luca-mastracode': minor
+---
+
+Close the silent-skip hole in full-auto pipeline runs (the incident where execute mode didn't fire but finalize moved every todo to `done`).
+
+**Hard gates** — bad state transitions are now blocked at the tool layer, not just by LLM instructions:
+
+- `workflowState(complete-phase)` rejects with `EMPTY_PHASE_BLOCKED` when a phase has zero file changes and zero commits and no `phase-empty-justification` ledger entry exists. New `justify-empty-phase` action lets the agent declare an intentional no-op (e.g. docs-only-in-MuninnDB).
+- `workflowState(advance-wave)` rejects with `WAVE_ADVANCE_NO_VERIFICATION` when no `verification-result.json` exists for the current wave.
+- `manageTodos(move|move-batch → done)` requires a `verificationRef` pointing to a passing criterion in `verification-history.jsonl`; rejects with `TODO_DONE_UNVERIFIED` otherwise.
+
+**Diff-based phase proof** (`phase-diff.ts`) snapshots the working tree at `start-phase` and computes the diff at `complete-phase`, surfacing it via the new `phase-diff-summary` ledger event.
+
+**Run identity & archiving** (`session-ledger.ts`) — every ledger entry is now stamped with a per-run `runId`. Pipeline reset archives prior `session-ledger.jsonl`, `verification-history.jsonl`, `confidence-journal.jsonl`, and `routing-history.jsonl` to `.planning/runs/<priorRunId>/`.
+
+**Postmortem analyzer & gate** (`postmortem.ts`, `tools/run-postmortem.ts`) — new `runPostmortem` Mastra tool with `analyze | render | gate | list-runs` actions. Reads the four append-only JSONL artifacts and produces a structured report covering empty phases, unverified todo completions, forced transitions, low-confidence decisions, missing wave verifications, pipeline re-entries, and idle-bypass anomalies. Returns pre-formatted MuninnDB pitfall payloads for the agent to forward to the `default` vault so future runs can recall recurring failure modes.
+
+**Finalize wiring** — new Step 4.5 "Postmortem Gate" calls `runPostmortem(action: "gate")` before PR creation; critical violations block the PR and re-enter the pipeline. Step 6 calls `runPostmortem(action: "render")` to write `.planning/POSTMORTEM.md` for the PR body.
+
+**Pipeline guard idle-bypass logging** (`pipeline-guard.ts`) — when the guard bypasses enforcement because `pipelineStep === 'idle'` or is missing, it now emits a one-time-per-turn `pipeline-guard-idle-bypass` ledger event so postmortem can surface stale-state contamination. Previously this bypass was silent.
+
+**`luca retro` CLI** — new command prints `.planning/POSTMORTEM.md` (or lists archived runs under `.planning/runs/` with `--list`) so users can inspect retrospective reports without launching the harness.

--- a/.changeset/run-observability-postmortem.md
+++ b/.changeset/run-observability-postmortem.md
@@ -22,3 +22,5 @@ Close the silent-skip hole in full-auto pipeline runs (the incident where execut
 **Pipeline guard idle-bypass logging** (`pipeline-guard.ts`) — when the guard bypasses enforcement because `pipelineStep === 'idle'` or is missing, it now emits a one-time-per-turn `pipeline-guard-idle-bypass` ledger event so postmortem can surface stale-state contamination. Previously this bypass was silent.
 
 **`luca retro` CLI** — new command prints `.planning/POSTMORTEM.md` (or lists archived runs under `.planning/runs/` with `--list`) so users can inspect retrospective reports without launching the harness.
+
+**Stale verification-result.json hardening** — `archivePriorRun()` now also moves `.planning/verification-result.json` (not just JSONL histories) so a prior run's PASS snapshot can't satisfy the new run's wave/phase guards. Belt-and-braces: results are now stamped with `runId` on write, and `readVerificationResult()` returns `null` when the stamped runId doesn't match the current run — so the silent-skip hole stays closed even if reset wasn't called between runs.

--- a/packages/luca-framework/src/cli.ts
+++ b/packages/luca-framework/src/cli.ts
@@ -22,6 +22,7 @@ const main = defineCommand({
         'vault:init': () =>
             import('./commands/vault-init').then((m) => m.vaultInitCommand),
         run: () => import('./commands/run').then((m) => m.runCommand),
+        retro: () => import('./commands/retro').then((m) => m.retroCommand),
         doctor: () => import('./commands/doctor').then((m) => m.default),
         version: () =>
             import('./commands/version').then((m) => m.versionCommand),

--- a/packages/luca-framework/src/commands/retro.ts
+++ b/packages/luca-framework/src/commands/retro.ts
@@ -1,0 +1,64 @@
+/**
+ * CLI command: luca retro
+ *
+ * Inspect the most recent Luca pipeline postmortem. Prints the cached
+ * `.planning/POSTMORTEM.md` if it exists. With `--list`, enumerates
+ * archived runs under `.planning/runs/`. Generating a fresh postmortem
+ * for the live run is done from inside the harness via `runPostmortem`.
+ */
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+
+import { defineCommand } from 'citty'
+import { join, resolve } from 'pathe'
+
+import { logger } from '../utils/logger'
+
+export const retroCommand = defineCommand({
+    meta: {
+        name: 'retro',
+        description:
+            'Show the latest Luca pipeline postmortem from .planning/POSTMORTEM.md',
+    },
+    args: {
+        list: {
+            type: 'boolean',
+            description: 'List archived runs under .planning/runs/',
+            required: false,
+        },
+    },
+    async run({ args }) {
+        const planningDir = resolve(process.cwd(), '.planning')
+        const runsDir = join(planningDir, 'runs')
+
+        if (args.list) {
+            if (!existsSync(runsDir)) {
+                logger.info('No archived runs found in .planning/runs/')
+                return
+            }
+            const entries = readdirSync(runsDir).filter((name) => {
+                try {
+                    return statSync(join(runsDir, name)).isDirectory()
+                } catch {
+                    return false
+                }
+            })
+            if (entries.length === 0) {
+                logger.info('No archived runs found in .planning/runs/')
+                return
+            }
+            for (const runId of entries) {
+                logger.info(runId)
+            }
+            return
+        }
+
+        const postmortemPath = join(planningDir, 'POSTMORTEM.md')
+        if (!existsSync(postmortemPath)) {
+            logger.warn(
+                'No .planning/POSTMORTEM.md found. Run `luca run` and let finalize emit one, or call runPostmortem(action: "render") inside the harness.'
+            )
+            return
+        }
+        process.stdout.write(readFileSync(postmortemPath, 'utf8'))
+    },
+})

--- a/packages/luca-mastracode/commands/pr-address.md
+++ b/packages/luca-mastracode/commands/pr-address.md
@@ -35,6 +35,25 @@ Parse and group comments:
 
 Build a comment map with fields: `commentId, author, body, file, line, inReplyTo, isDuplicate, duplicateGroupId`.
 
+**Snapshot the iteration boundary.** Record the current `git rev-parse HEAD` SHA as `iterationStartSha`. The regression check at Step 7 will use this to compute the set of paths the iteration modified and the before/after finding deltas.
+
+### Step 1.5 — Filter Stale Comments
+
+Comments filed against an earlier commit may already be addressed by subsequent fix commits on the branch. Treating them as actionable wastes iteration cycles and produces confused replies.
+
+Run the stale-comment filter:
+
+```
+prReview(action: "filter-stale", comments: <all comments fetched in Step 1>)
+```
+
+The tool returns three buckets:
+- **`actionable`** — comments whose cited code still exists in the working tree at the same location. Continue with categorization for these.
+- **`stale`** — comments whose cited code has been rewritten, removed, or relocated by more than 5 lines. **Skip categorization for these — they cannot be acted on.** When responding (Step 5), post a reply explaining the comment is stale and pointing at the commit that addressed the underlying code.
+- **`replies`** — comments with `in_reply_to_id` set; pass through, not first-class findings.
+
+Append a note to the comment audit summary at Step 2: `Stale: <n> comments (skipped from categorization)`.
+
 ### Step 2 — Categorize Comments
 
 Unless `--skip-validation` is set, classify each unique comment (deduplicated):
@@ -63,6 +82,37 @@ Total: N unique comments (N duplicates grouped)
 ```
 
 If `--dry-run`, stop here.
+
+### Step 2.5 — Detect Cross-Perspective Convergence
+
+When two or more independent reviewer perspectives flag the same location, that location is materially more likely to be a real issue. Auto-promote severity so converged findings are treated as MUST-FIX rather than as independent SHOULD-FIX items.
+
+Build a `findings` array from the categorized comments — one entry per actionable comment, plus any findings from other perspectives this iteration has access to (e.g. `claim-verifier` output, the reviewer agent's MUST-FIX/SHOULD-FIX entries from `.planning/REVIEW-*.md`). Map each to:
+
+```
+{
+  id:         <stable id, e.g. comment id or "claim-verifier:<n>">,
+  perspective:<who produced it, e.g. "Copilot", "claim-verifier", "reviewer-agent">,
+  path:       <file path>,
+  line:       <line number>,
+  severity:   <"must-fix"|"should-fix"|"nit"|"style"|"improvement"|...>,
+  category:   <"security"|"bug"|"style"|...>,
+  summary:    <short description>,
+}
+```
+
+Run convergence detection:
+
+```
+prReview(action: "detect-convergence", findings: <array>, lineTolerance: 2)
+```
+
+For each promotion the tool returns:
+- Find the corresponding categorized comment in your audit map.
+- Update its category to **must-fix** (regardless of its original category) and add a note: `Promoted via convergence with <other perspectives>`.
+- Surface the promotion in the comment audit summary: `Converged: <n> findings promoted to must-fix via 2+ perspectives`.
+
+Continue to Step 3 with the promoted categorization.
 
 ### Step 3 — Plan Fixes
 
@@ -112,7 +162,35 @@ gh api repos/{owner}/{repo}/issues/<number>/comments -f body="<reply>"
    ```
    Check that every comment thread has a reply. Report any gaps.
 
-### Step 7 — Store Learnings
+### Step 7 — Iteration-N Regression Check
+
+Fix commits sometimes introduce new issues that the original review didn't flag. Without this check, those new findings only surface in the *next* review pass, costing another full iteration. Catch them now.
+
+1. **Snapshot the post-iteration findings.** Re-fetch all PR comments:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/<number>/comments?per_page=100
+   ```
+   If the PR has automated reviewer hooks (Copilot, CodeRabbit, etc.) configured to re-run on push, allow a brief settle window (~30s) before re-fetching.
+
+2. **Build before/after finding arrays.** The `before` array is the same `findings` array you built at Step 2.5 (pre-iteration state). The `after` array is built the same way from the freshly-fetched comments — but include only comments authored *at or after* `iterationStartSha` to filter out persistent prior findings.
+
+3. **Compute touched paths** between the iteration boundary and the current HEAD:
+   ```
+   prReview(
+     action: "regression-check",
+     before:  <pre-iteration findings>,
+     after:   <post-iteration findings>,
+     fromSha: <iterationStartSha>,
+     toSha:   "HEAD"
+   )
+   ```
+
+4. **Handle the verdict.**
+
+   - `success: true` → iteration complete. Report `<n> resolved, <n> unchanged, <n> new on untouched paths` in the final summary.
+   - `success: false` (`PR_REVIEW_REGRESSION_DETECTED`) → fix commits introduced new findings. **Do not declare the iteration complete.** Re-enter Step 3 (Plan Fixes) with `report.regressions` as the input set. The regression cycle is bounded — if 3 consecutive iterations fail this check, escalate to the user with a summary of what's regressing and pause the loop.
+
+### Step 8 — Store Learnings
 
 Store **recurring patterns** in MuninnDB (skip one-off fixes):
 

--- a/packages/luca-mastracode/src/claim-verifier.ts
+++ b/packages/luca-mastracode/src/claim-verifier.ts
@@ -1,0 +1,583 @@
+/**
+ * Claim verifier — deterministic check that text artifacts (changesets, PR
+ * bodies, PLAN.md task entries) cite symbols, file paths, and counts that
+ * actually exist in the working tree.
+ *
+ * Targets the #1 repeat offender across PR-review corpus: changesets that
+ * cite renamed/removed symbols, design docs that drift from shipped code,
+ * VERIFICATION.md with stale index/trigger names, etc. The pattern is
+ * artifacts written before the final review iteration, never reconciled.
+ *
+ * Three claim types extracted from text:
+ *   - symbol:       backtick-wrapped identifier   →  git grep, fail if 0 hits
+ *   - file-path:    repo-relative path with ext   →  existsSync, fail if missing
+ *   - quantitative: "<N> <countable-noun>"        →  grep noun, ±1 tolerance
+ *
+ * Pure data layer. Tool wrapper lives in tools/claim-verifier.ts.
+ */
+import { spawnSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ClaimType = 'symbol' | 'file-path' | 'quantitative'
+
+export interface ExtractedClaim {
+    type: ClaimType
+    /** Raw matched text (e.g. "`MyFunction`", "src/foo.ts", "5 indexes") */
+    text: string
+    /** For quantitative: numeric value */
+    number?: number
+    /** For quantitative: counted noun, lowercase, singular */
+    noun?: string
+    /** Identifier extracted from a backtick wrapper (symbols only) */
+    identifier?: string
+    /** Path resolved against repo root (file-path only) */
+    path?: string
+    /** 1-indexed line number in source artifact */
+    sourceLine: number
+    /** Up to 1 line of context around the match */
+    sourceContext: string
+}
+
+export type FailureReason =
+    | 'symbol-not-found'
+    | 'file-not-found'
+    | 'count-mismatch'
+    | 'timeout'
+    | 'artifact-unreadable'
+
+export interface ClaimFailure {
+    claim: ExtractedClaim
+    reason: FailureReason
+    evidence: string
+}
+
+export interface ClaimVerificationReport {
+    passed: boolean
+    totalClaims: number
+    failures: ClaimFailure[]
+    extractedBreakdown: {
+        symbols: number
+        filePaths: number
+        quantitative: number
+    }
+    /** True when the budget was exhausted; remaining claims are not verified */
+    timedOut: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Stopwords + allow-lists
+// ---------------------------------------------------------------------------
+
+/** Backtick-wrapped tokens to skip (CLI tool names, pure prose, primitives). */
+const SYMBOL_STOPWORDS = new Set([
+    'true',
+    'false',
+    'null',
+    'undefined',
+    'void',
+    'any',
+    'unknown',
+    'never',
+    'string',
+    'number',
+    'boolean',
+    'object',
+    'array',
+    'bun',
+    'npm',
+    'pnpm',
+    'yarn',
+    'git',
+    'gh',
+    'pr',
+    'ci',
+    'cd',
+    'repo',
+    'main',
+    'master',
+    'dev',
+    'build',
+    'test',
+    'lint',
+    'tsc',
+    'eslint',
+    'todo',
+    'fixme',
+    'note',
+    'warn',
+    'info',
+    'log',
+    'http',
+    'https',
+    'json',
+    'yaml',
+    'toml',
+    'env',
+    'src',
+    'dist',
+    'lib',
+    'app',
+    'apps',
+])
+
+/**
+ * Nouns that count as "real countable things" for quantitative claims.
+ * Conservative on purpose — false negatives are fine, false positives bite.
+ */
+const COUNTABLE_NOUNS = new Set([
+    'file',
+    'files',
+    'test',
+    'tests',
+    'table',
+    'tables',
+    'index',
+    'indexes',
+    'indices',
+    'function',
+    'functions',
+    'endpoint',
+    'endpoints',
+    'route',
+    'routes',
+    'mutation',
+    'mutations',
+    'query',
+    'queries',
+    'action',
+    'actions',
+    'tool',
+    'tools',
+    'mode',
+    'modes',
+    'phase',
+    'phases',
+    'wave',
+    'waves',
+    'commit',
+    'commits',
+    'package',
+    'packages',
+    'module',
+    'modules',
+    'class',
+    'classes',
+    'method',
+    'methods',
+    'component',
+    'components',
+    'hook',
+    'hooks',
+])
+
+/** Singularize a counted noun for grep purposes (cheap heuristic). */
+function singularize(noun: string): string {
+    const lower = noun.toLowerCase()
+    if (lower === 'indices') return 'index'
+    if (lower === 'queries') return 'query'
+    if (lower === 'classes') return 'class'
+    if (lower === 'indexes') return 'index'
+    if (lower.endsWith('ies') && lower.length > 3)
+        return lower.slice(0, -3) + 'y'
+    if (lower.endsWith('s') && !lower.endsWith('ss')) return lower.slice(0, -1)
+    return lower
+}
+
+// ---------------------------------------------------------------------------
+// Extraction
+// ---------------------------------------------------------------------------
+
+const BACKTICK_RE = /`([^`\n]+)`/g
+const FILE_PATH_RE =
+    /(?:^|[\s(`'"])((?:packages|src|apps|lib|tests?|docs?|\.planning|\.luca|\.changeset|\.github)\/[\w./-]+\.[\w]+)(?=[\s)`'".,;!?]|$)/g
+const QUANTITATIVE_RE = /\b(\d+)\s+([a-zA-Z]+)\b/g
+const IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+/**
+ * Extract all claims from a text artifact.
+ *
+ * Returns an empty array for empty input. Deduplicates by (type, key) so a
+ * symbol cited 5× yields one claim. The first-seen sourceLine wins.
+ */
+export function extractClaims(text: string): ExtractedClaim[] {
+    if (!text) return []
+
+    const lines = text.split('\n')
+    const seen = new Set<string>()
+    const claims: ExtractedClaim[] = []
+
+    const pushIfNew = (key: string, claim: ExtractedClaim) => {
+        if (seen.has(key)) return
+        seen.add(key)
+        claims.push(claim)
+    }
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i] ?? ''
+        const sourceLine = i + 1
+        const sourceContext = line.trim().slice(0, 240)
+
+        // Symbols — backtick-wrapped identifiers
+        for (const match of line.matchAll(BACKTICK_RE)) {
+            const inner = (match[1] ?? '').trim()
+
+            // File-path-shaped backticks → handled by FILE_PATH_RE branch below
+            if (inner.includes('/') && /\.\w+(?:[#?:]|$)/.test(inner)) continue
+
+            if (!IDENTIFIER_RE.test(inner)) continue
+            if (inner.length < 3) continue
+            if (SYMBOL_STOPWORDS.has(inner.toLowerCase())) continue
+
+            const key = `symbol:${inner}`
+            pushIfNew(key, {
+                type: 'symbol',
+                text: match[0],
+                identifier: inner,
+                sourceLine,
+                sourceContext,
+            })
+        }
+
+        // File paths
+        for (const match of line.matchAll(FILE_PATH_RE)) {
+            const path = match[1]
+            if (!path) continue
+            const key = `path:${path}`
+            pushIfNew(key, {
+                type: 'file-path',
+                text: path,
+                path,
+                sourceLine,
+                sourceContext,
+            })
+        }
+
+        // Quantitative claims
+        for (const match of line.matchAll(QUANTITATIVE_RE)) {
+            const numStr = match[1]
+            const noun = match[2]
+            if (!numStr || !noun) continue
+
+            // Skip version-shaped (v1, 1.0 already filtered by \b boundary).
+            // Skip 4-digit years.
+            if (numStr.length === 4) {
+                const n = Number(numStr)
+                if (n >= 1900 && n <= 2200) continue
+            }
+
+            const lowerNoun = noun.toLowerCase()
+            if (!COUNTABLE_NOUNS.has(lowerNoun)) continue
+
+            const num = Number(numStr)
+            if (!Number.isFinite(num)) continue
+
+            const key = `count:${num}:${lowerNoun}`
+            pushIfNew(key, {
+                type: 'quantitative',
+                text: `${numStr} ${noun}`,
+                number: num,
+                noun: singularize(lowerNoun),
+                sourceLine,
+                sourceContext,
+            })
+        }
+    }
+
+    return claims
+}
+
+// ---------------------------------------------------------------------------
+// Verification
+// ---------------------------------------------------------------------------
+
+interface VerifyOpts {
+    repoRoot: string
+    /** Total budget in ms across all grep/fs operations. Default 30000. */
+    totalBudgetMs?: number
+    /** Per-claim budget in ms. Default 5000. */
+    perClaimBudgetMs?: number
+}
+
+interface GrepResult {
+    ok: boolean
+    matchedFiles: string[]
+    timedOut: boolean
+}
+
+function gitAvailable(repoRoot: string): boolean {
+    const r = spawnSync(
+        'git',
+        ['-C', repoRoot, 'rev-parse', '--is-inside-work-tree'],
+        { encoding: 'utf-8' }
+    )
+    return r.status === 0
+}
+
+function gitGrepFiles(
+    repoRoot: string,
+    needle: string,
+    timeoutMs: number
+): GrepResult {
+    // `--untracked` is critical: at finalize time, newly-authored files may
+    // be untracked (or only staged) but the symbols they contain are still
+    // valid claims. Without it, fresh files yield false-positive failures.
+    const r = spawnSync(
+        'git',
+        [
+            '-C',
+            repoRoot,
+            'grep',
+            '--untracked',
+            '-l',
+            '--fixed-strings',
+            needle,
+        ],
+        { encoding: 'utf-8', timeout: timeoutMs }
+    )
+
+    if (r.signal === 'SIGTERM' || r.error?.message?.includes('ETIMEDOUT')) {
+        return { ok: false, matchedFiles: [], timedOut: true }
+    }
+
+    // git grep exits 0 with matches, 1 without, >1 on error.
+    if (r.status === 1) return { ok: true, matchedFiles: [], timedOut: false }
+    if (r.status !== 0) return { ok: false, matchedFiles: [], timedOut: false }
+
+    const matchedFiles = (r.stdout ?? '')
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    return { ok: true, matchedFiles, timedOut: false }
+}
+
+/**
+ * Filesystem-walk fallback for non-git environments. Slow but correct.
+ * Walks repoRoot, skips node_modules + .git + dist, greps each file.
+ */
+function fsGrepFiles(
+    repoRoot: string,
+    needle: string,
+    timeoutMs: number
+): GrepResult {
+    const start = Date.now()
+    const matchedFiles: string[] = []
+
+    // Avoid shell injection on the needle: pass via xargs grep -F with the
+    // needle on grep's argv, not interpolated into the command string.
+    const r = spawnSync(
+        'sh',
+        [
+            '-c',
+            // Skip vendor/build dirs, pipe through grep -lF with the needle
+            // delivered via argv ($1) to keep it free of shell quoting.
+            `find "${repoRoot.replace(/"/g, '\\"')}" -type d \\( -name node_modules -o -name .git -o -name dist -o -name build -o -name .next \\) -prune -o -type f -print0 | xargs -0 grep -lF -- "$1" 2>/dev/null`,
+            'sh',
+            needle,
+        ],
+        { encoding: 'utf-8', timeout: timeoutMs }
+    )
+
+    if (r.signal === 'SIGTERM' || r.error?.message?.includes('ETIMEDOUT')) {
+        return { ok: false, matchedFiles: [], timedOut: true }
+    }
+
+    if (r.stdout) {
+        for (const line of r.stdout.split('\n')) {
+            const trimmed = line.trim()
+            if (trimmed) matchedFiles.push(trimmed)
+        }
+    }
+    return {
+        ok: true,
+        matchedFiles,
+        timedOut: Date.now() - start > timeoutMs,
+    }
+}
+
+function searchFiles(
+    repoRoot: string,
+    needle: string,
+    timeoutMs: number,
+    useGit: boolean
+): GrepResult {
+    if (useGit) return gitGrepFiles(repoRoot, needle, timeoutMs)
+    return fsGrepFiles(repoRoot, needle, timeoutMs)
+}
+
+/**
+ * Verify a list of claims against the repo. Stops early when the total
+ * budget is exhausted; remaining claims are returned as `timeout` failures.
+ */
+export function verifyClaims(
+    claims: ExtractedClaim[],
+    opts: VerifyOpts
+): ClaimVerificationReport {
+    const totalBudgetMs = opts.totalBudgetMs ?? 30_000
+    const perClaimBudgetMs = opts.perClaimBudgetMs ?? 5_000
+    const useGit = gitAvailable(opts.repoRoot)
+    const start = Date.now()
+    const failures: ClaimFailure[] = []
+    let timedOut = false
+
+    const breakdown = {
+        symbols: 0,
+        filePaths: 0,
+        quantitative: 0,
+    }
+
+    for (const claim of claims) {
+        if (claim.type === 'symbol') breakdown.symbols++
+        else if (claim.type === 'file-path') breakdown.filePaths++
+        else breakdown.quantitative++
+
+        if (Date.now() - start > totalBudgetMs) {
+            timedOut = true
+            failures.push({
+                claim,
+                reason: 'timeout',
+                evidence: `Total budget ${totalBudgetMs}ms exhausted before this claim was checked.`,
+            })
+            continue
+        }
+
+        if (claim.type === 'symbol' && claim.identifier) {
+            const r = searchFiles(
+                opts.repoRoot,
+                claim.identifier,
+                perClaimBudgetMs,
+                useGit
+            )
+            if (r.timedOut) {
+                timedOut = true
+                failures.push({
+                    claim,
+                    reason: 'timeout',
+                    evidence: `Search for symbol "${claim.identifier}" exceeded ${perClaimBudgetMs}ms.`,
+                })
+                continue
+            }
+            if (!r.ok || r.matchedFiles.length === 0) {
+                failures.push({
+                    claim,
+                    reason: 'symbol-not-found',
+                    evidence: `git grep for "${claim.identifier}" returned 0 hits.`,
+                })
+            }
+            continue
+        }
+
+        if (claim.type === 'file-path' && claim.path) {
+            const abs = join(opts.repoRoot, claim.path)
+            if (!existsSync(abs)) {
+                failures.push({
+                    claim,
+                    reason: 'file-not-found',
+                    evidence: `Path "${claim.path}" does not exist (resolved to ${abs}).`,
+                })
+            }
+            continue
+        }
+
+        if (
+            claim.type === 'quantitative' &&
+            claim.noun &&
+            typeof claim.number === 'number'
+        ) {
+            const r = searchFiles(
+                opts.repoRoot,
+                claim.noun,
+                perClaimBudgetMs,
+                useGit
+            )
+            if (r.timedOut) {
+                timedOut = true
+                failures.push({
+                    claim,
+                    reason: 'timeout',
+                    evidence: `Search for noun "${claim.noun}" exceeded ${perClaimBudgetMs}ms.`,
+                })
+                continue
+            }
+            if (!r.ok) {
+                // Treat a hard error as count-mismatch with 0 hits.
+                failures.push({
+                    claim,
+                    reason: 'count-mismatch',
+                    evidence: `grep for "${claim.noun}" failed; cannot verify "${claim.text}".`,
+                })
+                continue
+            }
+            const found = r.matchedFiles.length
+            const claimed = claim.number
+            // ±1 tolerance — prose variation is expected.
+            if (Math.abs(found - claimed) > 1) {
+                failures.push({
+                    claim,
+                    reason: 'count-mismatch',
+                    evidence: `Claim says "${claim.text}", repo has ${found} file(s) mentioning "${claim.noun}" (tolerance ±1).`,
+                })
+            }
+            continue
+        }
+    }
+
+    return {
+        passed: failures.length === 0,
+        totalClaims: claims.length,
+        failures,
+        extractedBreakdown: breakdown,
+        timedOut,
+    }
+}
+
+/**
+ * End-to-end: extract + verify a text artifact in one call.
+ */
+export function verifyTextArtifact(
+    text: string,
+    opts: VerifyOpts
+): ClaimVerificationReport {
+    const claims = extractClaims(text)
+    return verifyClaims(claims, opts)
+}
+
+/**
+ * Convenience: load a file from disk and verify it. Returns
+ * a synthetic `artifact-unreadable` failure if the file can't be read.
+ */
+export function verifyFile(
+    filePath: string,
+    opts: VerifyOpts
+): ClaimVerificationReport {
+    let text: string
+    try {
+        text = readFileSync(filePath, 'utf-8')
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        return {
+            passed: false,
+            totalClaims: 0,
+            failures: [
+                {
+                    claim: {
+                        type: 'file-path',
+                        text: filePath,
+                        path: filePath,
+                        sourceLine: 0,
+                        sourceContext: '',
+                    },
+                    reason: 'artifact-unreadable',
+                    evidence: `Could not read "${filePath}": ${msg}`,
+                },
+            ],
+            extractedBreakdown: { symbols: 0, filePaths: 0, quantitative: 0 },
+            timedOut: false,
+        }
+    }
+    return verifyTextArtifact(text, opts)
+}

--- a/packages/luca-mastracode/src/claim-verifier.ts
+++ b/packages/luca-mastracode/src/claim-verifier.ts
@@ -16,7 +16,7 @@
  * Pure data layer. Tool wrapper lives in tools/claim-verifier.ts.
  */
 import { spawnSync } from 'node:child_process'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 
 // ---------------------------------------------------------------------------
@@ -356,9 +356,39 @@ function gitGrepFiles(
 }
 
 /**
- * Filesystem-walk fallback for non-git environments. Slow but correct.
- * Walks repoRoot, skips node_modules + .git + dist, greps each file.
+ * Filesystem-walk fallback for non-git environments. Pure Node — no
+ * shell, no `find`, no `xargs`. Slower than `git grep` but portable
+ * (works on Windows, Alpine without coreutils, etc.).
+ *
+ * Skips common vendor/build directories and binary-looking files.
+ * Honors the timeout budget by checking elapsed time between files.
  */
+const FS_SKIP_DIRS = new Set([
+    'node_modules',
+    '.git',
+    'dist',
+    'build',
+    '.next',
+    '.turbo',
+    'coverage',
+    '.cache',
+])
+const FS_SKIP_EXTENSIONS = new Set([
+    '.png',
+    '.jpg',
+    '.jpeg',
+    '.gif',
+    '.webp',
+    '.ico',
+    '.pdf',
+    '.zip',
+    '.tar',
+    '.gz',
+    '.lock',
+    '.lockb',
+])
+const FS_MAX_FILE_BYTES = 5 * 1024 * 1024 // 5MB — skip larger files
+
 function fsGrepFiles(
     repoRoot: string,
     needle: string,
@@ -366,36 +396,54 @@ function fsGrepFiles(
 ): GrepResult {
     const start = Date.now()
     const matchedFiles: string[] = []
+    const stack: string[] = [repoRoot]
 
-    // Avoid shell injection on the needle: pass via xargs grep -F with the
-    // needle on grep's argv, not interpolated into the command string.
-    const r = spawnSync(
-        'sh',
-        [
-            '-c',
-            // Skip vendor/build dirs, pipe through grep -lF with the needle
-            // delivered via argv ($1) to keep it free of shell quoting.
-            `find "${repoRoot.replace(/"/g, '\\"')}" -type d \\( -name node_modules -o -name .git -o -name dist -o -name build -o -name .next \\) -prune -o -type f -print0 | xargs -0 grep -lF -- "$1" 2>/dev/null`,
-            'sh',
-            needle,
-        ],
-        { encoding: 'utf-8', timeout: timeoutMs }
-    )
-
-    if (r.signal === 'SIGTERM' || r.error?.message?.includes('ETIMEDOUT')) {
-        return { ok: false, matchedFiles: [], timedOut: true }
-    }
-
-    if (r.stdout) {
-        for (const line of r.stdout.split('\n')) {
-            const trimmed = line.trim()
-            if (trimmed) matchedFiles.push(trimmed)
+    while (stack.length > 0) {
+        if (Date.now() - start > timeoutMs) {
+            return { ok: false, matchedFiles, timedOut: true }
+        }
+        const dir = stack.pop()!
+        let entries: string[]
+        try {
+            entries = readdirSync(dir)
+        } catch {
+            continue
+        }
+        for (const name of entries) {
+            const full = join(dir, name)
+            let info
+            try {
+                info = statSync(full)
+            } catch {
+                continue
+            }
+            if (info.isDirectory()) {
+                if (FS_SKIP_DIRS.has(name)) continue
+                stack.push(full)
+                continue
+            }
+            if (!info.isFile()) continue
+            const dotIdx = name.lastIndexOf('.')
+            if (dotIdx >= 0) {
+                const ext = name.slice(dotIdx).toLowerCase()
+                if (FS_SKIP_EXTENSIONS.has(ext)) continue
+            }
+            if (info.size > FS_MAX_FILE_BYTES) continue
+            try {
+                const buf = readFileSync(full)
+                if (buf.includes(needle)) {
+                    matchedFiles.push(full)
+                }
+            } catch {
+                // unreadable — skip
+            }
         }
     }
+
     return {
         ok: true,
         matchedFiles,
-        timedOut: Date.now() - start > timeoutMs,
+        timedOut: false,
     }
 }
 

--- a/packages/luca-mastracode/src/context-refresher.ts
+++ b/packages/luca-mastracode/src/context-refresher.ts
@@ -6,26 +6,28 @@
  * and uses followUpRef to inject reminders into the conversation.
  */
 
+import { MODES } from './modes/mode-ids.js'
+import { appendLedger } from './session-ledger.js'
 import type { ThresholdName, BudgetState } from './token-budget.js'
 
-/** Mode-specific reminder templates, keyed by harness mode ID (e.g. "luca:1-triage", "build"). */
+/** Mode-specific reminder templates, keyed by harness mode ID. */
 const MODE_REMINDERS: Record<string, string> = {
-    'luca:1-triage':
+    [MODES.triage]:
         '<luca-reminder>You are in triage mode. ≤75 words output. Classify → rationale → next mode.</luca-reminder>',
-    'luca:2-research':
+    [MODES.research]:
         '<luca-reminder>You are in research mode. Budget: MODERATE ≤10, COMPLEX ≤20, CRITICAL ≤30 tool calls. Synthesis ≤200 lines.</luca-reminder>',
-    'luca:3-architect':
+    [MODES.architect]:
         '<luca-reminder>You are in architect mode. ≤3 sentences per task. ≤150 lines PLAN.md total. Validate with plan-reviewer before finishing.</luca-reminder>',
-    'luca:4-execute':
+    [MODES.execute]:
         '<luca-reminder>You are in execute mode. Run checks within 1 tool call of wave completion. Stalled ≥2 iterations = stop and escalate. No prose between tool calls.</luca-reminder>',
-    'luca:5-review':
+    [MODES.review]:
         '<luca-reminder>You are in review mode (read-only). Maximum 5 MUST-FIX items. MUST-FIX = correctness bugs, security, missing requirements ONLY.</luca-reminder>',
-    'luca:6-finalize':
+    [MODES.finalize]:
         '<luca-reminder>You are in finalize mode. Check every task in PLAN.md. Report exact completed/total ratio.</luca-reminder>',
     build: '<luca-reminder>You are in build mode. Implement atomically. Run checks after each logical unit.</luca-reminder>',
     fast: '<luca-reminder>Fast mode. Under 100 words. ≤25 words between tool calls.</luca-reminder>',
     plan: '<luca-reminder>Plan mode (read-only). Do NOT make changes. Explore and design only.</luca-reminder>',
-    'luca:discuss':
+    [MODES.discuss]:
         '<luca-reminder>Discuss mode (read-only). Under 300 words per turn. ≤2 clarifying questions.</luca-reminder>',
 }
 
@@ -66,8 +68,21 @@ export class ContextRefresher {
 
         try {
             await this.followUp({ content: reminder })
-        } catch {
-            // followUp failure should not crash the pipeline
+        } catch (err) {
+            // followUp failure should not crash the pipeline, but record it
+            // so postmortem can attribute missing context refreshes.
+            try {
+                appendLedger({
+                    type: 'context-refresher-followup-failed',
+                    payload: {
+                        threshold,
+                        mode: this.currentModeId,
+                        error: err instanceof Error ? err.message : String(err),
+                    },
+                })
+            } catch {
+                // ledger write itself failed — nothing else to do
+            }
         }
     }
 }

--- a/packages/luca-mastracode/src/context-refresher.ts
+++ b/packages/luca-mastracode/src/context-refresher.ts
@@ -72,13 +72,10 @@ export class ContextRefresher {
             // followUp failure should not crash the pipeline, but record it
             // so postmortem can attribute missing context refreshes.
             try {
-                appendLedger({
-                    type: 'context-refresher-followup-failed',
-                    payload: {
-                        threshold,
-                        mode: this.currentModeId,
-                        error: err instanceof Error ? err.message : String(err),
-                    },
+                appendLedger('context-refresher-followup-failed', {
+                    threshold,
+                    mode: this.currentModeId,
+                    error: err instanceof Error ? err.message : String(err),
                 })
             } catch {
                 // ledger write itself failed — nothing else to do

--- a/packages/luca-mastracode/src/continuation-messages.ts
+++ b/packages/luca-mastracode/src/continuation-messages.ts
@@ -7,6 +7,7 @@
  * amber-bordered box in the TUI.
  */
 import type { LucaWorkflowState } from './luca-store.js'
+import { MODES } from './modes/mode-ids.js'
 
 export function buildContinuationMessage(
     modeId: string,
@@ -22,7 +23,7 @@ export function buildContinuationMessage(
         : ''
 
     switch (modeId) {
-        case 'luca:2-research':
+        case MODES.research:
             return [
                 `[Luca Pipeline — auto-continuing from Triage]`,
                 ``,
@@ -37,7 +38,7 @@ export function buildContinuationMessage(
                 .filter(Boolean)
                 .join('\n')
 
-        case 'luca:3-architect':
+        case MODES.architect:
             return [
                 `[Luca Pipeline — auto-continuing from Research]`,
                 ``,
@@ -51,7 +52,7 @@ export function buildContinuationMessage(
                 .filter(Boolean)
                 .join('\n')
 
-        case 'luca:4-execute': {
+        case MODES.execute: {
             const planFile = state.planFile ?? '.planning/PLAN.md'
             const roadmapFile = state.roadmapFile ?? '.planning/ROADMAP.md'
             return [
@@ -71,7 +72,7 @@ export function buildContinuationMessage(
                 .join('\n')
         }
 
-        case 'luca:5-review':
+        case MODES.review:
             return [
                 `[Luca Pipeline — auto-continuing from Execute]`,
                 ``,
@@ -87,7 +88,7 @@ export function buildContinuationMessage(
                 .filter(Boolean)
                 .join('\n')
 
-        case 'luca:6-finalize':
+        case MODES.finalize:
             return [
                 `[Luca Pipeline — auto-continuing from Review]`,
                 ``,
@@ -100,7 +101,7 @@ export function buildContinuationMessage(
                 .filter(Boolean)
                 .join('\n')
 
-        case 'luca:1-triage':
+        case MODES.triage:
             return [
                 `[Luca Pipeline — starting]`,
                 ``,

--- a/packages/luca-mastracode/src/instructions/execute.md
+++ b/packages/luca-mastracode/src/instructions/execute.md
@@ -191,6 +191,25 @@ Spawn **fix** subagent with error details and affected files. Fix subagent addre
 
 **Hard limit**: If `iteration >= 3` and convergence is not `resolved`, stop and escalate.
 
+## Step 2.5: Run Repo-Local Rule Pack
+
+After `runChecks` reports `resolved`, run the repo-local rule pack engine:
+
+```
+runRules(action: "gate")
+```
+
+The engine discovers `.luca/rules/*.ts` files in the repo (zero or more — repos that haven't authored any rules get a no-op). Each rule encodes a project-specific "house rule" that the team has had to flag in PR review repeatedly: Convex anti-patterns, auth invariants, internal API conventions, naming rules, etc.
+
+| Outcome | Meaning | Action |
+|---|---|---|
+| `success: true` | No must-fix rule findings (or no rules loaded). | Proceed to Step 3 (Verify). |
+| `success: false`, `code: RULE_VIOLATIONS_DETECTED` | One or more must-fix findings. | Fix the violations and re-run `runRules(action: "gate")`. Do NOT proceed to verification while must-fix rule findings exist. |
+
+Non-must-fix findings (`should-fix`, `nit`, `info`) are returned but do not block; surface them in the wave's verification report so the reviewer agent can weigh them.
+
+If a rule throws at runtime, it appears in `report.executionErrors`. Surface to the user and proceed — a single broken rule should not block the wave, but the user should know about it so they can fix the rule pack.
+
 ## Step 3: Verify
 
 Spawn a **verifier** subagent after checks pass:
@@ -436,7 +455,7 @@ manageTodos(
 Identifiers may be numeric indices or slug strings (mixing is allowed); slugs are always stable.
 
 ## Tool Coordination
-After each wave: (1) `runChecks` → (2) if fail: fix → re-check → (3) if pass: `workflowState(advance-wave)`. Do NOT advance without passing checks.
+After each wave: (1) `runChecks` → (2) if fail: fix → re-check → (3) if pass: `runRules(gate)` → (4) if rule-violations: fix → re-gate → (5) if pass: spawn verifier → `workflowState(advance-wave)`. Do NOT advance without passing checks AND passing the rule gate.
 After all waves: `workflowState(complete-phase)` → `workflowState(switch-mode, targetMode: "luca:5-review")`.
 
 ## Luca Reminders

--- a/packages/luca-mastracode/src/instructions/finalize.md
+++ b/packages/luca-mastracode/src/instructions/finalize.md
@@ -231,6 +231,25 @@ runPostmortem(action: "render")
 
 This writes `.planning/POSTMORTEM.md`. Reference it in the PR body (Step 5) and the Final Summary (Step 7).
 
+## Step 4.5: Recurring-Pitfall Rule Suggestions
+
+Scan all available runs (current + archived) for pitfalls that have recurred at or above the promotion threshold:
+
+```
+runRules(action: "suggest", threshold: 3)
+```
+
+The engine groups violations by `code` across runs, counts the number of *distinct runs* each code appeared in, and renders draft `.luca/rules/*.ts` templates for any code meeting the threshold to `.planning/SUGGESTED-RULES.md`.
+
+Drafts are **not** auto-applied — they are starting templates, not finished rules. The recurrence detection answers "what should we have a machine-checkable rule for?" but the user implements the matcher.
+
+**Result handling:**
+
+- `report.recurring.length === 0` — nothing to suggest. Continue.
+- `report.recurring.length > 0` — `.planning/SUGGESTED-RULES.md` was written. Reference it in the PR body so the user sees the suggestions on review. **Do not block the PR** on suggestions; this is advisory.
+
+The threshold defaults to 3 (a pitfall that has bitten you in 3+ runs). Repos that want stricter or looser promotion can override via `threshold`.
+
 ## Step 5: PR Creation
 
 Only reached if Step 3 (Gap Detection) and Step 4 (Postmortem Gate) both passed.
@@ -432,7 +451,7 @@ Read `workflowState(action: "read")` for:
 - Plan and research data for gap detection
 
 ## Tool Coordination
-Sequence: (1) `runChecks` → (2) spawn shadow-scanner → (3) `verificationResult(write)` → (4) `runPostmortem(gate)` → (5) write changeset + draft PR body → (6) `claimVerifier(gate)` over changeset + PR body → (7) `manageTodos(move-batch → done)` with `verificationRef` for every item, in one call → (8) `gh pr create`.
+Sequence: (1) `runChecks` → (2) spawn shadow-scanner → (3) `verificationResult(write)` → (4) `runPostmortem(gate)` → (5) `runRules(suggest)` → (6) write changeset + draft PR body → (7) `claimVerifier(gate)` over changeset + PR body → (8) `manageTodos(move-batch → done)` with `verificationRef` for every item, in one call → (9) `gh pr create`.
 
 **Critical:** `manageTodos` will reject any `move → done` without a valid `verificationRef: { criterionId, wave }` pointing at a PASS criterion in `verification-history.jsonl`. Capture the criterion IDs from your `verificationResult(write)` call and pass them through.
 

--- a/packages/luca-mastracode/src/instructions/finalize.md
+++ b/packages/luca-mastracode/src/instructions/finalize.md
@@ -193,6 +193,48 @@ Verify all planned work was completed:
   3. **STOP.** Review mode handles from here, iterating Execute → Review as needed.
   - If user prefers not to fix: track as follow-up issues, proceed to cleanup
 
+## Step 4.5: Postmortem Gate
+
+Before any PR creation, run the postmortem gate. This catches silent-skip incidents (execute mode skipped but todos moved to done), unverified completions, and forced transitions.
+
+```
+runPostmortem(action: "gate")
+```
+
+**If it returns `code: POSTMORTEM_VIOLATIONS`:**
+
+1. Forward each pitfall in the response to MuninnDB so future runs can recall the failure mode:
+   ```
+   for pitfall in response.pitfalls:
+     mcp__muninn__muninn_remember(
+       vault: "default",
+       concept: pitfall.concept,
+       type: pitfall.type,
+       content: pitfall.content,
+       tags: pitfall.tags,
+       op_id: pitfall.op_id
+     )
+   ```
+2. Re-enter the pipeline at the appropriate stage:
+   ```
+   workflowState(
+     action: "re-enter-pipeline",
+     targetMode: "luca:4-execute" | "luca:5-review",
+     reason: "<violation summary>"
+   )
+   ```
+3. **STOP.** Do not create a PR. The re-entered pipeline must converge before finalize runs again.
+
+**If the gate passes** (no critical violations), continue to Step 5. Warnings are non-blocking but should be referenced in the PR body.
+
+Then render the human-readable report:
+
+```
+runPostmortem(action: "render")
+```
+
+This writes `.planning/POSTMORTEM.md`. Reference it in the PR body (Step 3) and the Final Summary (Step 6).
+
 ## Step 5: Cross-Milestone Continuation
 
 Check if `.planning/ROADMAP.md` has remaining phases:
@@ -238,7 +280,7 @@ sessionLedger(action: "metrics")
 
 Returns: total events, mode transitions, phases completed, total iterations, session duration.
 
-Also: `verificationResult(action: "aggregate")`
+Also: `verificationResult(action: "aggregate")` and `runPostmortem(action: "render")` (regenerates `.planning/POSTMORTEM.md` with final metrics).
 
 ### Final Summary
 
@@ -336,7 +378,9 @@ Read `workflowState(action: "read")` for:
 - Plan and research data for gap detection
 
 ## Tool Coordination
-Sequence: (1) `runChecks` → (2) spawn shadow-scanner → (3) `verificationResult(write)` → (4) `manageTodos(move-batch → done)` for all completed items in one call.
+Sequence: (1) `runChecks` → (2) spawn shadow-scanner → (3) `verificationResult(write)` → (4) `runPostmortem(gate)` → (5) `manageTodos(move-batch → done)` with `verificationRef` for every item, in one call.
+
+**Critical:** `manageTodos` will reject any `move → done` without a valid `verificationRef: { criterionId, wave }` pointing at a PASS criterion in `verification-history.jsonl`. Capture the criterion IDs from your `verificationResult(write)` call and pass them through.
 
 ## Luca Reminders
 Obey `<luca-reminder>` tags when they appear in conversation — they contain authoritative mid-session guidance that supersedes stale context.

--- a/packages/luca-mastracode/src/instructions/finalize.md
+++ b/packages/luca-mastracode/src/instructions/finalize.md
@@ -18,10 +18,13 @@ You receive control from **Review mode**. Read the latest `.planning/REVIEW-*.md
 
 1. **Milestone boundary** — capture learnings, prune patterns, archive session
 2. **Shadow debt scan** — advisory scan for AI-session debris before PR
-3. **PR creation** — create pull request if git workflow was used
-4. **Gap detection** — verify all planned work was completed
-5. **Cross-milestone continuation** — loop back if roadmap has remaining phases
-6. **Session cleanup** — release locks, summarize work
+3. **Gap detection** — verify all planned work was completed
+4. **Postmortem gate** — block on critical pipeline violations before PR
+5. **PR creation** — create pull request if git workflow was used (only after gap + postmortem checks pass)
+6. **Cross-milestone continuation** — loop back if roadmap has remaining phases
+7. **Session cleanup** — release locks, summarize work
+
+> **Ordering matters.** Gap detection and the postmortem gate run *before* PR creation. A failing gate must re-enter the pipeline rather than ship a PR.
 
 ---
 
@@ -31,8 +34,9 @@ You receive control from **Review mode**. Read the latest `.planning/REVIEW-*.md
 task_write(tasks: [
   { content: "Capture milestone learnings", status: "in_progress", activeForm: "Capturing milestone learnings" },
   { content: "Run shadow debt scan", status: "pending", activeForm: "Running shadow debt scan" },
-  { content: "Create pull request", status: "pending", activeForm: "Creating pull request" },
   { content: "Run gap detection audit", status: "pending", activeForm: "Running gap detection audit" },
+  { content: "Run postmortem gate", status: "pending", activeForm: "Running postmortem gate" },
+  { content: "Create pull request", status: "pending", activeForm: "Creating pull request" },
   { content: "Clean up and summarize", status: "pending", activeForm: "Cleaning up session artifacts" }
 ])
 ```
@@ -103,7 +107,7 @@ Also write to `.planning/SESSION-ARCHIVE.md`:
 <top patterns and pitfalls>
 
 ## Metrics
-<quantitative summary — see Step 6>
+<quantitative summary — see Step 7>
 ```
 
 ## Step 2: Shadow Debt Scan
@@ -121,41 +125,9 @@ Advisory scan for AI-session debris before PR:
 
 If `repoCleanup` returns `status: "disabled"`, skip silently.
 
-## Step 3: PR Creation
+## Step 3: Gap Detection
 
-If git workflow was used (issue + branch created):
-
-### 3a. Recall Release Conventions
-
-**Before any PR work**, recall release details from MuninnDB:
-
-```
-mcp__muninn__muninn_recall(
-  vault: "<repo_vault>",
-  context: ["release checklist", "PR title format", "version convention", "naming convention"],
-  mode: "semantic",
-  limit: 5
-)
-```
-
-Use recalled conventions to determine: version number, title format (`type(scope): vX.Y.Z #issue description`), milestone linkage, and PR body structure. If no version memory exists, check `packages/luca-mastracode/package.json` for current version and determine the appropriate bump.
-
-### 3b. Create PR
-
-1. **Push** feature branch to remote
-2. **Create PR** with:
-   - **Title**: Per recalled convention — `type(scope): vX.Y.Z #issue description`
-   - **Description**: Summary, `Closes #<issue-number>`, key changes by phase, testing summary, known limitations
-   - **Milestone**: Tag to version milestone
-   - **Labels**: Match issue labels
-   - **Reviewers**: If configured
-3. Store PR URL in `workflow_state`
-
-If `--skip-branch` was set, skip.
-
-## Step 4: Gap Detection
-
-Verify all planned work was completed:
+Verify all planned work was completed **before** opening a PR:
 
 ### Gap Audit
 
@@ -183,7 +155,7 @@ Verify all planned work was completed:
 
 ### Gap Resolution
 
-- **Minor gaps** (missing docs, incomplete tests): flag in PR description as follow-up
+- **Minor gaps** (missing docs, incomplete tests): flag in PR description as follow-up (record now, surface in Step 5)
 - **Major gaps** (missing functionality, failing tests): re-enter pipeline:
   1. Save gap results to workflow state
   2. Re-enter at Review or Execute:
@@ -191,11 +163,11 @@ Verify all planned work was completed:
      workflowState(action: "re-enter-pipeline", targetMode: "luca:5-review", reason: "Post-finalize gap detection found major gaps: <summary>")
      ```
   3. **STOP.** Review mode handles from here, iterating Execute → Review as needed.
-  - If user prefers not to fix: track as follow-up issues, proceed to cleanup
+  - If user prefers not to fix: track as follow-up issues, proceed to the postmortem gate
 
-## Step 4.5: Postmortem Gate
+## Step 4: Postmortem Gate
 
-Before any PR creation, run the postmortem gate. This catches silent-skip incidents (execute mode skipped but todos moved to done), unverified completions, and forced transitions.
+**Always runs before PR creation.** Catches silent-skip incidents (execute mode skipped but todos moved to done), unverified completions, and forced transitions.
 
 ```
 runPostmortem(action: "gate")
@@ -233,9 +205,43 @@ Then render the human-readable report:
 runPostmortem(action: "render")
 ```
 
-This writes `.planning/POSTMORTEM.md`. Reference it in the PR body (Step 3) and the Final Summary (Step 6).
+This writes `.planning/POSTMORTEM.md`. Reference it in the PR body (Step 5) and the Final Summary (Step 7).
 
-## Step 5: Cross-Milestone Continuation
+## Step 5: PR Creation
+
+Only reached if Step 3 (Gap Detection) and Step 4 (Postmortem Gate) both passed.
+
+If git workflow was used (issue + branch created):
+
+### 5a. Recall Release Conventions
+
+**Before any PR work**, recall release details from MuninnDB:
+
+```
+mcp__muninn__muninn_recall(
+  vault: "<repo_vault>",
+  context: ["release checklist", "PR title format", "version convention", "naming convention"],
+  mode: "semantic",
+  limit: 5
+)
+```
+
+Use recalled conventions to determine: version number, title format (`type(scope): vX.Y.Z #issue description`), milestone linkage, and PR body structure. If no version memory exists, check `packages/luca-mastracode/package.json` for current version and determine the appropriate bump.
+
+### 5b. Create PR
+
+1. **Push** feature branch to remote
+2. **Create PR** with:
+   - **Title**: Per recalled convention — `type(scope): vX.Y.Z #issue description`
+   - **Description**: Summary, `Closes #<issue-number>`, key changes by phase, testing summary, known limitations, link to `.planning/POSTMORTEM.md`
+   - **Milestone**: Tag to version milestone
+   - **Labels**: Match issue labels
+   - **Reviewers**: If configured
+3. Store PR URL in `workflow_state`
+
+If `--skip-branch` was set, skip.
+
+## Step 6: Cross-Milestone Continuation
 
 Check if `.planning/ROADMAP.md` has remaining phases:
 
@@ -256,7 +262,7 @@ else:
 
 Maximum **3 milestones per session**. If more remain: summarize what's left, create issues, note continuation point.
 
-## Step 6: Session Cleanup
+## Step 7: Session Cleanup
 
 ### Release Pipeline Lock
 

--- a/packages/luca-mastracode/src/instructions/finalize.md
+++ b/packages/luca-mastracode/src/instructions/finalize.md
@@ -18,13 +18,13 @@ You receive control from **Review mode**. Read the latest `.planning/REVIEW-*.md
 
 1. **Milestone boundary** — capture learnings, prune patterns, archive session
 2. **Shadow debt scan** — advisory scan for AI-session debris before PR
-3. **Gap detection** — verify all planned work was completed
+3. **Gap detection** — verify all planned work was completed; reconcile PLAN.md against shipped code
 4. **Postmortem gate** — block on critical pipeline violations before PR
-5. **PR creation** — create pull request if git workflow was used (only after gap + postmortem checks pass)
+5. **PR creation** — write changeset post-convergence, run claim verifier, then create pull request
 6. **Cross-milestone continuation** — loop back if roadmap has remaining phases
 7. **Session cleanup** — release locks, summarize work
 
-> **Ordering matters.** Gap detection and the postmortem gate run *before* PR creation. A failing gate must re-enter the pipeline rather than ship a PR.
+> **Ordering matters.** Gap detection, postmortem gate, and claim verifier all run *before* `gh pr create`. The changeset is written **after** review iteration converges, not before — pre-convergence drafts are the #1 source of doc drift. A failing gate must re-enter the pipeline rather than ship a PR.
 
 ---
 
@@ -36,6 +36,8 @@ task_write(tasks: [
   { content: "Run shadow debt scan", status: "pending", activeForm: "Running shadow debt scan" },
   { content: "Run gap detection audit", status: "pending", activeForm: "Running gap detection audit" },
   { content: "Run postmortem gate", status: "pending", activeForm: "Running postmortem gate" },
+  { content: "Write changeset and draft PR body", status: "pending", activeForm: "Writing changeset and PR body" },
+  { content: "Run claim verifier gate", status: "pending", activeForm: "Running claim verifier gate" },
   { content: "Create pull request", status: "pending", activeForm: "Creating pull request" },
   { content: "Clean up and summarize", status: "pending", activeForm: "Cleaning up session artifacts" }
 ])
@@ -165,6 +167,28 @@ Verify all planned work was completed **before** opening a PR:
   3. **STOP.** Review mode handles from here, iterating Execute → Review as needed.
   - If user prefers not to fix: track as follow-up issues, proceed to the postmortem gate
 
+### Step 3c — PLAN.md reconciliation
+
+Run the claim verifier against `.planning/PLAN.md`:
+
+```
+claimVerifier(action: "verify-file", path: ".planning/PLAN.md")
+```
+
+Failures here are NOT blocking by themselves — PLAN.md is allowed to contain forward-looking language for incomplete tasks. But:
+
+- **Symbol-not-found** failures cited in tasks marked **complete** → block, re-enter execute (the task references a symbol that doesn't exist in the working tree).
+- **File-not-found** failures cited in tasks marked **complete** → block, re-enter execute.
+- **Count-mismatch** failures → warn only, surface in PR body Follow-Up section.
+
+Cross-reference each failure against PLAN.md task status before deciding to block. A failed claim attached to an incomplete task is expected; a failed claim attached to a completed task is drift.
+
+If blocking:
+
+```
+workflowState(action: "re-enter-pipeline", targetMode: "luca:4-execute", reason: "PLAN.md reconciliation: completed task cites missing symbol/path: <summary>")
+```
+
 ## Step 4: Postmortem Gate
 
 **Always runs before PR creation.** Catches silent-skip incidents (execute mode skipped but todos moved to done), unverified completions, and forced transitions.
@@ -228,7 +252,31 @@ mcp__muninn__muninn_recall(
 
 Use recalled conventions to determine: version number, title format (`type(scope): vX.Y.Z #issue description`), milestone linkage, and PR body structure. If no version memory exists, check `packages/luca-mastracode/package.json` for current version and determine the appropriate bump.
 
-### 5b. Create PR
+### 5b.1. Write release artifacts (AFTER review iteration converged)
+
+Now — and only now, after every review iteration is resolved — write the changeset (`.changeset/<slug>.md`) and any release notes. **Writing these before this point is the #1 cause of drift between artifact claims and shipped code.** Symbols rename mid-review, schemas evolve, counts shift; only the post-convergence tree is trustworthy as the source of truth for release artifacts.
+
+If a changeset already exists from earlier in the session: re-read it now, reconcile against the current branch, and rewrite it. Do not assume it's still accurate.
+
+### 5b.2. Verify artifact claims
+
+Run the claim verifier across the changeset and PR body draft **before** calling `gh pr create`:
+
+```
+claimVerifier(action: "gate", paths: [".changeset/<slug>.md"], texts: [<pr_body_draft>])
+```
+
+If it returns `code: CLAIM_VERIFICATION_FAILED`:
+
+- Each failure is a backticked symbol, file path, or quantitative count cited in your draft that doesn't exist in the working tree.
+- For `symbol-not-found` / `file-not-found`: the draft is wrong (renamed/removed since drafting) **or** the code is wrong (the work isn't actually shipped). Inspect both.
+- For `count-mismatch`: numbers drifted. Re-count or rephrase.
+- Fix the draft (or the code) and re-run the gate until it passes.
+- **Do not open the PR with unverified claims.**
+
+After the gate passes, proceed.
+
+### 5b.3. Create PR
 
 1. **Push** feature branch to remote
 2. **Create PR** with:
@@ -384,9 +432,11 @@ Read `workflowState(action: "read")` for:
 - Plan and research data for gap detection
 
 ## Tool Coordination
-Sequence: (1) `runChecks` → (2) spawn shadow-scanner → (3) `verificationResult(write)` → (4) `runPostmortem(gate)` → (5) `manageTodos(move-batch → done)` with `verificationRef` for every item, in one call.
+Sequence: (1) `runChecks` → (2) spawn shadow-scanner → (3) `verificationResult(write)` → (4) `runPostmortem(gate)` → (5) write changeset + draft PR body → (6) `claimVerifier(gate)` over changeset + PR body → (7) `manageTodos(move-batch → done)` with `verificationRef` for every item, in one call → (8) `gh pr create`.
 
 **Critical:** `manageTodos` will reject any `move → done` without a valid `verificationRef: { criterionId, wave }` pointing at a PASS criterion in `verification-history.jsonl`. Capture the criterion IDs from your `verificationResult(write)` call and pass them through.
+
+**Also critical:** `claimVerifier(gate)` runs *after* the changeset is written and *before* `gh pr create`. A failure here means the draft cites symbols/paths/counts that don't exist on the branch — either the draft is stale (rewrite) or the code didn't actually land (re-enter execute).
 
 ## Luca Reminders
 Obey `<luca-reminder>` tags when they appear in conversation — they contain authoritative mid-session guidance that supersedes stale context.

--- a/packages/luca-mastracode/src/instructions/review.md
+++ b/packages/luca-mastracode/src/instructions/review.md
@@ -181,6 +181,16 @@ Write to `.planning/REVIEW-{wave}.md` via **writePlanningFile** (action: "write"
 
 - **[{perspective}]** {description}
 
+### Optional: Self-check review claims
+
+Before finalizing the verdict, optionally run the claim verifier across your own MUST-FIX/SHOULD-FIX entries to catch hallucinated symbols or stale file paths in your own output:
+
+```
+claimVerifier(action: "verify-text", text: <full-review-output-as-string>)
+```
+
+If the verifier flags `symbol-not-found` for a symbol you cited in a finding, that finding is suspect — the symbol you're citing doesn't exist in the working tree. Either fix the citation or drop the finding. Non-blocking: this is a self-check, not a gate.
+
 ## Verdict
 
 {CLEAN | ISSUES_FOUND}

--- a/packages/luca-mastracode/src/launch.ts
+++ b/packages/luca-mastracode/src/launch.ts
@@ -75,6 +75,7 @@ import {
     resolveTriageModel,
     triageMode,
 } from './modes/triage.js'
+import { MODES } from './modes/mode-ids.js'
 import * as pipelineGuard from './pipeline-guard.js'
 import {
     buildPipelineProgressHeader,
@@ -119,13 +120,13 @@ import { clipToVisibleWidth, visibleWidth } from './tui-text-helpers.js'
  * is why they need this sync.
  */
 const PIPELINE_MODE_MODEL_RESOLVERS: Record<string, () => string> = {
-    'luca:discuss': resolveDiscussModel,
-    'luca:1-triage': resolveTriageModel,
-    'luca:2-research': resolveResearchModel,
-    'luca:3-architect': resolveArchitectModel,
-    'luca:4-execute': resolveExecuteModel,
-    'luca:5-review': resolveReviewModel,
-    'luca:6-finalize': resolveFinalizeModel,
+    [MODES.discuss]: resolveDiscussModel,
+    [MODES.triage]: resolveTriageModel,
+    [MODES.research]: resolveResearchModel,
+    [MODES.architect]: resolveArchitectModel,
+    [MODES.execute]: resolveExecuteModel,
+    [MODES.review]: resolveReviewModel,
+    [MODES.finalize]: resolveFinalizeModel,
 }
 
 /**
@@ -268,7 +269,7 @@ export async function main(): Promise<void> {
                     defaultModelId: discussMode.defaultModelId,
                     buildInstructions: buildDiscussInstructions,
                     resolveModelFn: resolveDiscussModel,
-                    tools: buildModeTools({ mode_id: 'luca:discuss' }),
+                    tools: buildModeTools({ mode_id: MODES.discuss }),
                 }),
             },
             // --- Luca pipeline modes ---
@@ -283,7 +284,7 @@ export async function main(): Promise<void> {
                     defaultModelId: triageMode.defaultModelId,
                     buildInstructions: buildTriageInstructions,
                     resolveModelFn: resolveTriageModel,
-                    tools: buildModeTools({ mode_id: 'luca:1-triage' }),
+                    tools: buildModeTools({ mode_id: MODES.triage }),
                 }),
             },
             {
@@ -297,7 +298,7 @@ export async function main(): Promise<void> {
                     defaultModelId: researchMode.defaultModelId,
                     buildInstructions: buildResearchInstructions,
                     resolveModelFn: resolveResearchModel,
-                    tools: buildModeTools({ mode_id: 'luca:2-research' }),
+                    tools: buildModeTools({ mode_id: MODES.research }),
                 }),
             },
             {
@@ -311,7 +312,7 @@ export async function main(): Promise<void> {
                     defaultModelId: architectMode.defaultModelId,
                     buildInstructions: buildArchitectInstructions,
                     resolveModelFn: resolveArchitectModel,
-                    tools: buildModeTools({ mode_id: 'luca:3-architect' }),
+                    tools: buildModeTools({ mode_id: MODES.architect }),
                 }),
             },
             {
@@ -325,7 +326,7 @@ export async function main(): Promise<void> {
                     defaultModelId: executeMode.defaultModelId,
                     buildInstructions: buildExecuteInstructions,
                     resolveModelFn: resolveExecuteModel,
-                    tools: buildModeTools({ mode_id: 'luca:4-execute' }),
+                    tools: buildModeTools({ mode_id: MODES.execute }),
                 }),
             },
             {
@@ -339,7 +340,7 @@ export async function main(): Promise<void> {
                     defaultModelId: reviewMode.defaultModelId,
                     buildInstructions: buildReviewInstructions,
                     resolveModelFn: resolveReviewModel,
-                    tools: buildModeTools({ mode_id: 'luca:5-review' }),
+                    tools: buildModeTools({ mode_id: MODES.review }),
                 }),
             },
             {
@@ -353,7 +354,7 @@ export async function main(): Promise<void> {
                     defaultModelId: finalizeMode.defaultModelId,
                     buildInstructions: buildFinalizeInstructions,
                     resolveModelFn: resolveFinalizeModel,
-                    tools: buildModeTools({ mode_id: 'luca:6-finalize' }),
+                    tools: buildModeTools({ mode_id: MODES.finalize }),
                 }),
             },
         ],
@@ -568,12 +569,12 @@ export async function main(): Promise<void> {
     // Since getDynamicWorkspace calls setToolsConfig on every message (line 499),
     // we must intercept workspaceFn to apply our config AFTER the stock function.
 
-    const READ_ONLY_MODES = new Set([
+    const READ_ONLY_MODES = new Set<string>([
         'plan',
-        'luca:discuss',
-        'luca:1-triage',
-        'luca:2-research',
-        'luca:5-review',
+        MODES.discuss,
+        MODES.triage,
+        MODES.research,
+        MODES.review,
     ])
 
     // Tool name overrides matching stock mastracode TOOL_NAME_OVERRIDES.

--- a/packages/luca-mastracode/src/luca-store.ts
+++ b/packages/luca-mastracode/src/luca-store.ts
@@ -11,6 +11,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { atomicWriteSync } from './atomic-write.js'
+import { MODES } from './modes/mode-ids.js'
 import { resolveBudgetLimits } from './state.js'
 import type { ComplexityLevel, ProfileLevel } from './state.js'
 
@@ -121,13 +122,13 @@ export function readLucaState(): LucaWorkflowState {
 
         // Migrate bare mode names to namespaced identifiers
         const BARE_TO_NAMESPACED: Record<string, string> = {
-            discuss: 'luca:discuss',
-            triage: 'luca:1-triage',
-            research: 'luca:2-research',
-            architect: 'luca:3-architect',
-            execute: 'luca:4-execute',
-            review: 'luca:5-review',
-            finalize: 'luca:6-finalize',
+            discuss: MODES.discuss,
+            triage: MODES.triage,
+            research: MODES.research,
+            architect: MODES.architect,
+            execute: MODES.execute,
+            review: MODES.review,
+            finalize: MODES.finalize,
         }
         if (state.pipelineStep && BARE_TO_NAMESPACED[state.pipelineStep]) {
             state.pipelineStep = BARE_TO_NAMESPACED[state.pipelineStep]

--- a/packages/luca-mastracode/src/luca-store.ts
+++ b/packages/luca-mastracode/src/luca-store.ts
@@ -16,6 +16,18 @@ import type { ComplexityLevel, ProfileLevel } from './state.js'
 
 const STATE_FILE = '.planning/luca-state.json'
 
+/**
+ * Mirror of `PhaseSnapshot` from `phase-diff.ts`. Inlined here to avoid a
+ * circular import (luca-store ↔ phase-diff via session-ledger).
+ */
+export interface PhaseSnapshotState {
+    phase: string
+    takenAt: string
+    headSha: string | null
+    dirtyFiles: string[]
+    gitAvailable: boolean
+}
+
 export interface PhaseResult {
     /** Phase name from ROADMAP.md */
     name: string
@@ -68,6 +80,16 @@ export interface LucaWorkflowState {
     // --- Session ---
     sessionId?: string
     startedAt?: string
+    runId?: string
+
+    // --- Phase proof (set by start-phase, consumed by complete-phase) ---
+    currentPhaseStartSnapshot?: PhaseSnapshotState
+
+    // --- Empty-phase justification (set by justify-empty-phase) ---
+    emptyPhaseJustifications?: Record<
+        string,
+        { category: string; reasoning: string; at: string }
+    >
 
     // --- Assigned work ---
     assignedTodos?: number[]

--- a/packages/luca-mastracode/src/modes/architect.ts
+++ b/packages/luca-mastracode/src/modes/architect.ts
@@ -14,6 +14,8 @@ import { readLucaState } from '../luca-store.js'
 import { resolveModel } from '../model-routing.js'
 import type { ComplexityLevel, ProfileLevel } from '../state.js'
 
+import { MODES } from './mode-ids.js'
+
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 function loadInstructions(): string {
@@ -68,7 +70,7 @@ export function resolveArchitectModel(
  * Architect agent configuration for mode registration.
  */
 export const architectMode = {
-    id: 'luca:3-architect' as const,
+    id: MODES.architect,
     name: 'luca: Architect',
     description:
         'Git workflow, roadmap creation, .planning/PLAN.md via goal-backward analysis, and plan review.',

--- a/packages/luca-mastracode/src/modes/discuss.ts
+++ b/packages/luca-mastracode/src/modes/discuss.ts
@@ -9,6 +9,8 @@ import { readFileSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { MODES } from './mode-ids.js'
+
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 function loadInstructions(): string {
@@ -27,7 +29,7 @@ export function resolveDiscussModel(): string {
 }
 
 export const discussMode = {
-    id: 'luca:discuss' as const,
+    id: MODES.discuss,
     name: 'luca: Discuss',
     description: 'Read-only brainstorming and open-ended discussion.',
     color: '#f59e0b',

--- a/packages/luca-mastracode/src/modes/execute.ts
+++ b/packages/luca-mastracode/src/modes/execute.ts
@@ -13,6 +13,8 @@ import { readLucaState } from '../luca-store.js'
 import { resolveModel } from '../model-routing.js'
 import type { ComplexityLevel, ProfileLevel } from '../state.js'
 
+import { MODES } from './mode-ids.js'
+
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 function loadInstructions(): string {
@@ -92,7 +94,7 @@ export function resolveExecuteModel(
  * Execute agent configuration for mode registration.
  */
 export const executeMode = {
-    id: 'luca:4-execute' as const,
+    id: MODES.execute,
     name: 'luca: Execute',
     description:
         'Implement code changes atomically with automated checks, verification, code review, and learning capture.',

--- a/packages/luca-mastracode/src/modes/finalize.ts
+++ b/packages/luca-mastracode/src/modes/finalize.ts
@@ -12,6 +12,8 @@ import { readLucaState } from '../luca-store.js'
 import { resolveModel } from '../model-routing.js'
 import type { ComplexityLevel, ProfileLevel } from '../state.js'
 
+import { MODES } from './mode-ids.js'
+
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 function loadInstructions(): string {
@@ -67,7 +69,7 @@ export function resolveFinalizeModel(
  * Finalize agent configuration for mode registration.
  */
 export const finalizeMode = {
-    id: 'luca:6-finalize' as const,
+    id: MODES.finalize,
     name: 'luca: Finalize',
     description:
         'Milestone boundaries, gap audit, PR creation, and session cleanup.',

--- a/packages/luca-mastracode/src/modes/mode-ids.ts
+++ b/packages/luca-mastracode/src/modes/mode-ids.ts
@@ -1,0 +1,60 @@
+/**
+ * Mode IDs — single source of truth.
+ *
+ * Every place in `luca-mastracode` that needs to refer to a pipeline
+ * mode should import from this module rather than hand-typing the
+ * `'luca:<n>-<name>'` literal. A typo in a hand-typed mode string
+ * routes silently to "unknown mode" with no compile error.
+ *
+ * Markdown instruction files (`instructions/*.md`) are intentionally
+ * left as plain literals — they are LLM prompts, not TypeScript, and
+ * cannot import from a module. The constants here are a `as const`
+ * tuple-ish object so renames in TypeScript propagate via the
+ * compiler, and the canonical names match the prompt strings.
+ *
+ * If you need the bare alias (`'execute'` instead of `'luca:4-execute'`)
+ * for legacy-state migration, use `BARE_TO_MODE_ID` in `luca-store.ts`.
+ */
+export const MODES = {
+    discuss: 'luca:discuss',
+    triage: 'luca:1-triage',
+    research: 'luca:2-research',
+    architect: 'luca:3-architect',
+    execute: 'luca:4-execute',
+    review: 'luca:5-review',
+    finalize: 'luca:6-finalize',
+} as const
+
+export type ModeKey = keyof typeof MODES
+export type ModeId = (typeof MODES)[ModeKey]
+
+/** All mode IDs as a frozen array. Order matches the canonical pipeline progression. */
+export const ALL_MODE_IDS: readonly ModeId[] = [
+    MODES.discuss,
+    MODES.triage,
+    MODES.research,
+    MODES.architect,
+    MODES.execute,
+    MODES.review,
+    MODES.finalize,
+] as const
+
+/** Modes that participate in the auto-pipeline (excludes one-off `discuss`). */
+export const PIPELINE_MODE_IDS: readonly ModeId[] = [
+    MODES.triage,
+    MODES.research,
+    MODES.architect,
+    MODES.execute,
+    MODES.review,
+    MODES.finalize,
+] as const
+
+/**
+ * Type guard — narrows an arbitrary string to ModeId.
+ */
+export function isModeId(value: unknown): value is ModeId {
+    return (
+        typeof value === 'string' &&
+        (ALL_MODE_IDS as readonly string[]).includes(value)
+    )
+}

--- a/packages/luca-mastracode/src/modes/research.ts
+++ b/packages/luca-mastracode/src/modes/research.ts
@@ -12,6 +12,8 @@ import { readLucaState } from '../luca-store.js'
 import { resolveModel } from '../model-routing.js'
 import type { ComplexityLevel, ProfileLevel } from '../state.js'
 
+import { MODES } from './mode-ids.js'
+
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 function loadInstructions(): string {
@@ -66,7 +68,7 @@ export function resolveResearchModel(
  * Research agent configuration for mode registration.
  */
 export const researchMode = {
-    id: 'luca:2-research' as const,
+    id: MODES.research,
     name: 'luca: Research',
     description: 'Deep codebase and ecosystem research before planning.',
     color: '#3b82f6',

--- a/packages/luca-mastracode/src/modes/review.ts
+++ b/packages/luca-mastracode/src/modes/review.ts
@@ -13,6 +13,8 @@ import { readLucaState } from '../luca-store.js'
 import { resolveModel } from '../model-routing.js'
 import type { ComplexityLevel, ProfileLevel } from '../state.js'
 
+import { MODES } from './mode-ids.js'
+
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 function loadInstructions(): string {
@@ -69,7 +71,7 @@ export function resolveReviewModel(
  * Review agent configuration for mode registration.
  */
 export const reviewMode = {
-    id: 'luca:5-review' as const,
+    id: MODES.review,
     name: 'luca: Review',
     description:
         'Read-only code audit: multi-perspective review, structured findings, and iteration routing.',

--- a/packages/luca-mastracode/src/modes/triage.ts
+++ b/packages/luca-mastracode/src/modes/triage.ts
@@ -11,6 +11,8 @@ import { fileURLToPath } from 'node:url'
 import { readLucaState } from '../luca-store.js'
 import { resolveModel } from '../model-routing.js'
 
+import { MODES } from './mode-ids.js'
+
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 function loadInstructions(): string {
@@ -87,7 +89,7 @@ export function resolveTriageModel(
  * Triage agent configuration for mode registration.
  */
 export const triageMode = {
-    id: 'luca:1-triage' as const,
+    id: MODES.triage,
     name: 'luca: Triage',
     description:
         'Parse, classify, and configure the workflow for a development request.',

--- a/packages/luca-mastracode/src/phase-diff.ts
+++ b/packages/luca-mastracode/src/phase-diff.ts
@@ -158,11 +158,18 @@ export function computePhaseDiff(start: PhaseSnapshot | null): PhaseDiff {
         if (!startDirty.has(f)) filesChanged.add(f)
     }
 
+    // If the working tree was already dirty at start-phase, edits to those
+    // pre-dirty files won't show up in either the HEAD..HEAD diff or the
+    // "new dirty files" delta above. Treat that as indeterminate so the
+    // empty-phase guard can't false-block real work on already-dirty files.
+    const baselineDirty = startDirty.size > 0
     const filesChangedArr = Array.from(filesChanged)
     return {
         filesChanged: filesChangedArr,
         commitsAdded,
-        isEmpty: filesChangedArr.length === 0 && commitsAdded.length === 0,
-        indeterminate: false,
+        isEmpty: baselineDirty
+            ? false
+            : filesChangedArr.length === 0 && commitsAdded.length === 0,
+        indeterminate: baselineDirty,
     }
 }

--- a/packages/luca-mastracode/src/phase-diff.ts
+++ b/packages/luca-mastracode/src/phase-diff.ts
@@ -1,0 +1,168 @@
+/**
+ * Phase diff proof — proves that an execute phase actually produced work.
+ *
+ * Strategy:
+ *   1. At `start-phase` we snapshot `git rev-parse HEAD` and the set of
+ *      dirty files reported by `git status --porcelain`.
+ *   2. At `complete-phase` we compute the diff against the current tree:
+ *      - Files changed via `git diff --name-only <startSha> HEAD` (committed work).
+ *      - Files newly dirty since the start snapshot (uncommitted work).
+ *      - Commits added since the start snapshot.
+ *   3. If both file changes and commits added are empty, the phase is
+ *      flagged `isEmpty: true` and `complete-phase` requires a matching
+ *      `phase-empty-justification` ledger event before it will accept the
+ *      transition.
+ *
+ * Non-git repos are tolerated: snapshot returns `gitAvailable: false` and
+ * the diff is returned with `indeterminate: true`. Non-git phases bypass
+ * the empty-phase guard (we can't prove emptiness without git).
+ */
+import { spawnSync } from 'node:child_process'
+
+export interface PhaseSnapshot {
+    /** Phase name this snapshot belongs to */
+    phase: string
+    /** ISO timestamp of when the snapshot was captured */
+    takenAt: string
+    /** HEAD commit SHA at snapshot time, or null if non-git */
+    headSha: string | null
+    /** Files dirty at snapshot time (relative paths) */
+    dirtyFiles: string[]
+    /** Whether the working directory is a git repo */
+    gitAvailable: boolean
+}
+
+export interface PhaseDiff {
+    filesChanged: string[]
+    commitsAdded: string[]
+    isEmpty: boolean
+    /** True when we couldn't compute a diff (no snapshot, no git) */
+    indeterminate: boolean
+}
+
+function runGit(args: string[]): {
+    ok: boolean
+    stdout: string
+    stderr: string
+} {
+    try {
+        const result = spawnSync('git', args, {
+            encoding: 'utf-8',
+            cwd: process.cwd(),
+        })
+        return {
+            ok: result.status === 0,
+            stdout: result.stdout ?? '',
+            stderr: result.stderr ?? '',
+        }
+    } catch {
+        return { ok: false, stdout: '', stderr: '' }
+    }
+}
+
+function isGitRepo(): boolean {
+    return runGit(['rev-parse', '--is-inside-work-tree']).ok
+}
+
+/**
+ * Capture the current HEAD + dirty file set, tagged with a phase name.
+ */
+export function snapshotWorkingTree(phase: string): PhaseSnapshot {
+    const takenAt = new Date().toISOString()
+    if (!isGitRepo()) {
+        return {
+            phase,
+            takenAt,
+            headSha: null,
+            dirtyFiles: [],
+            gitAvailable: false,
+        }
+    }
+
+    const head = runGit(['rev-parse', 'HEAD'])
+    const status = runGit(['status', '--porcelain'])
+    const dirtyFiles = status.ok
+        ? status.stdout
+              .split('\n')
+              .filter(Boolean)
+              .map((line) => line.slice(3).trim())
+              .filter(Boolean)
+        : []
+
+    return {
+        phase,
+        takenAt,
+        headSha: head.ok ? head.stdout.trim() : null,
+        dirtyFiles,
+        gitAvailable: true,
+    }
+}
+
+/**
+ * Compute the diff between a start snapshot and the current tree.
+ *
+ * Returns `indeterminate: true` when there's no usable snapshot or the
+ * repo isn't a git repo. Callers should treat indeterminate as
+ * "can't prove emptiness" — i.e. don't punish, but flag for postmortem.
+ */
+export function computePhaseDiff(start: PhaseSnapshot | null): PhaseDiff {
+    if (!start || !start.gitAvailable) {
+        return {
+            filesChanged: [],
+            commitsAdded: [],
+            isEmpty: false,
+            indeterminate: true,
+        }
+    }
+
+    if (!isGitRepo()) {
+        return {
+            filesChanged: [],
+            commitsAdded: [],
+            isEmpty: false,
+            indeterminate: true,
+        }
+    }
+
+    const filesChanged = new Set<string>()
+    const commitsAdded: string[] = []
+
+    if (start.headSha) {
+        const diff = runGit(['diff', '--name-only', start.headSha, 'HEAD'])
+        if (diff.ok) {
+            for (const f of diff.stdout.split('\n').map((s) => s.trim())) {
+                if (f) filesChanged.add(f)
+            }
+        }
+
+        const log = runGit(['rev-list', `${start.headSha}..HEAD`])
+        if (log.ok) {
+            for (const sha of log.stdout.split('\n').map((s) => s.trim())) {
+                if (sha) commitsAdded.push(sha)
+            }
+        }
+    }
+
+    const currentStatus = runGit(['status', '--porcelain'])
+    const currentDirty = currentStatus.ok
+        ? new Set(
+              currentStatus.stdout
+                  .split('\n')
+                  .filter(Boolean)
+                  .map((line) => line.slice(3).trim())
+                  .filter(Boolean)
+          )
+        : new Set<string>()
+    const startDirty = new Set(start.dirtyFiles)
+    for (const f of currentDirty) {
+        if (!startDirty.has(f)) filesChanged.add(f)
+    }
+
+    const filesChangedArr = Array.from(filesChanged)
+    return {
+        filesChanged: filesChangedArr,
+        commitsAdded,
+        isEmpty: filesChangedArr.length === 0 && commitsAdded.length === 0,
+        indeterminate: false,
+    }
+}

--- a/packages/luca-mastracode/src/pipeline-guard.ts
+++ b/packages/luca-mastracode/src/pipeline-guard.ts
@@ -31,6 +31,8 @@ interface TurnState {
     switchModeCalled: boolean
     /** Consecutive enforcement nudges sent without a successful switch-mode */
     consecutiveMisses: number
+    /** Whether the idle-bypass anomaly has already been logged this turn */
+    idleBypassLogged: boolean
 }
 
 /** Active tool_start → toolName+args mapping for tool_end correlation */
@@ -62,6 +64,7 @@ export function startTurn(modeId: string): void {
         toolCallCount: 0,
         switchModeCalled: false,
         consecutiveMisses: prevMisses,
+        idleBypassLogged: false,
     }
     pendingToolCalls.clear()
 }
@@ -131,8 +134,19 @@ export function checkTurnCompletion(reason: string | undefined): {
 
     // Don't enforce if the pipeline is not actively running — prevents
     // stale guard state from triggering false enforcement after completion.
+    // Log the bypass so retrospective analysis can detect cases where the
+    // guard was disabled by stale or missing pipeline state.
     const state = readLucaState()
     if (!state.pipelineStep || state.pipelineStep === 'idle') {
+        if (!currentTurn.idleBypassLogged) {
+            currentTurn.idleBypassLogged = true
+            appendLedger('pipeline-guard-idle-bypass', {
+                mode: currentTurn.modeId,
+                pipelineStep: state.pipelineStep ?? 'missing',
+                toolCallCount: currentTurn.toolCallCount,
+                switchModeCalled: currentTurn.switchModeCalled,
+            })
+        }
         return null
     }
 

--- a/packages/luca-mastracode/src/pipeline-guard.ts
+++ b/packages/luca-mastracode/src/pipeline-guard.ts
@@ -11,6 +11,7 @@
  * when the workflow-state tool's switch-mode action was invoked.
  */
 import { readLucaState, writeLucaState } from './luca-store.js'
+import { MODES } from './modes/mode-ids.js'
 import { followUpRef, switchModeRef } from './refs.js'
 import { appendLedger } from './session-ledger.js'
 import { PIPELINE_ORDER } from './tools/workflow-state.js'
@@ -157,7 +158,7 @@ export function checkTurnCompletion(reason: string | undefined): {
     }
 
     // Finalize is the last step — no switch-mode needed
-    if (currentTurn.modeId === 'luca:6-finalize') {
+    if (currentTurn.modeId === MODES.finalize) {
         return null
     }
 

--- a/packages/luca-mastracode/src/postmortem.ts
+++ b/packages/luca-mastracode/src/postmortem.ts
@@ -1,0 +1,543 @@
+/**
+ * Postmortem — structured retrospective analysis of a Luca pipeline run.
+ *
+ * Reads the four append-only JSONL artifacts under `.planning/`:
+ *   - session-ledger.jsonl       (mode/phase events, guards, diff summaries)
+ *   - verification-history.jsonl (per-wave PASS/FAIL/STALLED verdicts)
+ *   - confidence-journal.jsonl   (executor ambiguity decisions)
+ *   - routing-history.jsonl      (model routing decisions)
+ *
+ * Produces:
+ *   - A structured `PostmortemReport` for programmatic gating.
+ *   - A human-readable `.planning/POSTMORTEM.md` rendering.
+ *   - An optional list of `pitfall` payloads the agent should forward to
+ *     MuninnDB (default vault) so future runs can recall recurring failures.
+ */
+import {
+    existsSync,
+    writeFileSync,
+    mkdirSync,
+    readFileSync,
+} from 'node:fs'
+import { join } from 'node:path'
+
+import {
+    readLedger,
+    readLedgerForRun,
+    getCurrentRunId,
+    listRuns,
+    type LedgerEntry,
+} from './session-ledger.js'
+import {
+    readVerificationHistory,
+    type VerificationResult,
+} from './verification-result.js'
+import {
+    readConfidenceJournal,
+    type ConfidenceEntry,
+} from './confidence-journal.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ViolationCode =
+    | 'EMPTY_PHASE_NO_JUSTIFICATION'
+    | 'TODO_DONE_NO_VERIFICATION'
+    | 'FORCED_TRANSITION'
+    | 'LOW_CONFIDENCE_THRESHOLD'
+    | 'WAVE_NO_VERIFICATION'
+    | 'PIPELINE_RE_ENTERED'
+    | 'PIPELINE_GUARD_IDLE_BYPASS'
+
+export type ViolationSeverity = 'critical' | 'warning'
+
+export interface Violation {
+    severity: ViolationSeverity
+    code: ViolationCode
+    message: string
+    evidence: string
+    /** Stable fingerprint for idempotent MuninnDB storage */
+    evidenceFingerprint: string
+}
+
+export interface PhaseSummary {
+    name: string
+    startedAt?: string
+    completedAt?: string
+    diff?: {
+        filesChanged: string[]
+        commitsAdded: string[]
+        isEmpty: boolean
+        indeterminate: boolean
+    }
+    justification?: { category: string; reasoning: string; at?: string }
+    verifications: VerificationResult[]
+    todosMovedToDone: Array<{ slug: string; verificationRef: unknown }>
+}
+
+export interface PostmortemReport {
+    runId: string
+    startedAt?: string
+    endedAt?: string
+    durationMs?: number
+    phases: PhaseSummary[]
+    violations: Violation[]
+    metrics: {
+        totalEvents: number
+        modeTransitions: number
+        phasesCompleted: number
+        emptyPhasesJustified: number
+        todosMovedToDone: number
+        lowConfidenceCount: number
+        forcedTransitions: number
+        moveBlockedCount: number
+    }
+    /** Pre-formatted MuninnDB pitfall payloads (default vault). */
+    pitfalls: Array<{
+        vault: 'default'
+        concept: string
+        type: 'pitfall'
+        content: string
+        tags: string[]
+        op_id: string
+    }>
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fingerprint(input: string): string {
+    // Cheap deterministic hash; we just need uniqueness within a run.
+    let hash = 0
+    for (let i = 0; i < input.length; i++) {
+        hash = (hash << 5) - hash + input.charCodeAt(i)
+        hash |= 0
+    }
+    return Math.abs(hash).toString(36)
+}
+
+const LOW_CONFIDENCE_THRESHOLD = 3
+
+function eventDataString(e: LedgerEntry, key: string): string | undefined {
+    const v = e.data[key]
+    return typeof v === 'string' ? v : undefined
+}
+
+// ---------------------------------------------------------------------------
+// Core analysis
+// ---------------------------------------------------------------------------
+
+export function analyzeRun(runId?: string): PostmortemReport {
+    const targetRunId = runId ?? getCurrentRunId()
+    const all = readLedger()
+    const entries = runId
+        ? readLedgerForRun(targetRunId)
+        : all.filter((e) => e.runId === targetRunId)
+
+    const startedAt = entries[0]?.timestamp
+    const endedAt = entries[entries.length - 1]?.timestamp
+    const durationMs =
+        startedAt && endedAt
+            ? new Date(endedAt).getTime() - new Date(startedAt).getTime()
+            : undefined
+
+    const verifications = readVerificationHistory()
+    const confidence = readConfidenceJournal()
+
+    // ── Group events by phase ─────────────────────────────────────────────
+    const phaseMap = new Map<string, PhaseSummary>()
+    function getPhase(name: string): PhaseSummary {
+        let p = phaseMap.get(name)
+        if (!p) {
+            p = {
+                name,
+                verifications: [],
+                todosMovedToDone: [],
+            }
+            phaseMap.set(name, p)
+        }
+        return p
+    }
+
+    for (const e of entries) {
+        const phaseName = eventDataString(e, 'phase')
+        switch (e.event) {
+            case 'phase-start': {
+                if (phaseName) getPhase(phaseName).startedAt = e.timestamp
+                break
+            }
+            case 'phase-complete': {
+                if (phaseName) getPhase(phaseName).completedAt = e.timestamp
+                break
+            }
+            case 'phase-diff-summary': {
+                if (!phaseName) break
+                const p = getPhase(phaseName)
+                p.diff = {
+                    filesChanged: Array.isArray(e.data.filesChanged)
+                        ? (e.data.filesChanged as string[])
+                        : [],
+                    commitsAdded: Array.isArray(e.data.commitsAdded)
+                        ? (e.data.commitsAdded as string[])
+                        : [],
+                    isEmpty: e.data.isEmpty === true,
+                    indeterminate: e.data.indeterminate === true,
+                }
+                break
+            }
+            case 'phase-empty-justification': {
+                if (!phaseName) break
+                const p = getPhase(phaseName)
+                p.justification = {
+                    category: eventDataString(e, 'category') ?? 'unknown',
+                    reasoning: eventDataString(e, 'reasoning') ?? '',
+                    at: e.timestamp,
+                }
+                break
+            }
+            case 'todo-moved-to-done': {
+                // Attach to most recent phase by timestamp.
+                const recentPhase = mostRecentPhaseAt(entries, e.timestamp)
+                if (recentPhase) {
+                    getPhase(recentPhase).todosMovedToDone.push({
+                        slug: eventDataString(e, 'slug') ?? '<unknown>',
+                        verificationRef: e.data.verificationRef ?? null,
+                    })
+                }
+                break
+            }
+        }
+    }
+
+    // Attach verification history per phase by name.
+    for (const v of verifications) {
+        if (v.phase) {
+            getPhase(v.phase).verifications.push(v)
+        }
+    }
+
+    const phases = Array.from(phaseMap.values())
+
+    // ── Detect violations ─────────────────────────────────────────────────
+    const violations: Violation[] = []
+
+    // 1. Empty phase without justification
+    for (const p of phases) {
+        if (p.diff?.isEmpty && !p.justification) {
+            violations.push({
+                severity: 'critical',
+                code: 'EMPTY_PHASE_NO_JUSTIFICATION',
+                message: `Phase "${p.name}" completed with zero file changes and zero commits but has no phase-empty-justification entry.`,
+                evidence: `phase=${p.name} completedAt=${p.completedAt ?? '?'}`,
+                evidenceFingerprint: fingerprint(
+                    `EMPTY_PHASE:${p.name}:${p.completedAt ?? ''}`
+                ),
+            })
+        }
+    }
+
+    // 2. Todos moved to done without verificationRef (or blocked attempts)
+    const moveBlocked = entries.filter((e) => e.event === 'todo-move-blocked')
+    for (const e of moveBlocked) {
+        violations.push({
+            severity: 'critical',
+            code: 'TODO_DONE_NO_VERIFICATION',
+            message: `Blocked attempt to move todo "${eventDataString(e, 'identifier') ?? '?'}" to done without a valid verificationRef.`,
+            evidence: `reason=${eventDataString(e, 'reason') ?? '?'} at=${e.timestamp}`,
+            evidenceFingerprint: fingerprint(
+                `TODO_BLOCKED:${eventDataString(e, 'identifier') ?? ''}:${e.timestamp}`
+            ),
+        })
+    }
+    // Belt-and-suspenders: any todos-moved-to-done with falsy verificationRef
+    for (const p of phases) {
+        for (const t of p.todosMovedToDone) {
+            if (!t.verificationRef) {
+                violations.push({
+                    severity: 'critical',
+                    code: 'TODO_DONE_NO_VERIFICATION',
+                    message: `Todo "${t.slug}" moved to done without a verificationRef in phase "${p.name}".`,
+                    evidence: `phase=${p.name} slug=${t.slug}`,
+                    evidenceFingerprint: fingerprint(
+                        `TODO_NOREF:${p.name}:${t.slug}`
+                    ),
+                })
+            }
+        }
+    }
+
+    // 3. Forced transitions (warning level — pipeline-guard intervened)
+    const forced = entries.filter(
+        (e) => e.event === 'pipeline-forced-transition'
+    )
+    for (const e of forced) {
+        violations.push({
+            severity: 'warning',
+            code: 'FORCED_TRANSITION',
+            message: `Pipeline-guard force-transitioned the agent (it failed to call switch-mode).`,
+            evidence: `from=${eventDataString(e, 'from') ?? '?'} to=${eventDataString(e, 'to') ?? '?'} at=${e.timestamp}`,
+            evidenceFingerprint: fingerprint(
+                `FORCED:${e.timestamp}:${eventDataString(e, 'from') ?? ''}`
+            ),
+        })
+    }
+
+    // 4. Low-confidence-threshold breach (warning)
+    const lowConfidence = confidence.filter(
+        (c: ConfidenceEntry) => c.confidence === 'low'
+    )
+    if (lowConfidence.length >= LOW_CONFIDENCE_THRESHOLD) {
+        violations.push({
+            severity: 'warning',
+            code: 'LOW_CONFIDENCE_THRESHOLD',
+            message: `${lowConfidence.length} low-confidence executor decisions (threshold=${LOW_CONFIDENCE_THRESHOLD}). Human review recommended before merge.`,
+            evidence: `count=${lowConfidence.length} categories=${lowConfidence.map((c) => c.category).join(',')}`,
+            evidenceFingerprint: fingerprint(
+                `LOWCONF:${lowConfidence.length}:${targetRunId}`
+            ),
+        })
+    }
+
+    // 5. Wave advance blocked
+    const waveBlocked = entries.filter(
+        (e) => e.event === 'wave-advance-blocked'
+    )
+    for (const e of waveBlocked) {
+        violations.push({
+            severity: 'critical',
+            code: 'WAVE_NO_VERIFICATION',
+            message: `Attempt to advance wave without verification-result.`,
+            evidence: `phase=${eventDataString(e, 'phase') ?? '?'} wave=${e.data.wave ?? '?'} at=${e.timestamp}`,
+            evidenceFingerprint: fingerprint(
+                `WAVE_BLOCKED:${eventDataString(e, 'phase') ?? ''}:${e.data.wave ?? ''}`
+            ),
+        })
+    }
+
+    // 6. Pipeline re-entered (informational warning)
+    const reEntered = entries.filter((e) => e.event === 'pipeline-re-entered')
+    for (const e of reEntered) {
+        violations.push({
+            severity: 'warning',
+            code: 'PIPELINE_RE_ENTERED',
+            message: `Pipeline was re-entered mid-run (often indicates rework).`,
+            evidence: `targetMode=${eventDataString(e, 'targetMode') ?? '?'} reason=${eventDataString(e, 'reason') ?? '?'}`,
+            evidenceFingerprint: fingerprint(
+                `REENTRY:${e.timestamp}:${eventDataString(e, 'targetMode') ?? ''}`
+            ),
+        })
+    }
+
+    // 7. Pipeline-guard idle bypass (warning — silent skip risk)
+    const idleBypass = entries.filter(
+        (e) => e.event === 'pipeline-guard-idle-bypass'
+    )
+    for (const e of idleBypass) {
+        violations.push({
+            severity: 'warning',
+            code: 'PIPELINE_GUARD_IDLE_BYPASS',
+            message: `Pipeline-guard skipped enforcement because pipelineStep was idle. May indicate stale state contamination.`,
+            evidence: `at=${e.timestamp}`,
+            evidenceFingerprint: fingerprint(
+                `IDLE_BYPASS:${e.timestamp}`
+            ),
+        })
+    }
+
+    // ── Metrics ───────────────────────────────────────────────────────────
+    const metrics = {
+        totalEvents: entries.length,
+        modeTransitions: entries.filter((e) => e.event === 'mode-transition')
+            .length,
+        phasesCompleted: entries.filter((e) => e.event === 'phase-complete')
+            .length,
+        emptyPhasesJustified: entries.filter(
+            (e) => e.event === 'phase-empty-justification'
+        ).length,
+        todosMovedToDone: entries.filter((e) => e.event === 'todo-moved-to-done')
+            .length,
+        lowConfidenceCount: lowConfidence.length,
+        forcedTransitions: forced.length,
+        moveBlockedCount: moveBlocked.length,
+    }
+
+    // ── Pitfall payloads (default vault) ──────────────────────────────────
+    const critical = violations.filter((v) => v.severity === 'critical')
+    const pitfalls = critical.map((v) => ({
+        vault: 'default' as const,
+        concept: `pitfall:${v.code.toLowerCase().replace(/_/g, '-')}`,
+        type: 'pitfall' as const,
+        content: `## ${v.code}\n\n${v.message}\n\n**Evidence**: ${v.evidence}\n\n**Run**: ${targetRunId}`,
+        tags: [
+            'luca',
+            'pipeline',
+            'postmortem',
+            v.code.toLowerCase(),
+        ] as string[],
+        op_id: `${targetRunId}:${v.code}:${v.evidenceFingerprint}`,
+    }))
+
+    return {
+        runId: targetRunId,
+        startedAt,
+        endedAt,
+        durationMs,
+        phases,
+        violations,
+        metrics,
+        pitfalls,
+    }
+}
+
+/**
+ * Walk backwards through ledger entries from `at` to find the most recent
+ * `phase-start` event. Used to attribute todo-moved-to-done events to a phase.
+ */
+function mostRecentPhaseAt(
+    entries: LedgerEntry[],
+    at: string
+): string | undefined {
+    const target = new Date(at).getTime()
+    let best: string | undefined
+    for (const e of entries) {
+        if (e.event !== 'phase-start') continue
+        if (new Date(e.timestamp).getTime() > target) break
+        const name = eventDataString(e, 'phase')
+        if (name) best = name
+    }
+    return best
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+const POSTMORTEM_FILE = '.planning/POSTMORTEM.md'
+
+function ensurePlanningDir(): void {
+    const dir = join(process.cwd(), '.planning')
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+}
+
+export function renderPostmortemMarkdown(report: PostmortemReport): string {
+    const lines: string[] = []
+    lines.push(`# Postmortem — Run ${report.runId}`)
+    lines.push('')
+    lines.push(`- **Started**: ${report.startedAt ?? 'unknown'}`)
+    lines.push(`- **Ended**: ${report.endedAt ?? 'unknown'}`)
+    if (report.durationMs !== undefined) {
+        const mins = Math.round(report.durationMs / 60_000)
+        lines.push(`- **Duration**: ${mins} min`)
+    }
+    lines.push('')
+
+    // Violations summary
+    const critical = report.violations.filter((v) => v.severity === 'critical')
+    const warnings = report.violations.filter((v) => v.severity === 'warning')
+    lines.push(`## Violations`)
+    lines.push('')
+    lines.push(`- **Critical**: ${critical.length}`)
+    lines.push(`- **Warning**: ${warnings.length}`)
+    lines.push('')
+
+    if (report.violations.length > 0) {
+        lines.push(`| Severity | Code | Message |`)
+        lines.push(`| --- | --- | --- |`)
+        for (const v of report.violations) {
+            const msg = v.message.replace(/\|/g, '\\|')
+            lines.push(`| ${v.severity} | \`${v.code}\` | ${msg} |`)
+        }
+        lines.push('')
+    }
+
+    // Per-phase summary
+    lines.push(`## Phases`)
+    lines.push('')
+    if (report.phases.length === 0) {
+        lines.push('_No phases recorded._')
+        lines.push('')
+    }
+    for (const p of report.phases) {
+        lines.push(`### ${p.name}`)
+        lines.push('')
+        lines.push(
+            `- Started: ${p.startedAt ?? '?'} | Completed: ${p.completedAt ?? '?'}`
+        )
+        if (p.diff) {
+            const status = p.diff.indeterminate
+                ? '_(indeterminate — non-git or no snapshot)_'
+                : p.diff.isEmpty
+                  ? '⚠ EMPTY'
+                  : `${p.diff.filesChanged.length} files, ${p.diff.commitsAdded.length} commits`
+            lines.push(`- Diff: ${status}`)
+        }
+        if (p.justification) {
+            lines.push(
+                `- Empty-phase justification: \`${p.justification.category}\` — ${p.justification.reasoning}`
+            )
+        }
+        if (p.verifications.length > 0) {
+            const verdicts = p.verifications
+                .map((v) => `wave ${v.wave}: ${v.status}`)
+                .join(', ')
+            lines.push(`- Verifications: ${verdicts}`)
+        }
+        if (p.todosMovedToDone.length > 0) {
+            lines.push(
+                `- Todos moved to done: ${p.todosMovedToDone.map((t) => t.slug).join(', ')}`
+            )
+        }
+        lines.push('')
+    }
+
+    // Metrics
+    lines.push(`## Metrics`)
+    lines.push('')
+    for (const [k, v] of Object.entries(report.metrics)) {
+        lines.push(`- **${k}**: ${v}`)
+    }
+    lines.push('')
+
+    // Next steps
+    lines.push(`## What to do next`)
+    lines.push('')
+    if (critical.length > 0) {
+        lines.push(
+            `- 🛑 **Critical violations present.** Finalize cannot create a PR until these are resolved. Re-enter pipeline at execute or review.`
+        )
+    } else if (warnings.length > 0) {
+        lines.push(
+            `- ⚠ Warnings present but non-blocking. Review the table above before merging.`
+        )
+    } else {
+        lines.push(`- ✅ No violations detected. Run is clean.`)
+    }
+    lines.push('')
+
+    return lines.join('\n')
+}
+
+export function writePostmortem(report: PostmortemReport): {
+    path: string
+    bytes: number
+} {
+    ensurePlanningDir()
+    const md = renderPostmortemMarkdown(report)
+    const p = join(process.cwd(), POSTMORTEM_FILE)
+    writeFileSync(p, md, 'utf-8')
+    return { path: POSTMORTEM_FILE, bytes: md.length }
+}
+
+export function readPostmortem(): string | null {
+    const p = join(process.cwd(), POSTMORTEM_FILE)
+    if (!existsSync(p)) return null
+    try {
+        return readFileSync(p, 'utf-8')
+    } catch {
+        return null
+    }
+}
+
+export { listRuns }

--- a/packages/luca-mastracode/src/postmortem.ts
+++ b/packages/luca-mastracode/src/postmortem.ts
@@ -259,15 +259,21 @@ export function analyzeRun(runId?: string): PostmortemReport {
     const violations: Violation[] = []
 
     // 1. Empty phase without justification
+    //
+    // Only consider phases that *actually completed*. A blocked
+    // `complete-phase` attempt still writes a `phase-diff-summary`
+    // entry, but the phase itself never finished — flagging it as
+    // critical would double-count an already-blocked unsafe action.
     for (const p of phases) {
+        if (!p.completedAt) continue
         if (p.diff?.isEmpty && !p.justification) {
             violations.push({
                 severity: 'critical',
                 code: 'EMPTY_PHASE_NO_JUSTIFICATION',
                 message: `Phase "${p.name}" completed with zero file changes and zero commits but has no phase-empty-justification entry.`,
-                evidence: `phase=${p.name} completedAt=${p.completedAt ?? '?'}`,
+                evidence: `phase=${p.name} completedAt=${p.completedAt}`,
                 evidenceFingerprint: fingerprint(
-                    `EMPTY_PHASE:${p.name}:${p.completedAt ?? ''}`
+                    `EMPTY_PHASE:${p.name}:${p.completedAt}`
                 ),
             })
         }

--- a/packages/luca-mastracode/src/postmortem.ts
+++ b/packages/luca-mastracode/src/postmortem.ts
@@ -26,6 +26,10 @@ import {
     readLedgerForRun,
     getCurrentRunId,
     listRuns,
+    listArchivedRuns,
+    resolveRunArtifactDir,
+    readJsonlAt,
+    ARTIFACT_FILES,
     type LedgerEntry,
 } from './session-ledger.js'
 import {
@@ -131,10 +135,44 @@ function eventDataString(e: LedgerEntry, key: string): string | undefined {
 
 export function analyzeRun(runId?: string): PostmortemReport {
     const targetRunId = runId ?? getCurrentRunId()
-    const all = readLedger()
-    const entries = runId
-        ? readLedgerForRun(targetRunId)
-        : all.filter((e) => e.runId === targetRunId)
+    const currentRunId = getCurrentRunId()
+    const isCurrentRun = targetRunId === currentRunId
+
+    // For the current run, read live `.planning/*.jsonl` artifacts.
+    // For archived runs, read from `.planning/runs/<runId>/` so we don't
+    // mix in entries from a later run that's now occupying the live files.
+    let entries: LedgerEntry[]
+    let verifications: VerificationResult[]
+    let confidence: ConfidenceEntry[]
+
+    if (isCurrentRun) {
+        const all = readLedger()
+        entries = all.filter((e) => e.runId === targetRunId)
+        verifications = readVerificationHistory()
+        confidence = readConfidenceJournal()
+    } else {
+        const archiveDir = resolveRunArtifactDir(targetRunId)
+        if (archiveDir) {
+            entries = readJsonlAt<LedgerEntry>(
+                archiveDir,
+                ARTIFACT_FILES.ledger
+            ).filter((e) => e.runId === targetRunId)
+            verifications = readJsonlAt<VerificationResult>(
+                archiveDir,
+                ARTIFACT_FILES.verification
+            )
+            confidence = readJsonlAt<ConfidenceEntry>(
+                archiveDir,
+                ARTIFACT_FILES.confidence
+            )
+        } else {
+            // Fall back to filtering the live ledger if no archive exists
+            // (e.g. user passed a runId that's still in the live file).
+            entries = readLedgerForRun(targetRunId)
+            verifications = []
+            confidence = []
+        }
+    }
 
     const startedAt = entries[0]?.timestamp
     const endedAt = entries[entries.length - 1]?.timestamp
@@ -142,9 +180,6 @@ export function analyzeRun(runId?: string): PostmortemReport {
         startedAt && endedAt
             ? new Date(endedAt).getTime() - new Date(startedAt).getTime()
             : undefined
-
-    const verifications = readVerificationHistory()
-    const confidence = readConfidenceJournal()
 
     // ── Group events by phase ─────────────────────────────────────────────
     const phaseMap = new Map<string, PhaseSummary>()
@@ -238,13 +273,19 @@ export function analyzeRun(runId?: string): PostmortemReport {
         }
     }
 
-    // 2. Todos moved to done without verificationRef (or blocked attempts)
+    // 2. Todos moved to done without verificationRef
+    //
+    // Blocked attempts (`todo-move-blocked`) are downgraded to warnings —
+    // the gate already prevented the unsafe transition, so this is just
+    // signal that the agent tried something and got corrected. Only an
+    // actual unsafe transition (todo successfully moved to done without a
+    // verificationRef) is critical.
     const moveBlocked = entries.filter((e) => e.event === 'todo-move-blocked')
     for (const e of moveBlocked) {
         violations.push({
-            severity: 'critical',
+            severity: 'warning',
             code: 'TODO_DONE_NO_VERIFICATION',
-            message: `Blocked attempt to move todo "${eventDataString(e, 'identifier') ?? '?'}" to done without a valid verificationRef.`,
+            message: `Blocked attempt to move todo "${eventDataString(e, 'identifier') ?? '?'}" to done without a valid verificationRef. Tool layer prevented the unsafe transition.`,
             evidence: `reason=${eventDataString(e, 'reason') ?? '?'} at=${e.timestamp}`,
             evidenceFingerprint: fingerprint(
                 `TODO_BLOCKED:${eventDataString(e, 'identifier') ?? ''}:${e.timestamp}`
@@ -252,6 +293,7 @@ export function analyzeRun(runId?: string): PostmortemReport {
         })
     }
     // Belt-and-suspenders: any todos-moved-to-done with falsy verificationRef
+    // are real unsafe transitions and must remain critical.
     for (const p of phases) {
         for (const t of p.todosMovedToDone) {
             if (!t.verificationRef) {
@@ -300,15 +342,17 @@ export function analyzeRun(runId?: string): PostmortemReport {
         })
     }
 
-    // 5. Wave advance blocked
+    // 5. Wave advance blocked — downgraded to warning because the tool
+    // layer already prevented the unsafe transition. The presence of a
+    // block tells us the agent tried, but it didn't actually advance.
     const waveBlocked = entries.filter(
         (e) => e.event === 'wave-advance-blocked'
     )
     for (const e of waveBlocked) {
         violations.push({
-            severity: 'critical',
+            severity: 'warning',
             code: 'WAVE_NO_VERIFICATION',
-            message: `Attempt to advance wave without verification-result.`,
+            message: `Blocked attempt to advance wave without verification-result. Tool layer prevented the unsafe transition.`,
             evidence: `phase=${eventDataString(e, 'phase') ?? '?'} wave=${e.data.wave ?? '?'} at=${e.timestamp}`,
             evidenceFingerprint: fingerprint(
                 `WAVE_BLOCKED:${eventDataString(e, 'phase') ?? ''}:${e.data.wave ?? ''}`

--- a/packages/luca-mastracode/src/pr-review/convergence.ts
+++ b/packages/luca-mastracode/src/pr-review/convergence.ts
@@ -223,11 +223,18 @@ export function detectConvergence(
     const groups = groupFindings(findings, tolerance)
     const convergentGroups = groups.filter((g) => g.perspectives.length >= 2)
     const promotions: ConvergencePromotion[] = []
-    const promoted: ReviewFinding[] = []
+
+    // Start with a copy of every input finding so non-convergent findings
+    // are never silently dropped from the output. We then overwrite entries
+    // belonging to convergent groups with their (possibly promoted) version.
+    const promoted: ReviewFinding[] = findings.map((f) => ({ ...f }))
+    const indexById = new Map<string, number>()
+    promoted.forEach((f, i) => indexById.set(f.id, i))
 
     for (const g of convergentGroups) {
         for (const f of g.findings) {
             const sev = f.severity.toLowerCase()
+            const idx = indexById.get(f.id)
             if (promotable.has(sev)) {
                 promotions.push({
                     findingId: f.id,
@@ -237,7 +244,9 @@ export function detectConvergence(
                     reason: `Converged with ${g.perspectives.length} perspectives at ${g.path}:${g.minLine}-${g.maxLine}: ${g.perspectives.join(', ')}.`,
                     groupKey: g.key,
                 })
-                promoted.push({ ...f, severity: 'must-fix' })
+                if (idx !== undefined) {
+                    promoted[idx] = { ...f, severity: 'must-fix' }
+                }
             } else if (sev === 'must-fix' || sev === 'must' || sev === 'high' || sev === 'critical') {
                 // Already at or above must-fix; no promotion, but mark it so callers can render the convergence evidence.
                 promotions.push({
@@ -248,9 +257,6 @@ export function detectConvergence(
                     reason: `Already must-fix; converged with ${g.perspectives.length} perspectives at ${g.path}:${g.minLine}-${g.maxLine}: ${g.perspectives.join(', ')}.`,
                     groupKey: g.key,
                 })
-                promoted.push({ ...f })
-            } else {
-                promoted.push({ ...f })
             }
         }
     }

--- a/packages/luca-mastracode/src/pr-review/convergence.ts
+++ b/packages/luca-mastracode/src/pr-review/convergence.ts
@@ -1,0 +1,264 @@
+/**
+ * Cross-perspective convergence — when two or more independent reviewer
+ * perspectives flag the same location, that location is materially more
+ * likely to be a real issue. Auto-promote severity accordingly.
+ *
+ * Background: PR-review corpus shows that the harness currently treats
+ * each reviewer's findings as independent SHOULD-FIX items. When Copilot,
+ * a human reviewer, and the project's own claim-verifier all flag the
+ * same line, the harness still treats each as one signal. This bleeds
+ * iteration cycles and lets real issues slip through under "should-fix"
+ * categorization.
+ *
+ * A "perspective" is anything that produces a finding with a path/line:
+ *   - GitHub PR review comments (Copilot, humans, CodeRabbit, etc.)
+ *   - The project's claim-verifier output
+ *   - The Luca review-mode reviewer agent's MUST-FIX/SHOULD-FIX entries
+ *   - External CI annotations (e.g. lint, typecheck, test failures)
+ *
+ * Findings are grouped by (path, line ±LINE_TOLERANCE). When >= 2
+ * distinct perspectives target the same group, severity is promoted:
+ *   - any 'should-fix' or weaker finding in the group → 'must-fix'
+ *   - 'must-fix' findings get a 'must-fix-converged' marker but no further bump
+ *
+ * Pure data layer. Tool wrapper lives in tools/pr-review.ts.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * A finding from any reviewer perspective. Severity values are intentionally
+ * permissive strings so callers can map their own scales (Copilot's body text
+ * categorization, claim-verifier's reason codes, reviewer-agent labels).
+ */
+export interface ReviewFinding {
+    /** Stable id within a perspective. */
+    id: string
+    /** Which reviewer / source produced this. */
+    perspective: string
+    /** Repo-relative path the finding applies to. May be omitted for non-line findings. */
+    path?: string
+    /** 1-indexed line number the finding applies to. May be omitted. */
+    line?: number
+    /** Free-form severity (e.g. 'must-fix', 'should-fix', 'nit', 'info', 'praise'). */
+    severity: string
+    /** Short categorization label (e.g. 'security', 'bug', 'style'). */
+    category?: string
+    /** Human-readable summary of the finding. */
+    summary: string
+}
+
+export interface ConvergenceGroup {
+    /** Stable group key for idempotent referencing. */
+    key: string
+    path: string
+    /** Anchor line — the median line of all findings in the group. */
+    anchorLine: number
+    /** Minimum line in the group. */
+    minLine: number
+    /** Maximum line in the group. */
+    maxLine: number
+    /** Distinct perspectives represented (e.g. ['Copilot', 'claim-verifier']). */
+    perspectives: string[]
+    /** All findings clustered into this group. */
+    findings: ReviewFinding[]
+}
+
+export interface ConvergencePromotion {
+    findingId: string
+    perspective: string
+    fromSeverity: string
+    toSeverity: string
+    reason: string
+    groupKey: string
+}
+
+export interface ConvergenceReport {
+    groups: ConvergenceGroup[]
+    /** Subset of groups that have >=2 distinct perspectives. */
+    convergentGroups: ConvergenceGroup[]
+    /** Severity promotions applied to findings. */
+    promotions: ConvergencePromotion[]
+    /** Findings with severity adjusted (originals are not mutated). */
+    promotedFindings: ReviewFinding[]
+}
+
+export interface DetectOptions {
+    /** Lines within +/- this distance of an anchor are considered "same location". Default 2. */
+    lineTolerance?: number
+    /**
+     * Severity levels considered weaker than 'must-fix' and eligible for promotion.
+     * Default: ['nit', 'info', 'optional', 'should-fix', 'style', 'improvement'].
+     */
+    promotableSeverities?: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEFAULT_LINE_TOLERANCE = 2
+
+const DEFAULT_PROMOTABLE: ReadonlySet<string> = new Set([
+    'nit',
+    'info',
+    'optional',
+    'should-fix',
+    'should',
+    'style',
+    'improvement',
+    'minor',
+    'low',
+])
+
+function median(nums: number[]): number {
+    if (nums.length === 0) return 0
+    const sorted = [...nums].sort((a, b) => a - b)
+    const mid = Math.floor(sorted.length / 2)
+    if (sorted.length % 2 === 0) {
+        const a = sorted[mid - 1] ?? 0
+        const b = sorted[mid] ?? 0
+        return Math.floor((a + b) / 2)
+    }
+    return sorted[mid] ?? 0
+}
+
+function distinctPerspectives(findings: ReviewFinding[]): string[] {
+    const set = new Set<string>()
+    for (const f of findings) set.add(f.perspective)
+    return [...set].sort()
+}
+
+// ---------------------------------------------------------------------------
+// Grouping
+// ---------------------------------------------------------------------------
+
+/**
+ * Greedy single-link clustering by line proximity. Findings on the same path
+ * whose line numbers fall within `lineTolerance` of any existing group member
+ * are merged into that group.
+ *
+ * Findings without a path or line are returned as singleton groups (so they
+ * can never converge with anything — convergence requires location).
+ */
+function groupFindings(
+    findings: ReviewFinding[],
+    lineTolerance: number
+): ConvergenceGroup[] {
+    const byPath = new Map<string, ReviewFinding[]>()
+    const orphaned: ReviewFinding[] = []
+    for (const f of findings) {
+        if (!f.path || f.line == null) {
+            orphaned.push(f)
+            continue
+        }
+        const arr = byPath.get(f.path) ?? []
+        arr.push(f)
+        byPath.set(f.path, arr)
+    }
+
+    const groups: ConvergenceGroup[] = []
+
+    for (const [path, items] of byPath) {
+        // Sort by line so single-link clustering is deterministic.
+        items.sort((a, b) => (a.line ?? 0) - (b.line ?? 0))
+        const buckets: ReviewFinding[][] = []
+        for (const f of items) {
+            const line = f.line ?? 0
+            // Try to attach to an existing bucket whose max line is within tolerance.
+            const target = buckets.find((b) => {
+                const maxLine = Math.max(...b.map((x) => x.line ?? 0))
+                return Math.abs(maxLine - line) <= lineTolerance
+            })
+            if (target) {
+                target.push(f)
+            } else {
+                buckets.push([f])
+            }
+        }
+        for (const b of buckets) {
+            const lines = b.map((x) => x.line ?? 0)
+            groups.push({
+                key: `${path}:${Math.min(...lines)}-${Math.max(...lines)}`,
+                path,
+                anchorLine: median(lines),
+                minLine: Math.min(...lines),
+                maxLine: Math.max(...lines),
+                perspectives: distinctPerspectives(b),
+                findings: b,
+            })
+        }
+    }
+
+    for (const f of orphaned) {
+        groups.push({
+            key: `orphan:${f.perspective}:${f.id}`,
+            path: f.path ?? '<no-path>',
+            anchorLine: f.line ?? 0,
+            minLine: f.line ?? 0,
+            maxLine: f.line ?? 0,
+            perspectives: [f.perspective],
+            findings: [f],
+        })
+    }
+
+    return groups
+}
+
+// ---------------------------------------------------------------------------
+// Detection + promotion
+// ---------------------------------------------------------------------------
+
+export function detectConvergence(
+    findings: ReviewFinding[],
+    opts: DetectOptions = {}
+): ConvergenceReport {
+    const tolerance = opts.lineTolerance ?? DEFAULT_LINE_TOLERANCE
+    const promotable = opts.promotableSeverities
+        ? new Set(opts.promotableSeverities.map((s) => s.toLowerCase()))
+        : DEFAULT_PROMOTABLE
+
+    const groups = groupFindings(findings, tolerance)
+    const convergentGroups = groups.filter((g) => g.perspectives.length >= 2)
+    const promotions: ConvergencePromotion[] = []
+    const promoted: ReviewFinding[] = []
+
+    for (const g of convergentGroups) {
+        for (const f of g.findings) {
+            const sev = f.severity.toLowerCase()
+            if (promotable.has(sev)) {
+                promotions.push({
+                    findingId: f.id,
+                    perspective: f.perspective,
+                    fromSeverity: f.severity,
+                    toSeverity: 'must-fix',
+                    reason: `Converged with ${g.perspectives.length} perspectives at ${g.path}:${g.minLine}-${g.maxLine}: ${g.perspectives.join(', ')}.`,
+                    groupKey: g.key,
+                })
+                promoted.push({ ...f, severity: 'must-fix' })
+            } else if (sev === 'must-fix' || sev === 'must' || sev === 'high' || sev === 'critical') {
+                // Already at or above must-fix; no promotion, but mark it so callers can render the convergence evidence.
+                promotions.push({
+                    findingId: f.id,
+                    perspective: f.perspective,
+                    fromSeverity: f.severity,
+                    toSeverity: f.severity,
+                    reason: `Already must-fix; converged with ${g.perspectives.length} perspectives at ${g.path}:${g.minLine}-${g.maxLine}: ${g.perspectives.join(', ')}.`,
+                    groupKey: g.key,
+                })
+                promoted.push({ ...f })
+            } else {
+                promoted.push({ ...f })
+            }
+        }
+    }
+
+    return {
+        groups,
+        convergentGroups,
+        promotions,
+        promotedFindings: promoted,
+    }
+}

--- a/packages/luca-mastracode/src/pr-review/regression.ts
+++ b/packages/luca-mastracode/src/pr-review/regression.ts
@@ -1,0 +1,235 @@
+/**
+ * Iteration-N regression check — detect when fix commits in a review
+ * iteration introduce *new* findings on the paths they touched.
+ *
+ * Background: across the PR-review corpus, a non-trivial fraction of
+ * "fix" commits introduce new issues that weren't flagged in the original
+ * review. The harness currently doesn't re-check after each iteration —
+ * fixes are pushed, replies are posted, the iteration is closed. New
+ * findings only surface in the *next* review pass, costing another full
+ * iteration cycle.
+ *
+ * This module is the deterministic delta layer:
+ *   - Inputs: pre-iteration findings, post-iteration findings, list of
+ *     paths modified by fix commits in this iteration.
+ *   - Outputs: which findings are regressions (new in post-set on a
+ *     touched path), which are resolved (gone from post-set), which are
+ *     unchanged (present in both).
+ *
+ * The "actually re-run the reviewer" part is the orchestration layer's
+ * job — pr-address.md tells the harness to snapshot, commit, re-fetch,
+ * then call this regression check on the delta.
+ *
+ * Pure data layer. Tool wrapper lives in tools/pr-review.ts.
+ */
+import type { ReviewFinding } from './convergence.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RegressionInputs {
+    /** Findings present BEFORE the fix iteration commits landed. */
+    before: ReviewFinding[]
+    /** Findings present AFTER the fix iteration commits landed. */
+    after: ReviewFinding[]
+    /** Repo-relative paths that were modified by fix commits in this iteration. */
+    touchedPaths: string[]
+}
+
+export interface RegressionFinding {
+    finding: ReviewFinding
+    /**
+     * Why we believe this is a regression:
+     *   - 'new-on-touched-path': a finding on a path the iteration modified that wasn't in the pre-iteration set
+     *   - 'severity-escalated': a finding with the same identity as one before, but at higher severity
+     */
+    reason: 'new-on-touched-path' | 'severity-escalated'
+    evidence: string
+}
+
+export interface RegressionReport {
+    /** Findings introduced by the fix iteration (true regressions). */
+    regressions: RegressionFinding[]
+    /** Findings that existed in `before` but are no longer in `after` — the iteration's wins. */
+    resolved: ReviewFinding[]
+    /** Findings present in both sets, unchanged. */
+    unchanged: ReviewFinding[]
+    /** Findings new in `after` but on paths the iteration did not touch — likely external (e.g. new CI rule), not a regression. */
+    newButUntouched: ReviewFinding[]
+}
+
+export interface RegressionOptions {
+    /**
+     * Severity ranking, lowest to highest. Used to detect escalation.
+     * Default: ['nit','info','optional','should-fix','must-fix','critical']
+     */
+    severityRank?: string[]
+    /** Treat a path as touched if it appears in any of these lists. */
+    touchedPathsAlias?: { [logical: string]: string[] }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEFAULT_SEVERITY_RANK: ReadonlyArray<string> = [
+    'praise',
+    'nit',
+    'info',
+    'optional',
+    'style',
+    'improvement',
+    'should-fix',
+    'should',
+    'must-fix',
+    'must',
+    'high',
+    'critical',
+]
+
+/**
+ * Stable identity for cross-snapshot matching. We can't use comment id
+ * because re-fetched findings may have different ids if the perspective
+ * regenerates them. Instead, identity is `(perspective, path, anchor-line, summary-prefix)`.
+ */
+export function findingIdentity(f: ReviewFinding): string {
+    const summaryPrefix = (f.summary ?? '').replace(/\s+/g, ' ').trim().slice(0, 80)
+    const anchor = f.line == null ? '?' : String(f.line)
+    return [f.perspective, f.path ?? '<no-path>', anchor, summaryPrefix].join('::')
+}
+
+function severityIndex(severity: string, ranking: ReadonlyArray<string>): number {
+    const idx = ranking.indexOf(severity.toLowerCase())
+    return idx === -1 ? 0 : idx
+}
+
+function pathIsTouched(
+    findingPath: string | undefined,
+    touched: ReadonlySet<string>
+): boolean {
+    if (!findingPath) return false
+    return touched.has(findingPath)
+}
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+export function checkRegression(
+    inputs: RegressionInputs,
+    opts: RegressionOptions = {}
+): RegressionReport {
+    const ranking = opts.severityRank ?? DEFAULT_SEVERITY_RANK
+    const touched = new Set(inputs.touchedPaths)
+
+    // Index `before` by identity. If multiple findings share an identity we
+    // keep the highest-severity one (worst case for the agent).
+    const beforeIndex = new Map<string, ReviewFinding>()
+    for (const f of inputs.before) {
+        const key = findingIdentity(f)
+        const existing = beforeIndex.get(key)
+        if (
+            !existing ||
+            severityIndex(f.severity, ranking) >
+                severityIndex(existing.severity, ranking)
+        ) {
+            beforeIndex.set(key, f)
+        }
+    }
+
+    const afterIndex = new Map<string, ReviewFinding>()
+    for (const f of inputs.after) {
+        const key = findingIdentity(f)
+        const existing = afterIndex.get(key)
+        if (
+            !existing ||
+            severityIndex(f.severity, ranking) >
+                severityIndex(existing.severity, ranking)
+        ) {
+            afterIndex.set(key, f)
+        }
+    }
+
+    const regressions: RegressionFinding[] = []
+    const unchanged: ReviewFinding[] = []
+    const newButUntouched: ReviewFinding[] = []
+    const resolved: ReviewFinding[] = []
+
+    // Findings in `before` no longer in `after` → resolved.
+    for (const [key, f] of beforeIndex) {
+        if (!afterIndex.has(key)) {
+            resolved.push(f)
+        }
+    }
+
+    // Findings in `after`:
+    //   - if not in `before` AND on touched path → regression (new-on-touched-path).
+    //   - if not in `before` AND on untouched path → newButUntouched.
+    //   - if in `before` with lower severity → regression (severity-escalated).
+    //   - if in `before` with same/lower severity → unchanged.
+    for (const [key, f] of afterIndex) {
+        const prev = beforeIndex.get(key)
+        if (!prev) {
+            if (pathIsTouched(f.path, touched)) {
+                regressions.push({
+                    finding: f,
+                    reason: 'new-on-touched-path',
+                    evidence: `New finding from '${f.perspective}' at ${f.path ?? '<no-path>'}:${f.line ?? '?'} on a path modified by this iteration.`,
+                })
+            } else {
+                newButUntouched.push(f)
+            }
+            continue
+        }
+        const prevSev = severityIndex(prev.severity, ranking)
+        const curSev = severityIndex(f.severity, ranking)
+        if (curSev > prevSev) {
+            regressions.push({
+                finding: f,
+                reason: 'severity-escalated',
+                evidence: `Severity escalated from '${prev.severity}' to '${f.severity}' on the same finding.`,
+            })
+        } else {
+            unchanged.push(f)
+        }
+    }
+
+    return { regressions, resolved, unchanged, newButUntouched }
+}
+
+// ---------------------------------------------------------------------------
+// Touched-path extraction helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the list of paths modified between two git refs. Returned paths
+ * are repo-relative. Returns an empty array on any git error (caller can
+ * decide whether to treat that as "nothing touched" or fall back to a
+ * different strategy).
+ *
+ * Implementation note: callers usually pass `before = baseBranch` and
+ * `after = HEAD`, but this is left to the caller because the right pair
+ * depends on the iteration boundary (e.g. the SHA at iteration-start vs.
+ * the latest fix-commit SHA).
+ */
+export function diffPaths(
+    repoRoot: string,
+    fromSha: string,
+    toSha: string
+): string[] {
+    // Lazy require so that pure consumers (like tests using only the
+    // data structures above) don't need git on PATH.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { spawnSync } = require('node:child_process') as typeof import('node:child_process')
+    const r = spawnSync('git', ['diff', '--name-only', `${fromSha}..${toSha}`], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        timeout: 5000,
+    })
+    if (r.status !== 0) return []
+    return (r.stdout ?? '')
+        .split('\n')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+}

--- a/packages/luca-mastracode/src/pr-review/regression.ts
+++ b/packages/luca-mastracode/src/pr-review/regression.ts
@@ -22,6 +22,8 @@
  *
  * Pure data layer. Tool wrapper lives in tools/pr-review.ts.
  */
+import { spawnSync } from 'node:child_process'
+
 import type { ReviewFinding } from './convergence.js'
 
 // ---------------------------------------------------------------------------
@@ -218,10 +220,6 @@ export function diffPaths(
     fromSha: string,
     toSha: string
 ): string[] {
-    // Lazy require so that pure consumers (like tests using only the
-    // data structures above) don't need git on PATH.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { spawnSync } = require('node:child_process') as typeof import('node:child_process')
     const r = spawnSync('git', ['diff', '--name-only', `${fromSha}..${toSha}`], {
         cwd: repoRoot,
         encoding: 'utf8',

--- a/packages/luca-mastracode/src/pr-review/stale-filter.ts
+++ b/packages/luca-mastracode/src/pr-review/stale-filter.ts
@@ -1,0 +1,382 @@
+/**
+ * Stale-comment filter — identify PR review comments that no longer apply
+ * because the cited code has changed since the comment was filed.
+ *
+ * Background: across the PR-review corpus, ~57% of Copilot inline comments
+ * on iterated PRs are stale — they point at code that has already been
+ * changed by an earlier fix iteration. Treating them as still-actionable
+ * causes the iteration loop to spend cycles on already-fixed issues, post
+ * confused replies, and conflate stale findings with current ones.
+ *
+ * A comment is considered stale when ANY of the following hold:
+ *   1. The cited file no longer exists in the working tree.
+ *   2. The diff_hunk's "after" lines no longer appear at or near the
+ *      cited line in the current working tree (line drift > 5 lines or
+ *      content mismatch).
+ *   3. The comment's commit_id is older than HEAD AND the cited path was
+ *      modified between commit_id and HEAD AND the line content has
+ *      changed.
+ *
+ * Pure data layer. Tool wrapper lives in tools/pr-review.ts.
+ */
+import { spawnSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal PR review comment shape — the subset of GitHub API fields we need.
+ * Matches `gh api repos/{owner}/{repo}/pulls/{n}/comments` response items.
+ */
+export interface PrReviewComment {
+    id: number
+    path: string
+    /** 1-indexed line in the file at `commit_id`. May be null for outdated comments. */
+    line: number | null
+    /** 1-indexed line at `original_commit_id` (when comment was first filed). */
+    original_line: number | null
+    /** Most recent commit the comment is anchored to. */
+    commit_id: string
+    /** Commit at which the comment was originally filed. */
+    original_commit_id: string
+    /** The unified diff hunk shown in the comment ("@@ ... @@\n + ..." etc.). */
+    diff_hunk: string
+    /** Comment body. */
+    body: string
+    /** Reply-to relationship; replies are not first-class findings. */
+    in_reply_to_id?: number | null
+    /** Author. */
+    user?: { login?: string; type?: string }
+}
+
+export type StaleReason =
+    | 'file-missing'
+    | 'line-out-of-range'
+    | 'content-mismatch'
+    | 'commit-outdated-and-path-modified'
+
+export interface StaleVerdict {
+    commentId: number
+    stale: boolean
+    reason?: StaleReason
+    evidence: string
+    /** Best-effort line where the original anchored content currently lives, if found. */
+    currentLine?: number
+}
+
+export interface FilterResult {
+    /** Comments judged still-applicable. */
+    actionable: PrReviewComment[]
+    /** Comments judged stale, with reasons. */
+    stale: Array<{ comment: PrReviewComment; verdict: StaleVerdict }>
+    /** Replies (in_reply_to_id !== null) — pass through, not first-class findings. */
+    replies: PrReviewComment[]
+    /** Audit verdicts for every input comment, keyed by commentId. */
+    verdicts: Record<number, StaleVerdict>
+}
+
+// ---------------------------------------------------------------------------
+// Diff hunk parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the "added" / context lines from a unified diff hunk that represent
+ * the state of the file AT the comment's commit_id. These are the lines a
+ * human would see when viewing the comment — the post-diff version.
+ *
+ * GitHub's `diff_hunk` looks like:
+ *   @@ -10,5 +10,7 @@ context
+ *    unchanged line
+ *   -removed line
+ *   +added line
+ *   +another added line
+ *    unchanged line
+ *
+ * For staleness detection we want lines that exist in the post-state:
+ * unchanged (' ') and added ('+'). Removed lines ('-') are not in the
+ * current file and aren't useful anchors.
+ */
+export function extractHunkAnchorLines(diffHunk: string): string[] {
+    const lines = diffHunk.split('\n')
+    const anchors: string[] = []
+    for (const line of lines) {
+        if (line.startsWith('@@')) continue
+        if (line.startsWith('-')) continue
+        // ' ' (context) and '+' (added) are present in the post-state.
+        if (line.startsWith(' ') || line.startsWith('+')) {
+            anchors.push(line.slice(1))
+        } else if (line.length === 0) {
+            // Empty hunk line — keep as anchor so we don't lose alignment.
+            anchors.push('')
+        }
+    }
+    // Trailing trim — GitHub sometimes appends an empty line.
+    while (anchors.length > 0 && anchors[anchors.length - 1] === '') {
+        anchors.pop()
+    }
+    return anchors
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function readFileLines(repoRoot: string, relPath: string): string[] | null {
+    const full = join(repoRoot, relPath)
+    if (!existsSync(full)) return null
+    try {
+        return readFileSync(full, 'utf8').split('\n')
+    } catch {
+        return null
+    }
+}
+
+interface GitInvokeResult {
+    ok: boolean
+    stdout: string
+}
+
+function git(repoRoot: string, args: string[], timeoutMs = 5000): GitInvokeResult {
+    try {
+        const r = spawnSync('git', args, {
+            cwd: repoRoot,
+            encoding: 'utf8',
+            timeout: timeoutMs,
+        })
+        if (r.status !== 0) return { ok: false, stdout: '' }
+        return { ok: true, stdout: r.stdout ?? '' }
+    } catch {
+        return { ok: false, stdout: '' }
+    }
+}
+
+function isCommitReachable(repoRoot: string, sha: string): boolean {
+    if (!sha) return false
+    return git(repoRoot, ['cat-file', '-e', `${sha}^{commit}`]).ok
+}
+
+function pathChangedBetween(
+    repoRoot: string,
+    fromSha: string,
+    toSha: string,
+    path: string
+): boolean {
+    const r = git(repoRoot, ['diff', '--name-only', `${fromSha}..${toSha}`, '--', path])
+    if (!r.ok) return false
+    return r.stdout.split('\n').some((l) => l.trim() === path)
+}
+
+function getHeadSha(repoRoot: string): string | undefined {
+    const r = git(repoRoot, ['rev-parse', 'HEAD'])
+    if (!r.ok) return undefined
+    return r.stdout.trim() || undefined
+}
+
+/**
+ * Find the best-matching contiguous run of anchor lines in `fileLines`,
+ * preferring matches near `expectedLine`. Returns the 1-indexed start line
+ * of the match, or undefined if no acceptable match exists.
+ *
+ * "Acceptable" means: at least 60% of anchors match exactly in order at
+ * a contiguous offset, with no more than 2 intervening mismatches. This
+ * tolerates whitespace tweaks and comment edits that don't change the
+ * cited code's identity.
+ */
+export function findAnchorInFile(
+    fileLines: string[],
+    anchors: string[],
+    expectedLine: number | null
+): { line: number; matchedRatio: number } | undefined {
+    const meaningfulAnchors = anchors.filter((a) => a.trim().length > 0)
+    if (meaningfulAnchors.length === 0) return undefined
+
+    // Search window — prefer ±50 lines around expectedLine, fall back to whole file.
+    const expected = expectedLine ?? 1
+    const windowSize = 50
+    const windowStart = Math.max(0, expected - 1 - windowSize)
+    const windowEnd = Math.min(fileLines.length, expected - 1 + windowSize)
+
+    type Candidate = { line: number; matchedRatio: number }
+
+    function scoreAt(startIdx: number): Candidate | undefined {
+        let matched = 0
+        let mismatches = 0
+        let cursor = startIdx
+        for (const anchor of meaningfulAnchors) {
+            // Search forward up to 3 lines for this anchor.
+            let found = -1
+            for (let probe = 0; probe < 4 && cursor + probe < fileLines.length; probe++) {
+                if (fileLines[cursor + probe] === anchor) {
+                    found = probe
+                    break
+                }
+            }
+            if (found === -1) {
+                mismatches++
+                if (mismatches > 2) return undefined
+                cursor++
+                continue
+            }
+            matched++
+            cursor += found + 1
+        }
+        const ratio = matched / meaningfulAnchors.length
+        if (ratio < 0.6) return undefined
+        return { line: startIdx + 1, matchedRatio: ratio }
+    }
+
+    let best: Candidate | undefined
+    for (let i = windowStart; i < windowEnd; i++) {
+        const c = scoreAt(i)
+        if (!c) continue
+        if (!best || c.matchedRatio > best.matchedRatio || Math.abs(c.line - expected) < Math.abs(best.line - expected)) {
+            best = c
+        }
+    }
+    if (best) return best
+
+    // Fallback: search whole file for highest-ratio match.
+    for (let i = 0; i < fileLines.length; i++) {
+        if (i >= windowStart && i < windowEnd) continue
+        const c = scoreAt(i)
+        if (!c) continue
+        if (!best || c.matchedRatio > best.matchedRatio) {
+            best = c
+        }
+    }
+    return best
+}
+
+// ---------------------------------------------------------------------------
+// Per-comment staleness verdict
+// ---------------------------------------------------------------------------
+
+export interface VerdictOptions {
+    repoRoot: string
+    /** HEAD SHA. Defaults to `git rev-parse HEAD`. */
+    headSha?: string
+    /** Maximum line drift (in lines) before a relocated anchor is considered stale. */
+    maxDriftLines?: number
+}
+
+export function verdictFor(
+    comment: PrReviewComment,
+    opts: VerdictOptions
+): StaleVerdict {
+    const { repoRoot } = opts
+    const maxDrift = opts.maxDriftLines ?? 5
+
+    // 1. File missing → stale.
+    const fileLines = readFileLines(repoRoot, comment.path)
+    if (!fileLines) {
+        return {
+            commentId: comment.id,
+            stale: true,
+            reason: 'file-missing',
+            evidence: `Cited path '${comment.path}' no longer exists in the working tree.`,
+        }
+    }
+
+    // 2. Try to anchor the comment via diff_hunk.
+    const anchors = extractHunkAnchorLines(comment.diff_hunk)
+    const expectedLine = comment.line ?? comment.original_line
+    const match = findAnchorInFile(fileLines, anchors, expectedLine)
+
+    if (!match) {
+        return {
+            commentId: comment.id,
+            stale: true,
+            reason: 'content-mismatch',
+            evidence: `Diff hunk anchors not found in current '${comment.path}'. The cited code has likely been rewritten or removed.`,
+        }
+    }
+
+    if (expectedLine != null) {
+        const drift = Math.abs(match.line - expectedLine)
+        if (drift > maxDrift) {
+            return {
+                commentId: comment.id,
+                stale: true,
+                reason: 'line-out-of-range',
+                evidence: `Cited line ${expectedLine} differs from current anchor location ${match.line} by ${drift} lines (> ${maxDrift}).`,
+                currentLine: match.line,
+            }
+        }
+    }
+
+    // 3. Commit-id outdated AND path modified between commit_id and HEAD.
+    const headSha = opts.headSha ?? getHeadSha(repoRoot)
+    if (
+        headSha &&
+        comment.commit_id &&
+        comment.commit_id !== headSha &&
+        isCommitReachable(repoRoot, comment.commit_id) &&
+        pathChangedBetween(repoRoot, comment.commit_id, headSha, comment.path)
+    ) {
+        // Still anchored, but path changed — confirm by re-checking match ratio.
+        if (match.matchedRatio < 0.85) {
+            return {
+                commentId: comment.id,
+                stale: true,
+                reason: 'commit-outdated-and-path-modified',
+                evidence: `Path '${comment.path}' was modified between commit ${comment.commit_id.slice(0, 7)} and HEAD ${headSha.slice(0, 7)} and only ${(match.matchedRatio * 100).toFixed(0)}% of anchors match. Likely stale.`,
+                currentLine: match.line,
+            }
+        }
+    }
+
+    return {
+        commentId: comment.id,
+        stale: false,
+        evidence: `Anchored at line ${match.line} (${(match.matchedRatio * 100).toFixed(0)}% match).`,
+        currentLine: match.line,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Filter
+// ---------------------------------------------------------------------------
+
+export interface FilterOptions {
+    repoRoot: string
+    /** HEAD SHA. Defaults to current `git rev-parse HEAD`. */
+    headSha?: string
+    /** Maximum line drift before treating a relocated anchor as stale. */
+    maxDriftLines?: number
+}
+
+export function filterStaleComments(
+    comments: PrReviewComment[],
+    opts: FilterOptions
+): FilterResult {
+    const headSha = opts.headSha ?? getHeadSha(opts.repoRoot)
+    const verdictOpts: VerdictOptions = {
+        repoRoot: opts.repoRoot,
+        headSha,
+        maxDriftLines: opts.maxDriftLines,
+    }
+
+    const actionable: PrReviewComment[] = []
+    const stale: FilterResult['stale'] = []
+    const replies: PrReviewComment[] = []
+    const verdicts: Record<number, StaleVerdict> = {}
+
+    for (const c of comments) {
+        if (c.in_reply_to_id != null) {
+            replies.push(c)
+            continue
+        }
+        const v = verdictFor(c, verdictOpts)
+        verdicts[c.id] = v
+        if (v.stale) {
+            stale.push({ comment: c, verdict: v })
+        } else {
+            actionable.push(c)
+        }
+    }
+
+    return { actionable, stale, replies, verdicts }
+}

--- a/packages/luca-mastracode/src/retro.ts
+++ b/packages/luca-mastracode/src/retro.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env bun
+/**
+ * Luca retro — retrospective inspection CLI for a Luca pipeline run.
+ *
+ * Reads `.planning/` artifacts in the current working directory and prints
+ * either:
+ *   • the rendered POSTMORTEM.md (default), or
+ *   • a list of archived runs (`--list`), or
+ *   • a structured JSON report (`--json`).
+ *
+ * This entrypoint is intentionally separate from `launch.ts` so that
+ * `luca retro` can run without booting the full Mastra harness.
+ *
+ * Usage:
+ *   bun run packages/luca-mastracode/src/retro.ts            # current run
+ *   bun run packages/luca-mastracode/src/retro.ts --list     # list runs
+ *   bun run packages/luca-mastracode/src/retro.ts --run <id> # specific run
+ *   bun run packages/luca-mastracode/src/retro.ts --json     # JSON report
+ */
+import { analyzeRun, renderPostmortemMarkdown } from './postmortem.js'
+import { listRuns } from './session-ledger.js'
+
+interface ParsedArgs {
+    list: boolean
+    json: boolean
+    runId?: string
+    help: boolean
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+    const out: ParsedArgs = { list: false, json: false, help: false }
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i]
+        if (a === '--list') out.list = true
+        else if (a === '--json') out.json = true
+        else if (a === '--help' || a === '-h') out.help = true
+        else if (a === '--run' || a === '--run-id') {
+            const next = argv[i + 1]
+            if (next && !next.startsWith('--')) {
+                out.runId = next
+                i++
+            }
+        }
+    }
+    return out
+}
+
+function printHelp(): void {
+    console.log(
+        [
+            'luca retro — inspect a Luca pipeline run',
+            '',
+            'Reads `.planning/` artifacts in the current working directory.',
+            '',
+            'Usage:',
+            '  luca retro                 Render the current run as Markdown',
+            '  luca retro --list          List archived runs in the ledger',
+            '  luca retro --run <id>      Render a specific run',
+            '  luca retro --json          Emit the structured report as JSON',
+            '  luca retro --help          Show this help',
+        ].join('\n')
+    )
+}
+
+const args = parseArgs(process.argv.slice(2))
+
+if (args.help) {
+    printHelp()
+    process.exit(0)
+}
+
+if (args.list) {
+    const runs = listRuns()
+    if (runs.length === 0) {
+        console.log('No runs recorded in .planning/session-ledger.jsonl.')
+        process.exit(0)
+    }
+    const sorted = [...runs].sort((a, b) =>
+        a.firstEvent.localeCompare(b.firstEvent)
+    )
+    console.log('Runs:')
+    for (const r of sorted) {
+        console.log(
+            `  ${r.runId}  events=${r.eventCount}  ${r.firstEvent} → ${r.lastEvent}`
+        )
+    }
+    process.exit(0)
+}
+
+const report = analyzeRun(args.runId)
+
+if (args.json) {
+    console.log(JSON.stringify(report, null, 2))
+    process.exit(0)
+}
+
+console.log(renderPostmortemMarkdown(report))
+const critical = report.violations.filter((v) => v.severity === 'critical')
+process.exit(critical.length > 0 ? 1 : 0)

--- a/packages/luca-mastracode/src/retro.ts
+++ b/packages/luca-mastracode/src/retro.ts
@@ -18,7 +18,7 @@
  *   bun run packages/luca-mastracode/src/retro.ts --json     # JSON report
  */
 import { analyzeRun, renderPostmortemMarkdown } from './postmortem.js'
-import { listRuns } from './session-ledger.js'
+import { listRuns, listArchivedRuns } from './session-ledger.js'
 
 interface ParsedArgs {
     list: boolean
@@ -70,19 +70,38 @@ if (args.help) {
 }
 
 if (args.list) {
-    const runs = listRuns()
-    if (runs.length === 0) {
-        console.log('No runs recorded in .planning/session-ledger.jsonl.')
+    // Live runs: present in the current `.planning/session-ledger.jsonl`.
+    // Archived runs: directories under `.planning/runs/` from previous
+    // pipeline-reset archival. Both are valid targets for `--run <id>`.
+    const liveRuns = listRuns()
+    const liveIds = new Set(liveRuns.map((r) => r.runId))
+    const archivedOnly = listArchivedRuns().filter((id) => !liveIds.has(id))
+
+    if (liveRuns.length === 0 && archivedOnly.length === 0) {
+        console.log(
+            'No runs recorded in .planning/session-ledger.jsonl or .planning/runs/.'
+        )
         process.exit(0)
     }
-    const sorted = [...runs].sort((a, b) =>
-        a.firstEvent.localeCompare(b.firstEvent)
-    )
-    console.log('Runs:')
-    for (const r of sorted) {
-        console.log(
-            `  ${r.runId}  events=${r.eventCount}  ${r.firstEvent} → ${r.lastEvent}`
+
+    if (liveRuns.length > 0) {
+        const sorted = [...liveRuns].sort((a, b) =>
+            a.firstEvent.localeCompare(b.firstEvent)
         )
+        console.log('Live runs (in current ledger):')
+        for (const r of sorted) {
+            console.log(
+                `  ${r.runId}  events=${r.eventCount}  ${r.firstEvent} → ${r.lastEvent}`
+            )
+        }
+    }
+
+    if (archivedOnly.length > 0) {
+        if (liveRuns.length > 0) console.log('')
+        console.log('Archived runs (in .planning/runs/):')
+        for (const id of [...archivedOnly].sort()) {
+            console.log(`  ${id}`)
+        }
     }
     process.exit(0)
 }

--- a/packages/luca-mastracode/src/rules/define-rule.ts
+++ b/packages/luca-mastracode/src/rules/define-rule.ts
@@ -1,0 +1,113 @@
+/**
+ * defineRule — schema and type contract for repo-local rule packs.
+ *
+ * Rules live in `.luca/rules/*.ts` in the consuming repo. Each file
+ * default-exports (or named-exports) one or more rules built with
+ * `defineRule`. The harness discovers them at execute-verify time and
+ * runs each rule against every file matching its `scope` glob.
+ *
+ * Rules return `RuleFinding[]` whose shape is intentionally compatible
+ * with the `ReviewFinding` type in `pr-review/convergence.ts` so the
+ * convergence detector can treat rule findings as a first-class
+ * reviewer perspective.
+ *
+ * The `RuleFile` argument is hybrid: rules get raw `content` for cheap
+ * regex checks, plus a lazy `ast()` getter for rules that need
+ * structural matching. Parsing only happens when a rule actually calls
+ * `ast()`, so simple rules stay fast.
+ */
+import type ts from 'typescript'
+
+export type RuleSeverity =
+    | 'must-fix'
+    | 'should-fix'
+    | 'nit'
+    | 'info'
+
+export interface RuleFinding {
+    /** Stable id — typically `<rule.id>:<path>:<line>`. */
+    id: string
+    /** Path relative to repo root. */
+    path: string
+    /** 1-indexed line number. Omit for file-level findings. */
+    line?: number
+    /** Severity used by convergence promotion + execute verification. */
+    severity: RuleSeverity
+    /** Optional category (e.g. 'security', 'style'). */
+    category?: string
+    /** Short, action-oriented description. Surfaced in PR comments and review reports. */
+    summary: string
+    /** Optional longer explanation rendered in postmortem reports. */
+    detail?: string
+}
+
+/**
+ * The argument passed to a rule's `check` function.
+ * `content` is the raw file text. `ast()` returns a parsed TypeScript
+ * SourceFile lazily on first call and caches the result.
+ */
+export interface RuleFile {
+    /** Path relative to the repo root. */
+    path: string
+    /** Absolute filesystem path. */
+    absolutePath: string
+    /** Raw file content. */
+    content: string
+    /**
+     * Parse the file as a TypeScript SourceFile.
+     *
+     * Uses the host TypeScript installation. `ScriptKind` is inferred
+     * from the file extension. Returns `null` for files the parser
+     * cannot handle (binary, unknown extension).
+     *
+     * Result is cached per RuleFile instance; subsequent calls in the
+     * same rule (or in different rules processing the same file in the
+     * same run) reuse the parse.
+     */
+    ast(): ts.SourceFile | null
+}
+
+export interface RuleDefinition {
+    /** Unique stable id, e.g. `convex/require-admin-identity`. Used for finding ids and pitfall keys. */
+    id: string
+    /** Default severity for findings produced by this rule. Individual findings may override via the `severity` field. */
+    severity: RuleSeverity
+    /** Short human-readable description shown in `--list` output and postmortem reports. */
+    description: string
+    /**
+     * Glob (or array of globs) matched against repo-relative paths.
+     * Rule runs once per matching file. Use 'never' to declare a
+     * rule that runs once per repo (scope: 'repo'), with `path: ''`
+     * passed in. Use this only for cross-file invariants.
+     */
+    scope: string | string[] | 'repo'
+    /** Optional category surfaced in findings. */
+    category?: string
+    /** Optional list of paths to exclude (relative to repo root). */
+    exclude?: string | string[]
+    /**
+     * The rule body. Must be sync. Returns an array of findings; an
+     * empty array means the rule passed for this file. Throwing is
+     * caught by the runner and reported as a rule-error finding so a
+     * single broken rule cannot crash the run.
+     */
+    check: (file: RuleFile) => RuleFinding[]
+}
+
+/**
+ * Author entry point. Wraps the input so future versions can add
+ * runtime validation, deprecation warnings, or schema migration
+ * without breaking existing rule packs.
+ */
+export function defineRule(rule: RuleDefinition): RuleDefinition {
+    if (!rule.id || typeof rule.id !== 'string') {
+        throw new Error('defineRule: rule.id is required and must be a string')
+    }
+    if (!rule.scope) {
+        throw new Error(`defineRule(${rule.id}): scope is required`)
+    }
+    if (typeof rule.check !== 'function') {
+        throw new Error(`defineRule(${rule.id}): check must be a function`)
+    }
+    return rule
+}

--- a/packages/luca-mastracode/src/rules/define-rule.ts
+++ b/packages/luca-mastracode/src/rules/define-rule.ts
@@ -76,9 +76,10 @@ export interface RuleDefinition {
     description: string
     /**
      * Glob (or array of globs) matched against repo-relative paths.
-     * Rule runs once per matching file. Use 'never' to declare a
-     * rule that runs once per repo (scope: 'repo'), with `path: ''`
-     * passed in. Use this only for cross-file invariants.
+     * Rule runs once per matching file. Use the literal string `'repo'`
+     * to declare a rule that runs once per repo with `path: ''` passed
+     * in (the runner synthesizes a single RuleFile rooted at the repo).
+     * Use repo scope only for cross-file invariants.
      */
     scope: string | string[] | 'repo'
     /** Optional category surfaced in findings. */

--- a/packages/luca-mastracode/src/rules/recurrence.ts
+++ b/packages/luca-mastracode/src/rules/recurrence.ts
@@ -1,0 +1,253 @@
+/**
+ * Recurrence-driven rule promotion.
+ *
+ * Counts how often the same postmortem pitfall has appeared across runs.
+ * When recurrence_count >= threshold (default 3), generates a *draft*
+ * `.luca/rules/<concept-slug>.ts` rule template and renders the full
+ * suggestion set to `.planning/SUGGESTED-RULES.md` for human review.
+ *
+ * Drafts are NEVER auto-applied. The harness's job is to surface a
+ * "this pitfall has bitten you 3+ times — here's a starting point for
+ * a machine-checkable rule" suggestion. The user edits and commits.
+ *
+ * Counting strategy:
+ *   - Iterate every available run (current + archived) via listRuns/
+ *     listArchivedRuns + analyzeRun.
+ *   - Group violations by `code` (the same key used to derive the
+ *     pitfall concept slug).
+ *   - Recurrence = count of distinct runs where the code appeared
+ *     (not total occurrences — we don't want a single noisy run
+ *     to spuriously promote a rule).
+ */
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { analyzeRun } from '../postmortem.js'
+import { listArchivedRuns, listRuns } from '../session-ledger.js'
+import type { ViolationCode } from '../postmortem.js'
+
+export interface RecurringPitfall {
+    /** ViolationCode that recurred. */
+    code: ViolationCode
+    /** Distinct run count where this code appeared. */
+    runCount: number
+    /** Total occurrences across all runs (sum of per-run violation counts). */
+    occurrences: number
+    /** Run IDs where this code appeared (oldest first). */
+    runIds: string[]
+    /** Most recent violation message seen. */
+    sampleMessage: string
+    /** Suggested rule id, e.g. `recurring/todo-move-blocked`. */
+    suggestedRuleId: string
+    /** Suggested concept slug, e.g. `pitfall:todo-move-blocked`. */
+    pitfallConcept: string
+}
+
+export interface RecurrenceReport {
+    /** Total distinct runs scanned. */
+    runsScanned: number
+    /** Recurrence threshold used. */
+    threshold: number
+    /** Pitfalls meeting or exceeding threshold, sorted by runCount desc. */
+    recurring: RecurringPitfall[]
+}
+
+const DEFAULT_THRESHOLD = 3
+
+/**
+ * Convert a ViolationCode to a kebab-case rule id slug.
+ * `TODO_MOVE_BLOCKED` -> `todo-move-blocked`
+ */
+function codeToSlug(code: ViolationCode): string {
+    return code.toLowerCase().replace(/_/g, '-')
+}
+
+/**
+ * Scan all available runs (current + archived) and surface pitfalls
+ * that have recurred at or above the threshold.
+ */
+export function detectRecurringPitfalls(opts?: {
+    threshold?: number
+}): RecurrenceReport {
+    const threshold = opts?.threshold ?? DEFAULT_THRESHOLD
+
+    const liveRuns = listRuns()
+    const liveIds = new Set(liveRuns.map((r) => r.runId))
+    const archivedIds = listArchivedRuns().filter((id) => !liveIds.has(id))
+    const allRunIds = [...liveRuns.map((r) => r.runId), ...archivedIds]
+
+    // Map ViolationCode -> { runIds: Set, occurrences: number, sampleMessage }
+    const stats = new Map<
+        ViolationCode,
+        {
+            runIds: Set<string>
+            occurrences: number
+            sampleMessage: string
+            mostRecentRunId: string
+        }
+    >()
+
+    for (const runId of allRunIds) {
+        let report
+        try {
+            report = analyzeRun(runId)
+        } catch {
+            continue
+        }
+        for (const v of report.violations) {
+            let entry = stats.get(v.code)
+            if (!entry) {
+                entry = {
+                    runIds: new Set(),
+                    occurrences: 0,
+                    sampleMessage: v.message,
+                    mostRecentRunId: runId,
+                }
+                stats.set(v.code, entry)
+            }
+            entry.runIds.add(runId)
+            entry.occurrences += 1
+            entry.sampleMessage = v.message
+            entry.mostRecentRunId = runId
+        }
+    }
+
+    const recurring: RecurringPitfall[] = []
+    for (const [code, entry] of stats) {
+        if (entry.runIds.size < threshold) continue
+        const slug = codeToSlug(code)
+        recurring.push({
+            code,
+            runCount: entry.runIds.size,
+            occurrences: entry.occurrences,
+            runIds: [...entry.runIds],
+            sampleMessage: entry.sampleMessage,
+            suggestedRuleId: `recurring/${slug}`,
+            pitfallConcept: `pitfall:${slug}`,
+        })
+    }
+
+    recurring.sort((a, b) => b.runCount - a.runCount)
+
+    return {
+        runsScanned: allRunIds.length,
+        threshold,
+        recurring,
+    }
+}
+
+/**
+ * Render a draft rule template for a recurring pitfall.
+ * Always returns valid TypeScript. Body is intentionally a TODO —
+ * the user fills in the matcher logic.
+ */
+export function renderDraftRule(pitfall: RecurringPitfall): string {
+    const sample = pitfall.sampleMessage
+        .replace(/\\/g, '\\\\')
+        .replace(/`/g, '\\`')
+    return `/**
+ * Auto-suggested rule from luca recurrence detection.
+ *
+ * This pitfall has appeared in ${pitfall.runCount} distinct run(s)
+ * (${pitfall.occurrences} total occurrence(s)).
+ *
+ * Sample violation message:
+ *   ${sample}
+ *
+ * NEXT STEPS:
+ *   1. Decide what code pattern this rule should catch.
+ *   2. Implement the matcher in the \`check\` function below.
+ *      - Use \`file.content\` for regex checks.
+ *      - Use \`file.ast()\` for AST-level matching.
+ *   3. Set \`scope\` to the glob of files this rule should run against.
+ *   4. Refine the severity (defaults to 'should-fix').
+ *   5. Delete this comment block once the rule is real.
+ */
+import { defineRule } from '@alecsibilia/luca-mastracode/rules/define-rule'
+
+export default defineRule({
+    id: '${pitfall.suggestedRuleId}',
+    severity: 'should-fix',
+    description: '${pitfall.code}: ${sample.replace(/'/g, "\\'")}',
+    scope: 'src/**/*.ts',
+    category: 'recurring',
+    check: (file) => {
+        // TODO: implement the check.
+        // Example (regex):
+        //   const findings = []
+        //   const re = /badPattern/g
+        //   let match
+        //   while ((match = re.exec(file.content)) !== null) {
+        //       const line = file.content.slice(0, match.index).split('\\n').length
+        //       findings.push({
+        //           id: \`${pitfall.suggestedRuleId}:\${file.path}:\${line}\`,
+        //           path: file.path,
+        //           line,
+        //           severity: 'should-fix',
+        //           summary: 'Recurring pitfall detected',
+        //       })
+        //   }
+        //   return findings
+        return []
+    },
+})
+`
+}
+
+/**
+ * Render the full SUGGESTED-RULES.md report — one section per recurring
+ * pitfall with a code block of the draft rule.
+ */
+export function renderSuggestedRulesMarkdown(
+    report: RecurrenceReport
+): string {
+    if (report.recurring.length === 0) {
+        return `# Suggested Rules
+
+No recurring pitfalls met the threshold (>= ${report.threshold} runs).
+Scanned ${report.runsScanned} run(s).
+`
+    }
+
+    const sections = report.recurring.map((p) => {
+        return `## ${p.code} — ${p.runCount} run(s), ${p.occurrences} occurrence(s)
+
+**Suggested rule id**: \`${p.suggestedRuleId}\`
+**Pitfall concept**: \`${p.pitfallConcept}\`
+**Sample message**: ${p.sampleMessage}
+
+**Runs where this appeared**:
+${p.runIds.map((id) => `- ${id}`).join('\n')}
+
+**Draft rule** — copy to \`.luca/rules/${codeToSlug(p.code)}.ts\` and fill in the matcher:
+
+\`\`\`ts
+${renderDraftRule(p)}\`\`\`
+`
+    })
+
+    return `# Suggested Rules
+
+Recurring pitfalls detected at threshold >= ${report.threshold} runs (out of ${report.runsScanned} scanned).
+
+These suggestions are **drafts**. Each is a starting template, not an automatic addition. Review the sample messages, decide whether the pattern is mechanically detectable, fill in the matcher, and commit the rule to \`.luca/rules/\`.
+
+---
+
+${sections.join('\n---\n\n')}`
+}
+
+/**
+ * Write SUGGESTED-RULES.md to .planning/. Creates the directory if missing.
+ */
+export function writeSuggestedRules(opts: {
+    repoRoot: string
+    report: RecurrenceReport
+}): { path: string; bytes: number } {
+    const planningDir = join(opts.repoRoot, '.planning')
+    if (!existsSync(planningDir)) mkdirSync(planningDir, { recursive: true })
+    const path = join(planningDir, 'SUGGESTED-RULES.md')
+    const md = renderSuggestedRulesMarkdown(opts.report)
+    writeFileSync(path, md, 'utf-8')
+    return { path, bytes: md.length }
+}

--- a/packages/luca-mastracode/src/rules/recurrence.ts
+++ b/packages/luca-mastracode/src/rules/recurrence.ts
@@ -162,10 +162,12 @@ export function renderDraftRule(pitfall: RecurringPitfall): string {
  *   3. Set \`scope\` to the glob of files this rule should run against.
  *   4. Refine the severity (defaults to 'should-fix').
  *   5. Delete this comment block once the rule is real.
+ *
+ * The rule is exported as a plain duck-typed object so it works in any
+ * consumer repo without a runtime dependency on the harness package.
  */
-import { defineRule } from '@alecsibilia/luca-mastracode/rules/define-rule'
 
-export default defineRule({
+export default {
     id: '${pitfall.suggestedRuleId}',
     severity: 'should-fix',
     description: '${pitfall.code}: ${sample.replace(/'/g, "\\'")}',
@@ -190,7 +192,7 @@ export default defineRule({
         //   return findings
         return []
     },
-})
+}
 `
 }
 

--- a/packages/luca-mastracode/src/rules/runner.ts
+++ b/packages/luca-mastracode/src/rules/runner.ts
@@ -1,0 +1,473 @@
+/**
+ * Rules runner — discover, load, and execute repo-local rule packs.
+ *
+ * Discovery:
+ *   - Walks `.luca/rules/` (default) for `*.ts` and `*.js` files,
+ *     ignoring `*.test.ts`, `*.spec.ts`, and dotfiles.
+ *   - Dynamically imports each file. Pulls every export that looks
+ *     like a `RuleDefinition` (default export, named exports, or
+ *     arrays thereof). A single file may export multiple rules.
+ *
+ * Execution:
+ *   - For each rule, resolve the `scope` glob(s) into a candidate
+ *     file list (excluding paths in `exclude`).
+ *   - Build one `RuleFile` per candidate with a lazy AST parser.
+ *   - Call `rule.check(file)` and collect findings.
+ *   - Errors thrown by a rule become a single `rule-error` finding
+ *     so one bad rule cannot crash the run.
+ *
+ * Reporting:
+ *   - Returns `RuleRunReport` with all findings, per-rule timing,
+ *     and any load/runtime errors. Caller decides what to do
+ *     (block phase, surface as advisory, etc.).
+ */
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { extname, isAbsolute, join, relative, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { createRequire } from 'node:module'
+
+import type ts from 'typescript'
+
+import type {
+    RuleDefinition,
+    RuleFile,
+    RuleFinding,
+} from './define-rule.js'
+
+// TypeScript is a devDependency of this package, but rule consumers
+// might invoke the runner from a project that doesn't have `typescript`
+// installed. We resolve it lazily via createRequire so AST-using rules
+// can degrade gracefully (ast() returns null) when the package is
+// missing, while regex-only rules keep working.
+let tsModuleCache: typeof ts | null | undefined = undefined
+function resolveTypeScript(): typeof ts | null {
+    if (tsModuleCache !== undefined) return tsModuleCache
+    try {
+        const req = createRequire(import.meta.url)
+        tsModuleCache = req('typescript') as typeof ts
+    } catch {
+        tsModuleCache = null
+    }
+    return tsModuleCache
+}
+
+export interface RuleLoadError {
+    file: string
+    message: string
+}
+
+export interface RuleExecutionError {
+    ruleId: string
+    path: string
+    message: string
+}
+
+export interface RuleRunReport {
+    /** Number of rule files discovered. */
+    rulesFilesDiscovered: number
+    /** Number of rules successfully loaded. */
+    rulesLoaded: number
+    /** Per-rule timing in milliseconds. */
+    timings: Record<string, number>
+    /** Total findings produced across all rules. */
+    findings: RuleFinding[]
+    /** Files that failed to load (syntax error, throw on import, etc.). */
+    loadErrors: RuleLoadError[]
+    /** Rule executions that threw at runtime. */
+    executionErrors: RuleExecutionError[]
+}
+
+/**
+ * Recursively walk a directory and return absolute paths of files
+ * matching the provided extensions. Skips dotfiles and `node_modules`.
+ */
+function walkDir(
+    dir: string,
+    extensions: string[],
+    out: string[] = []
+): string[] {
+    if (!existsSync(dir)) return out
+    let entries: string[]
+    try {
+        entries = require('node:fs').readdirSync(dir)
+    } catch {
+        return out
+    }
+    for (const name of entries) {
+        if (name.startsWith('.') || name === 'node_modules') continue
+        const full = join(dir, name)
+        let stats
+        try {
+            stats = statSync(full)
+        } catch {
+            continue
+        }
+        if (stats.isDirectory()) {
+            walkDir(full, extensions, out)
+        } else if (extensions.includes(extname(name))) {
+            // Skip test files
+            if (name.endsWith('.test.ts')) continue
+            if (name.endsWith('.test.js')) continue
+            if (name.endsWith('.spec.ts')) continue
+            if (name.endsWith('.spec.js')) continue
+            out.push(full)
+        }
+    }
+    return out
+}
+
+/**
+ * Type guard — does this object look like a `RuleDefinition`?
+ * We don't use `instanceof` because rule packs may import
+ * `defineRule` from a different module instance after dynamic
+ * import; we duck-type instead.
+ */
+function isRuleDefinition(value: unknown): value is RuleDefinition {
+    if (!value || typeof value !== 'object') return false
+    const v = value as Record<string, unknown>
+    return (
+        typeof v.id === 'string' &&
+        typeof v.severity === 'string' &&
+        typeof v.description === 'string' &&
+        typeof v.check === 'function' &&
+        v.scope !== undefined &&
+        v.scope !== null
+    )
+}
+
+/**
+ * Pull all rule definitions from a dynamically-imported module.
+ * Accepts default export, named exports, and arrays.
+ */
+function extractRules(module: unknown): RuleDefinition[] {
+    if (!module || typeof module !== 'object') return []
+    const collected: RuleDefinition[] = []
+    const visit = (value: unknown): void => {
+        if (isRuleDefinition(value)) {
+            collected.push(value)
+            return
+        }
+        if (Array.isArray(value)) {
+            for (const v of value) visit(v)
+            return
+        }
+        // Don't recurse into nested objects to avoid pulling in random
+        // structures that happen to have an `id` and a `check` function.
+    }
+    for (const key of Object.keys(module)) {
+        visit((module as Record<string, unknown>)[key])
+    }
+    return collected
+}
+
+/**
+ * Discover and load all rule definitions from a directory.
+ */
+export async function loadRules(opts: {
+    rulesDir: string
+}): Promise<{
+    rules: RuleDefinition[]
+    filesDiscovered: number
+    loadErrors: RuleLoadError[]
+}> {
+    const { rulesDir } = opts
+    const loadErrors: RuleLoadError[] = []
+    const files = walkDir(rulesDir, ['.ts', '.mts', '.js', '.mjs'])
+    const rules: RuleDefinition[] = []
+    const seenIds = new Set<string>()
+
+    for (const file of files) {
+        try {
+            const url = pathToFileURL(file).href
+            const mod = await import(url)
+            for (const rule of extractRules(mod)) {
+                if (seenIds.has(rule.id)) {
+                    loadErrors.push({
+                        file,
+                        message: `duplicate rule id: ${rule.id} (already defined elsewhere)`,
+                    })
+                    continue
+                }
+                seenIds.add(rule.id)
+                rules.push(rule)
+            }
+        } catch (err) {
+            loadErrors.push({
+                file,
+                message: err instanceof Error ? err.message : String(err),
+            })
+        }
+    }
+
+    return { rules, filesDiscovered: files.length, loadErrors }
+}
+
+/**
+ * Convert a glob-or-glob-array into an array.
+ */
+function asArray(value: string | string[] | undefined): string[] {
+    if (value === undefined) return []
+    return Array.isArray(value) ? value : [value]
+}
+
+/**
+ * Resolve a rule's `scope` against the repo root. Returns relative
+ * paths. Uses `Bun.Glob` when available (bundled with Bun), else
+ * falls back to a directory walk + minimatch-style filter.
+ */
+function resolveScope(opts: {
+    repoRoot: string
+    scope: string | string[] | 'repo'
+    exclude: string[]
+}): string[] {
+    const { repoRoot, scope, exclude } = opts
+    if (scope === 'repo') return ['']
+
+    const globs = asArray(scope as string | string[])
+    if (globs.length === 0) return []
+
+    const collected = new Set<string>()
+    // Bun's runtime provides `Bun.Glob` with `scanSync`. We are
+    // running inside Bun (per the project's bunfig.toml).
+    const BunGlobal = (
+        globalThis as unknown as {
+            Bun?: {
+                Glob: new (pattern: string) => {
+                    scanSync(opts: {
+                        cwd: string
+                        onlyFiles?: boolean
+                        followSymlinks?: boolean
+                    }): IterableIterator<string>
+                }
+            }
+        }
+    ).Bun
+    if (!BunGlobal?.Glob) {
+        throw new Error(
+            'rules-runner: Bun runtime required for glob scope resolution'
+        )
+    }
+    for (const pattern of globs) {
+        const glob = new BunGlobal.Glob(pattern)
+        for (const match of glob.scanSync({ cwd: repoRoot, onlyFiles: true })) {
+            collected.add(match)
+        }
+    }
+
+    if (exclude.length > 0) {
+        const excludeMatches = new Set<string>()
+        for (const pattern of exclude) {
+            const glob = new BunGlobal.Glob(pattern)
+            for (const match of glob.scanSync({
+                cwd: repoRoot,
+                onlyFiles: true,
+            })) {
+                excludeMatches.add(match)
+            }
+        }
+        for (const path of collected) {
+            if (excludeMatches.has(path)) collected.delete(path)
+        }
+    }
+
+    return [...collected]
+}
+
+/**
+ * Infer a TypeScript ScriptKind from a file extension.
+ */
+function scriptKindFor(tsMod: typeof ts, path: string): ts.ScriptKind {
+    const ext = extname(path).toLowerCase()
+    switch (ext) {
+        case '.ts':
+            return tsMod.ScriptKind.TS
+        case '.tsx':
+            return tsMod.ScriptKind.TSX
+        case '.js':
+        case '.mjs':
+        case '.cjs':
+            return tsMod.ScriptKind.JS
+        case '.jsx':
+            return tsMod.ScriptKind.JSX
+        case '.json':
+            return tsMod.ScriptKind.JSON
+        default:
+            return tsMod.ScriptKind.Unknown
+    }
+}
+
+/**
+ * Build a hybrid RuleFile with raw content + lazy AST.
+ * AST parses are cached on the RuleFile instance, so multiple rules
+ * processing the same file pay the parse cost only once.
+ */
+function makeRuleFile(opts: {
+    repoRoot: string
+    relPath: string
+    contentCache: Map<string, string>
+    astCache: Map<string, ts.SourceFile | null>
+}): RuleFile | null {
+    const { repoRoot, relPath, contentCache, astCache } = opts
+    const absolutePath = resolve(repoRoot, relPath)
+
+    let content = contentCache.get(relPath)
+    if (content === undefined) {
+        try {
+            content = readFileSync(absolutePath, 'utf-8')
+        } catch {
+            return null
+        }
+        contentCache.set(relPath, content)
+    }
+
+    return {
+        path: relPath,
+        absolutePath,
+        content,
+        ast(): ts.SourceFile | null {
+            if (astCache.has(relPath)) return astCache.get(relPath) ?? null
+            const tsMod = resolveTypeScript()
+            if (!tsMod) {
+                astCache.set(relPath, null)
+                return null
+            }
+            const kind = scriptKindFor(tsMod, relPath)
+            if (kind === tsMod.ScriptKind.Unknown) {
+                astCache.set(relPath, null)
+                return null
+            }
+            try {
+                const sf = tsMod.createSourceFile(
+                    relPath,
+                    content!,
+                    tsMod.ScriptTarget.Latest,
+                    /* setParentNodes */ true,
+                    kind
+                )
+                astCache.set(relPath, sf)
+                return sf
+            } catch {
+                astCache.set(relPath, null)
+                return null
+            }
+        },
+    }
+}
+
+/**
+ * Run a set of loaded rules against the working tree.
+ */
+export function runRules(opts: {
+    repoRoot: string
+    rules: RuleDefinition[]
+}): {
+    timings: Record<string, number>
+    findings: RuleFinding[]
+    executionErrors: RuleExecutionError[]
+} {
+    const { repoRoot, rules } = opts
+    const findings: RuleFinding[] = []
+    const executionErrors: RuleExecutionError[] = []
+    const timings: Record<string, number> = {}
+    const contentCache = new Map<string, string>()
+    const astCache = new Map<string, ts.SourceFile | null>()
+
+    for (const rule of rules) {
+        const start = performance.now()
+        const exclude = asArray(rule.exclude)
+        let candidates: string[]
+        try {
+            candidates = resolveScope({
+                repoRoot,
+                scope: rule.scope,
+                exclude,
+            })
+        } catch (err) {
+            executionErrors.push({
+                ruleId: rule.id,
+                path: '',
+                message: `scope resolution failed: ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            })
+            timings[rule.id] = performance.now() - start
+            continue
+        }
+
+        for (const relPath of candidates) {
+            const file = makeRuleFile({
+                repoRoot,
+                relPath,
+                contentCache,
+                astCache,
+            })
+            if (!file) continue
+            try {
+                const ruleFindings = rule.check(file)
+                if (Array.isArray(ruleFindings)) {
+                    for (const finding of ruleFindings) {
+                        // Default the category from the rule when missing.
+                        if (!finding.category && rule.category) {
+                            finding.category = rule.category
+                        }
+                        findings.push(finding)
+                    }
+                }
+            } catch (err) {
+                executionErrors.push({
+                    ruleId: rule.id,
+                    path: relPath,
+                    message:
+                        err instanceof Error ? err.message : String(err),
+                })
+            }
+        }
+
+        timings[rule.id] = performance.now() - start
+    }
+
+    return { timings, findings, executionErrors }
+}
+
+/**
+ * One-shot: discover, load, and run all rules in a repo's `.luca/rules/`.
+ */
+export async function discoverAndRun(opts: {
+    repoRoot: string
+    rulesDir?: string
+}): Promise<RuleRunReport> {
+    const repoRoot = isAbsolute(opts.repoRoot)
+        ? opts.repoRoot
+        : resolve(opts.repoRoot)
+    const rulesDir = opts.rulesDir
+        ? isAbsolute(opts.rulesDir)
+            ? opts.rulesDir
+            : resolve(repoRoot, opts.rulesDir)
+        : join(repoRoot, '.luca', 'rules')
+
+    const {
+        rules,
+        filesDiscovered,
+        loadErrors,
+    } = await loadRules({ rulesDir })
+
+    const { timings, findings, executionErrors } = runRules({
+        repoRoot,
+        rules,
+    })
+
+    return {
+        rulesFilesDiscovered: filesDiscovered,
+        rulesLoaded: rules.length,
+        timings,
+        findings,
+        loadErrors,
+        executionErrors,
+    }
+}
+
+// Helper used below — kept private to avoid a circular re-export.
+export function _formatRelative(repoRoot: string, absPath: string): string {
+    return relative(repoRoot, absPath)
+}

--- a/packages/luca-mastracode/src/rules/runner.ts
+++ b/packages/luca-mastracode/src/rules/runner.ts
@@ -21,7 +21,7 @@
  *     and any load/runtime errors. Caller decides what to do
  *     (block phase, surface as advisory, etc.).
  */
-import { existsSync, readFileSync, statSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { extname, isAbsolute, join, relative, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
@@ -90,7 +90,7 @@ function walkDir(
     if (!existsSync(dir)) return out
     let entries: string[]
     try {
-        entries = require('node:fs').readdirSync(dir)
+        entries = readdirSync(dir)
     } catch {
         return out
     }
@@ -396,12 +396,23 @@ export function runRules(opts: {
         }
 
         for (const relPath of candidates) {
-            const file = makeRuleFile({
-                repoRoot,
-                relPath,
-                contentCache,
-                astCache,
-            })
+            // `scope: 'repo'` produces a single sentinel candidate (`''`). For
+            // repo-scoped rules we synthesize a RuleFile pointing at the repo
+            // root rather than trying to read it as a file.
+            const file =
+                relPath === ''
+                    ? ({
+                          path: '',
+                          absolutePath: repoRoot,
+                          content: '',
+                          ast: () => null,
+                      } satisfies RuleFile)
+                    : makeRuleFile({
+                          repoRoot,
+                          relPath,
+                          contentCache,
+                          astCache,
+                      })
             if (!file) continue
             try {
                 const ruleFindings = rule.check(file)

--- a/packages/luca-mastracode/src/session-ledger.ts
+++ b/packages/luca-mastracode/src/session-ledger.ts
@@ -32,8 +32,10 @@ const RUNS_DIR = '.planning/runs'
 // ---------------------------------------------------------------------------
 
 /**
- * Crockford-base32 ULID-style identifier (sufficient for run uniqueness;
- * we don't need true ULID monotonicity here).
+ * Generate a base36 (lowercase a-z + 0-9) run identifier of the form
+ * `run_<timestamp36>_<random36>`. This is intentionally not a real ULID —
+ * we only need uniqueness within a `.planning/` directory, not lexicographic
+ * monotonicity or 128-bit collision resistance.
  */
 function generateRunId(): string {
     const ts = Date.now().toString(36)
@@ -167,6 +169,71 @@ export function listRuns(): Array<{
         eventCount: v.count,
     }))
 }
+
+/**
+ * List runIds for which `.planning/runs/<runId>/` archive directories exist
+ * on disk. Returns an empty array if no archives exist or `.planning/` is
+ * missing. Sort order is unspecified — callers should sort if needed.
+ */
+export function listArchivedRuns(): string[] {
+    const archiveRoot = join(process.cwd(), RUNS_DIR)
+    if (!existsSync(archiveRoot)) return []
+    try {
+        // `readdirSync` is synchronous and good enough here — archive
+        // directories are small (one entry per run).
+        const { readdirSync, statSync } = require('node:fs') as typeof import('node:fs')
+        return readdirSync(archiveRoot).filter((name: string) => {
+            try {
+                return statSync(join(archiveRoot, name)).isDirectory()
+            } catch {
+                return false
+            }
+        })
+    } catch {
+        return []
+    }
+}
+
+/**
+ * Resolve the directory holding JSONL artifacts for a given runId. Returns
+ * `.planning/` if `runId` matches the current run, otherwise
+ * `.planning/runs/<runId>/` if that archive exists, else null.
+ */
+export function resolveRunArtifactDir(runId: string): string | null {
+    const planningRoot = join(process.cwd(), '.planning')
+    const current = readLucaState().runId
+    if (current === runId) {
+        return existsSync(planningRoot) ? planningRoot : null
+    }
+    const archiveDir = join(process.cwd(), RUNS_DIR, runId)
+    return existsSync(archiveDir) ? archiveDir : null
+}
+
+/**
+ * Read JSONL entries from a specific file inside an arbitrary directory.
+ * Used by postmortem to load artifacts from archived run directories.
+ */
+export function readJsonlAt<T>(dir: string, basename: string): T[] {
+    const p = join(dir, basename)
+    if (!existsSync(p)) return []
+    try {
+        return readFileSync(p, 'utf-8')
+            .trim()
+            .split('\n')
+            .filter(Boolean)
+            .map((line) => JSON.parse(line) as T)
+    } catch {
+        return []
+    }
+}
+
+/** Filenames used inside both `.planning/` and `.planning/runs/<id>/` */
+export const ARTIFACT_FILES = {
+    ledger: 'session-ledger.jsonl',
+    routing: 'routing-history.jsonl',
+    verification: 'verification-history.jsonl',
+    confidence: 'confidence-journal.jsonl',
+} as const
 
 /**
  * Compute session metrics from the ledger.

--- a/packages/luca-mastracode/src/session-ledger.ts
+++ b/packages/luca-mastracode/src/session-ledger.ts
@@ -6,12 +6,63 @@
  *
  * The ledger captures every significant event: mode transitions, phase
  * start/complete, verification results, convergence state, and timing.
+ *
+ * Each entry is stamped with a `runId` so postmortem tools can isolate a
+ * single pipeline run even when multiple runs share a `.planning/` directory.
  */
-import { existsSync, readFileSync, mkdirSync, appendFileSync } from 'node:fs'
+import {
+    existsSync,
+    readFileSync,
+    mkdirSync,
+    appendFileSync,
+    renameSync,
+} from 'node:fs'
 import { join } from 'node:path'
+
+import { readLucaState, writeLucaState } from './luca-store.js'
 
 const LEDGER_FILE = '.planning/session-ledger.jsonl'
 const ROUTING_HISTORY_FILE = '.planning/routing-history.jsonl'
+const VERIFICATION_HISTORY_FILE = '.planning/verification-history.jsonl'
+const CONFIDENCE_JOURNAL_FILE = '.planning/confidence-journal.jsonl'
+const RUNS_DIR = '.planning/runs'
+
+// ---------------------------------------------------------------------------
+// Run identity
+// ---------------------------------------------------------------------------
+
+/**
+ * Crockford-base32 ULID-style identifier (sufficient for run uniqueness;
+ * we don't need true ULID monotonicity here).
+ */
+function generateRunId(): string {
+    const ts = Date.now().toString(36)
+    const rand = Math.random().toString(36).slice(2, 10)
+    return `run_${ts}_${rand}`
+}
+
+/**
+ * Resolve the current run ID. If `luca-state.json` doesn't have one yet,
+ * mint a new one and persist it.
+ */
+export function getCurrentRunId(): string {
+    const state = readLucaState()
+    if (typeof state.runId === 'string' && state.runId.length > 0) {
+        return state.runId
+    }
+    const runId = generateRunId()
+    writeLucaState({ runId })
+    return runId
+}
+
+/**
+ * Force a new run ID. Returns the new ID. Use at pipeline-reset.
+ */
+export function startNewRun(): string {
+    const runId = generateRunId()
+    writeLucaState({ runId })
+    return runId
+}
 
 // ---------------------------------------------------------------------------
 // Session ledger
@@ -19,6 +70,7 @@ const ROUTING_HISTORY_FILE = '.planning/routing-history.jsonl'
 
 export interface LedgerEntry {
     timestamp: string
+    runId: string
     event: string
     data: Record<string, unknown>
 }
@@ -38,6 +90,7 @@ export function appendLedger(
     ensurePlanningDir()
     const entry: LedgerEntry = {
         timestamp: new Date().toISOString(),
+        runId: getCurrentRunId(),
         event,
         data,
     }
@@ -66,16 +119,60 @@ export function readLedger(): LedgerEntry[] {
 }
 
 /**
- * Get ledger entries filtered by event type.
+ * Read ledger entries scoped to a single run.
  */
-export function getLedgerByEvent(event: string): LedgerEntry[] {
-    return readLedger().filter((e) => e.event === event)
+export function readLedgerForRun(runId: string): LedgerEntry[] {
+    return readLedger().filter((e) => e.runId === runId)
+}
+
+/**
+ * Get ledger entries filtered by event type (optionally scoped to a run).
+ */
+export function getLedgerByEvent(
+    event: string,
+    runId?: string
+): LedgerEntry[] {
+    const entries = readLedger().filter((e) => e.event === event)
+    return runId ? entries.filter((e) => e.runId === runId) : entries
+}
+
+/**
+ * List distinct runs present in the ledger, oldest first.
+ */
+export function listRuns(): Array<{
+    runId: string
+    firstEvent: string
+    lastEvent: string
+    eventCount: number
+}> {
+    const entries = readLedger()
+    const byRun = new Map<
+        string,
+        { first: string; last: string; count: number }
+    >()
+    for (const e of entries) {
+        const id = e.runId ?? 'unknown'
+        const existing = byRun.get(id)
+        if (!existing) {
+            byRun.set(id, { first: e.timestamp, last: e.timestamp, count: 1 })
+        } else {
+            existing.last = e.timestamp
+            existing.count += 1
+        }
+    }
+    return Array.from(byRun.entries()).map(([runId, v]) => ({
+        runId,
+        firstEvent: v.first,
+        lastEvent: v.last,
+        eventCount: v.count,
+    }))
 }
 
 /**
  * Compute session metrics from the ledger.
  */
-export function computeSessionMetrics(): {
+export function computeSessionMetrics(runId?: string): {
+    runId?: string
     totalEvents: number
     modeTransitions: number
     phasesCompleted: number
@@ -84,9 +181,10 @@ export function computeSessionMetrics(): {
     lastEvent?: string
     durationMs?: number
 } {
-    const entries = readLedger()
+    const entries = runId ? readLedgerForRun(runId) : readLedger()
     if (entries.length === 0) {
         return {
+            runId,
             totalEvents: 0,
             modeTransitions: 0,
             phasesCompleted: 0,
@@ -107,6 +205,7 @@ export function computeSessionMetrics(): {
             : undefined
 
     return {
+        runId: runId ?? first?.runId,
         totalEvents: entries.length,
         modeTransitions: transitions.length,
         phasesCompleted: phaseCompletions.length,
@@ -118,11 +217,48 @@ export function computeSessionMetrics(): {
 }
 
 // ---------------------------------------------------------------------------
+// Run archival
+// ---------------------------------------------------------------------------
+
+/**
+ * Move the current run's JSONL artifacts into `.planning/runs/<runId>/`
+ * so the new run starts with empty ledger files. Best-effort: missing
+ * source files are silently skipped.
+ */
+export function archivePriorRun(runId: string): void {
+    if (!runId) return
+    const planningRoot = join(process.cwd(), '.planning')
+    if (!existsSync(planningRoot)) return
+
+    const targetDir = join(process.cwd(), RUNS_DIR, runId)
+    if (!existsSync(targetDir)) mkdirSync(targetDir, { recursive: true })
+
+    const candidates = [
+        LEDGER_FILE,
+        ROUTING_HISTORY_FILE,
+        VERIFICATION_HISTORY_FILE,
+        CONFIDENCE_JOURNAL_FILE,
+    ]
+    for (const rel of candidates) {
+        const src = join(process.cwd(), rel)
+        if (!existsSync(src)) continue
+        const base = rel.split('/').pop() ?? rel
+        const dest = join(targetDir, base)
+        try {
+            renameSync(src, dest)
+        } catch {
+            // Cross-device or permission failure — best-effort archival.
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Routing history
 // ---------------------------------------------------------------------------
 
 export interface RoutingEntry {
     timestamp: string
+    runId: string
     agentType: string
     complexity: string
     profile: string
@@ -134,10 +270,14 @@ export interface RoutingEntry {
  * Append a routing decision to the routing history.
  */
 export function appendRoutingHistory(
-    entry: Omit<RoutingEntry, 'timestamp'>
+    entry: Omit<RoutingEntry, 'timestamp' | 'runId'>
 ): void {
     ensurePlanningDir()
-    const full: RoutingEntry = { ...entry, timestamp: new Date().toISOString() }
+    const full: RoutingEntry = {
+        ...entry,
+        runId: getCurrentRunId(),
+        timestamp: new Date().toISOString(),
+    }
     appendFileSync(
         join(process.cwd(), ROUTING_HISTORY_FILE),
         JSON.stringify(full) + '\n',
@@ -150,7 +290,8 @@ export function appendRoutingHistory(
  */
 export function readRoutingHistory({
     limit = 20,
-}: { limit?: number } = {}): RoutingEntry[] {
+    runId,
+}: { limit?: number; runId?: string } = {}): RoutingEntry[] {
     const p = join(process.cwd(), ROUTING_HISTORY_FILE)
     if (!existsSync(p)) return []
     try {
@@ -159,7 +300,8 @@ export function readRoutingHistory({
             .split('\n')
             .filter(Boolean)
             .map((line) => JSON.parse(line) as RoutingEntry)
-        return entries.slice(-limit)
+        const scoped = runId ? entries.filter((e) => e.runId === runId) : entries
+        return scoped.slice(-limit)
     } catch {
         return []
     }

--- a/packages/luca-mastracode/src/session-ledger.ts
+++ b/packages/luca-mastracode/src/session-ledger.ts
@@ -27,6 +27,7 @@ const LEDGER_FILE = '.planning/session-ledger.jsonl'
 const ROUTING_HISTORY_FILE = '.planning/routing-history.jsonl'
 const VERIFICATION_HISTORY_FILE = '.planning/verification-history.jsonl'
 const CONFIDENCE_JOURNAL_FILE = '.planning/confidence-journal.jsonl'
+const VERIFICATION_RESULT_FILE = '.planning/verification-result.json'
 const RUNS_DIR = '.planning/runs'
 
 // ---------------------------------------------------------------------------
@@ -289,9 +290,14 @@ export function computeSessionMetrics(runId?: string): {
 // ---------------------------------------------------------------------------
 
 /**
- * Move the current run's JSONL artifacts into `.planning/runs/<runId>/`
- * so the new run starts with empty ledger files. Best-effort: missing
- * source files are silently skipped.
+ * Move the current run's artifacts into `.planning/runs/<runId>/`
+ * so the new run starts clean. Best-effort: missing source files are
+ * silently skipped.
+ *
+ * The single-snapshot `verification-result.json` MUST be archived alongside
+ * the JSONL histories. Otherwise a stale wave-1 PASS from a prior run can
+ * satisfy the wave/phase guards in `workflow-state` and silently bypass
+ * verification on the next run.
  */
 export function archivePriorRun(runId: string): void {
     if (!runId) return
@@ -306,6 +312,7 @@ export function archivePriorRun(runId: string): void {
         ROUTING_HISTORY_FILE,
         VERIFICATION_HISTORY_FILE,
         CONFIDENCE_JOURNAL_FILE,
+        VERIFICATION_RESULT_FILE,
     ]
     for (const rel of candidates) {
         const src = join(process.cwd(), rel)

--- a/packages/luca-mastracode/src/session-ledger.ts
+++ b/packages/luca-mastracode/src/session-ledger.ts
@@ -16,6 +16,8 @@ import {
     mkdirSync,
     appendFileSync,
     renameSync,
+    readdirSync,
+    statSync,
 } from 'node:fs'
 import { join } from 'node:path'
 
@@ -181,7 +183,6 @@ export function listArchivedRuns(): string[] {
     try {
         // `readdirSync` is synchronous and good enough here — archive
         // directories are small (one entry per run).
-        const { readdirSync, statSync } = require('node:fs') as typeof import('node:fs')
         return readdirSync(archiveRoot).filter((name: string) => {
             try {
                 return statSync(join(archiveRoot, name)).isDirectory()

--- a/packages/luca-mastracode/src/tools/build-mode-tools.ts
+++ b/packages/luca-mastracode/src/tools/build-mode-tools.ts
@@ -9,6 +9,7 @@ import { MODE_PERMISSIONS } from './mode-permissions.js'
 import { pipelineLockTool } from './pipeline-lock.js'
 import { repoCleanupTool } from './repo-cleanup.js'
 import { runChecksTool } from './run-checks.js'
+import { runPostmortemTool } from './run-postmortem.js'
 import { sessionLedgerTool } from './session-ledger.js'
 import { verificationResultTool } from './verification-result.js'
 import { workflowStateTool } from './workflow-state.js'
@@ -52,6 +53,10 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
     confidence_journal: {
         tool: confidenceJournalTool,
         record_key: 'confidenceJournal',
+    },
+    run_postmortem: {
+        tool: runPostmortemTool,
+        record_key: 'runPostmortem',
     },
 }
 

--- a/packages/luca-mastracode/src/tools/build-mode-tools.ts
+++ b/packages/luca-mastracode/src/tools/build-mode-tools.ts
@@ -1,5 +1,6 @@
 import type { Tool } from '@mastra/core/tools'
 
+import { claimVerifierTool } from './claim-verifier.js'
 import { classifyComplexityTool } from './classify-complexity.js'
 import { confidenceJournalTool } from './confidence-journal.js'
 import { createScopedTool } from './create-scoped-tool.js'
@@ -57,6 +58,10 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
     run_postmortem: {
         tool: runPostmortemTool,
         record_key: 'runPostmortem',
+    },
+    claim_verifier: {
+        tool: claimVerifierTool,
+        record_key: 'claimVerifier',
     },
 }
 

--- a/packages/luca-mastracode/src/tools/build-mode-tools.ts
+++ b/packages/luca-mastracode/src/tools/build-mode-tools.ts
@@ -8,6 +8,7 @@ import { manageRoadmapTool } from './manage-roadmap.js'
 import { manageTodosTool } from './manage-todos.js'
 import { MODE_PERMISSIONS } from './mode-permissions.js'
 import { pipelineLockTool } from './pipeline-lock.js'
+import { prReviewTool } from './pr-review.js'
 import { repoCleanupTool } from './repo-cleanup.js'
 import { runChecksTool } from './run-checks.js'
 import { runPostmortemTool } from './run-postmortem.js'
@@ -62,6 +63,10 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
     claim_verifier: {
         tool: claimVerifierTool,
         record_key: 'claimVerifier',
+    },
+    pr_review: {
+        tool: prReviewTool,
+        record_key: 'prReview',
     },
 }
 

--- a/packages/luca-mastracode/src/tools/build-mode-tools.ts
+++ b/packages/luca-mastracode/src/tools/build-mode-tools.ts
@@ -12,6 +12,7 @@ import { prReviewTool } from './pr-review.js'
 import { repoCleanupTool } from './repo-cleanup.js'
 import { runChecksTool } from './run-checks.js'
 import { runPostmortemTool } from './run-postmortem.js'
+import { runRulesTool } from './run-rules.js'
 import { sessionLedgerTool } from './session-ledger.js'
 import { verificationResultTool } from './verification-result.js'
 import { workflowStateTool } from './workflow-state.js'
@@ -67,6 +68,10 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
     pr_review: {
         tool: prReviewTool,
         record_key: 'prReview',
+    },
+    run_rules: {
+        tool: runRulesTool,
+        record_key: 'runRules',
     },
 }
 

--- a/packages/luca-mastracode/src/tools/claim-verifier.ts
+++ b/packages/luca-mastracode/src/tools/claim-verifier.ts
@@ -1,0 +1,191 @@
+/**
+ * claim-verifier (tool) — Mastra tool wrapper for the claim verifier.
+ *
+ * Three actions:
+ *   - verify-text: verify claims in an inline text string (e.g. PR body draft).
+ *   - verify-file: verify claims in a file on disk (e.g. .changeset/<slug>.md).
+ *   - gate: verify across multiple paths/texts; returns CLAIM_VERIFICATION_FAILED
+ *           if any input has unverifiable claims. Used by finalize before PR creation.
+ *
+ * Every call appends a `claim-verifier-run` ledger event with totals so
+ * the postmortem analyzer can observe verifier activity over time.
+ */
+import { existsSync } from 'node:fs'
+import { isAbsolute, join } from 'node:path'
+
+import { createTool } from '@mastra/core/tools'
+import { z } from 'zod'
+
+import {
+    verifyFile,
+    verifyTextArtifact,
+    type ClaimVerificationReport,
+} from '../claim-verifier.js'
+import { appendLedger } from '../session-ledger.js'
+
+const PLANNING_DIR = '.planning'
+
+/**
+ * Resolve an artifact path. Tries:
+ *   1. The path as-is (absolute or repo-relative).
+ *   2. The path under .planning/ as a fallback.
+ */
+function resolveArtifactPath(repoRoot: string, p: string): string {
+    if (isAbsolute(p)) return p
+    const direct = join(repoRoot, p)
+    if (existsSync(direct)) return direct
+    const planning = join(repoRoot, PLANNING_DIR, p)
+    if (existsSync(planning)) return planning
+    return direct
+}
+
+interface SourcedReport {
+    source: string
+    report: ClaimVerificationReport
+}
+
+export const claimVerifierTool = createTool({
+    id: 'claim-verifier',
+    description:
+        'Verify factual claims (symbols, file paths, quantitative counts) in narrative artifacts ' +
+        '(changesets, PR bodies, PLAN.md, REVIEW-*.md) against the working tree. ' +
+        "Use 'verify-text' for inline strings, 'verify-file' for on-disk artifacts, " +
+        "and 'gate' as a pre-PR finalize check that blocks on any unverifiable claim. " +
+        'Catches doc-claim drift before it ships.',
+    inputSchema: z.object({
+        action: z
+            .enum(['verify-text', 'verify-file', 'gate'])
+            .describe(
+                'verify-text: verify an inline string | verify-file: verify a file path | gate: verify multiple inputs and block on failures'
+            ),
+        text: z
+            .string()
+            .optional()
+            .describe('Inline text to verify (verify-text only).'),
+        path: z
+            .string()
+            .optional()
+            .describe(
+                'Path to verify (verify-file only). Resolved relative to repo root, then .planning/.'
+            ),
+        paths: z
+            .array(z.string())
+            .optional()
+            .describe(
+                'Multiple file paths to verify (gate action). Each is resolved like verify-file.'
+            ),
+        texts: z
+            .array(z.string())
+            .optional()
+            .describe(
+                'Multiple inline texts to verify (gate action). Tagged "text-0", "text-1", ...'
+            ),
+    }),
+    execute: async (inputData) => {
+        const { action, text, path, paths, texts } = inputData
+        const repoRoot = process.cwd()
+
+        switch (action) {
+            case 'verify-text': {
+                if (!text) {
+                    return {
+                        success: false,
+                        message: 'verify-text requires `text`',
+                    }
+                }
+                const report = verifyTextArtifact(text, { repoRoot })
+                appendLedger('claim-verifier-run', {
+                    action,
+                    totalClaims: report.totalClaims,
+                    failureCount: report.failures.length,
+                    paths: [],
+                })
+                return {
+                    success: report.passed,
+                    message: report.passed
+                        ? `Verified ${report.totalClaims} claim(s), all passed.`
+                        : `Verified ${report.totalClaims} claim(s), ${report.failures.length} failure(s).`,
+                    report,
+                    pitfalls: [],
+                }
+            }
+            case 'verify-file': {
+                if (!path) {
+                    return {
+                        success: false,
+                        message: 'verify-file requires `path`',
+                    }
+                }
+                const resolved = resolveArtifactPath(repoRoot, path)
+                const report = verifyFile(resolved, { repoRoot })
+                appendLedger('claim-verifier-run', {
+                    action,
+                    totalClaims: report.totalClaims,
+                    failureCount: report.failures.length,
+                    paths: [path],
+                })
+                return {
+                    success: report.passed,
+                    message: report.passed
+                        ? `Verified ${report.totalClaims} claim(s) in ${path}, all passed.`
+                        : `Verified ${report.totalClaims} claim(s) in ${path}, ${report.failures.length} failure(s).`,
+                    report,
+                    pitfalls: [],
+                }
+            }
+            case 'gate': {
+                const reports: SourcedReport[] = []
+                const ledgerPaths: string[] = []
+                let totalClaims = 0
+                let totalFailures = 0
+
+                for (const p of paths ?? []) {
+                    const resolved = resolveArtifactPath(repoRoot, p)
+                    const report = verifyFile(resolved, { repoRoot })
+                    reports.push({ source: p, report })
+                    ledgerPaths.push(p)
+                    totalClaims += report.totalClaims
+                    totalFailures += report.failures.length
+                }
+
+                for (let i = 0; i < (texts ?? []).length; i++) {
+                    const t = (texts ?? [])[i] ?? ''
+                    const tag = `text-${i}`
+                    const report = verifyTextArtifact(t, { repoRoot })
+                    reports.push({ source: tag, report })
+                    totalClaims += report.totalClaims
+                    totalFailures += report.failures.length
+                }
+
+                appendLedger('claim-verifier-run', {
+                    action,
+                    totalClaims,
+                    failureCount: totalFailures,
+                    paths: ledgerPaths,
+                })
+
+                if (totalFailures > 0) {
+                    return {
+                        success: false,
+                        code: 'CLAIM_VERIFICATION_FAILED',
+                        message: `Claim verifier gate failed: ${totalFailures} failure(s) across ${reports.length} input(s). Fix the draft (or the code) until claims match the working tree.`,
+                        reports,
+                        pitfalls: [],
+                    }
+                }
+
+                return {
+                    success: true,
+                    message: `Claim verifier gate passed: ${totalClaims} claim(s) verified across ${reports.length} input(s).`,
+                    reports,
+                    pitfalls: [],
+                }
+            }
+            default:
+                return {
+                    success: false,
+                    message: `Unknown action: ${String(action)}`,
+                }
+        }
+    },
+})

--- a/packages/luca-mastracode/src/tools/index.ts
+++ b/packages/luca-mastracode/src/tools/index.ts
@@ -10,6 +10,7 @@ export { verificationResultTool } from './verification-result.js'
 export { repoCleanupTool } from './repo-cleanup.js'
 export { writePlanningFileTool } from './write-planning-file.js'
 export { confidenceJournalTool } from './confidence-journal.js'
+export { runPostmortemTool } from './run-postmortem.js'
 
 // Permission system
 export { createScopedTool } from './create-scoped-tool.js'

--- a/packages/luca-mastracode/src/tools/index.ts
+++ b/packages/luca-mastracode/src/tools/index.ts
@@ -11,6 +11,9 @@ export { repoCleanupTool } from './repo-cleanup.js'
 export { writePlanningFileTool } from './write-planning-file.js'
 export { confidenceJournalTool } from './confidence-journal.js'
 export { runPostmortemTool } from './run-postmortem.js'
+export { claimVerifierTool } from './claim-verifier.js'
+export { prReviewTool } from './pr-review.js'
+export { runRulesTool } from './run-rules.js'
 
 // Permission system
 export { createScopedTool } from './create-scoped-tool.js'

--- a/packages/luca-mastracode/src/tools/manage-todos.ts
+++ b/packages/luca-mastracode/src/tools/manage-todos.ts
@@ -1,6 +1,7 @@
 import { createTool } from '@mastra/core/tools'
 import { z } from 'zod'
 
+import { appendLedger } from '../session-ledger.js'
 import {
     addTodo,
     listTodos,
@@ -11,6 +12,56 @@ import {
     readTodoContent,
     type TodoStatus,
 } from '../todos.js'
+import { findCriterion } from '../verification-result.js'
+
+const verificationRefSchema = z.object({
+    criterionId: z
+        .string()
+        .describe('Stable criterion ID from verification-result.json'),
+    wave: z
+        .number()
+        .int()
+        .describe('Wave number whose verification result contains the criterion'),
+})
+
+type VerificationRef = z.infer<typeof verificationRefSchema>
+
+/**
+ * Validate a verificationRef points at a real, met, evidence-backed criterion.
+ * Returns null on success, or a structured error payload to return to the caller.
+ */
+function validateVerificationRef(ref: VerificationRef | undefined): {
+    code: string
+    message: string
+} | null {
+    if (!ref) {
+        return {
+            code: 'TODO_DONE_UNVERIFIED',
+            message:
+                'verificationRef is required when moving a todo to "done". Provide { criterionId, wave } pointing at a PASS criterion in verification-history.jsonl.',
+        }
+    }
+    const found = findCriterion(ref)
+    if (!found) {
+        return {
+            code: 'TODO_DONE_UNVERIFIED',
+            message: `verificationRef { criterionId: "${ref.criterionId}", wave: ${ref.wave} } not found in verification-history.jsonl. Write a verification-result with this criterion before moving the todo.`,
+        }
+    }
+    if (!found.criterion.met) {
+        return {
+            code: 'TODO_DONE_UNVERIFIED',
+            message: `Criterion "${ref.criterionId}" (wave ${ref.wave}) is recorded as NOT met. Cannot move the todo to done.`,
+        }
+    }
+    if (!found.criterion.evidence || !found.criterion.evidence.trim()) {
+        return {
+            code: 'TODO_DONE_UNVERIFIED',
+            message: `Criterion "${ref.criterionId}" (wave ${ref.wave}) has empty evidence. Move blocked — re-run verification with concrete evidence (file/line/test).`,
+        }
+    }
+    return null
+}
 
 export const manageTodosTool = createTool({
     id: 'manage-todos',
@@ -82,14 +133,22 @@ export const manageTodosTool = createTool({
                 z.object({
                     identifier: z.union([z.number(), z.string()]),
                     targetStatus: z.enum(['pending', 'backlog', 'done']),
+                    verificationRef: verificationRefSchema.optional(),
                 })
             )
             .optional()
             .describe(
-                'Array of {identifier, targetStatus} for batch status changes (required for move-batch). ' +
+                'Array of {identifier, targetStatus, verificationRef?} for batch status changes (required for move-batch). ' +
                     'Identifiers may be numeric indices or slug strings; mixing is allowed. ' +
                     'All identifiers are resolved against a single backlog snapshot before any moves run, ' +
-                    'so indices captured from a prior `list` call remain valid for the entire batch.'
+                    'so indices captured from a prior `list` call remain valid for the entire batch. ' +
+                    'verificationRef is REQUIRED for any item whose targetStatus is "done"; the batch is rejected atomically if any done item lacks a valid ref.'
+            ),
+        verificationRef: verificationRefSchema
+            .optional()
+            .describe(
+                'Required when moving a single todo to "done". Points at a PASS criterion in verification-history.jsonl. ' +
+                    'Format: { criterionId: string, wave: number }. The criterion must exist, be met, and have non-empty evidence.'
             ),
         filterStatus: z
             .enum(['pending', 'backlog', 'done'])
@@ -109,7 +168,10 @@ export const manageTodosTool = createTool({
             indices,
             items,
             filterStatus,
-        } = inputData
+            verificationRef,
+        } = inputData as typeof inputData & {
+            verificationRef?: VerificationRef
+        }
 
         switch (action) {
             case 'list': {
@@ -145,11 +207,33 @@ export const manageTodosTool = createTool({
                     return {
                         error: 'identifier and targetStatus are required for move',
                     }
+                if (targetStatus === 'done') {
+                    const violation = validateVerificationRef(verificationRef)
+                    if (violation) {
+                        appendLedger('todo-move-blocked', {
+                            identifier: String(identifier),
+                            targetStatus,
+                            reason: violation.code,
+                            message: violation.message,
+                        })
+                        return {
+                            error: violation.message,
+                            code: violation.code,
+                        }
+                    }
+                }
                 const moved = moveTodo({
                     identifier,
                     targetStatus: targetStatus as TodoStatus,
                 })
                 if (!moved) return { error: `Todo not found: ${identifier}` }
+                if (targetStatus === 'done' && verificationRef) {
+                    appendLedger('todo-moved-to-done', {
+                        slug: moved.slug,
+                        title: moved.title,
+                        verificationRef,
+                    })
+                }
                 return {
                     moved: `#${moved.index} ${moved.title} → ${moved.status}`,
                 }
@@ -159,7 +243,69 @@ export const manageTodosTool = createTool({
                     return {
                         error: 'items array is required for move-batch',
                     }
+                // Atomic guard: validate every done item BEFORE any move runs.
+                const blocked: Array<{
+                    identifier: string
+                    code: string
+                    message: string
+                }> = []
+                for (const it of items) {
+                    if (it.targetStatus === 'done') {
+                        const violation = validateVerificationRef(
+                            it.verificationRef
+                        )
+                        if (violation) {
+                            blocked.push({
+                                identifier: String(it.identifier),
+                                code: violation.code,
+                                message: violation.message,
+                            })
+                        }
+                    }
+                }
+                if (blocked.length > 0) {
+                    for (const b of blocked) {
+                        appendLedger('todo-move-blocked', {
+                            identifier: b.identifier,
+                            targetStatus: 'done',
+                            reason: b.code,
+                            message: b.message,
+                        })
+                    }
+                    return {
+                        error: `move-batch rejected: ${blocked.length} done-move(s) lack a valid verificationRef. The whole batch was atomic; no todos were moved.`,
+                        code: 'TODO_DONE_UNVERIFIED',
+                        blocked,
+                    }
+                }
+
                 const result = moveBatch({ items })
+
+                // Log each successful done move with its ref so postmortem can correlate.
+                const refByIdentifier = new Map<string, VerificationRef>()
+                for (const it of items) {
+                    if (it.targetStatus === 'done' && it.verificationRef) {
+                        refByIdentifier.set(
+                            String(it.identifier),
+                            it.verificationRef
+                        )
+                    }
+                }
+                for (const t of result.moved) {
+                    if (t.status === 'done') {
+                        const ref =
+                            refByIdentifier.get(String(t.index)) ??
+                            refByIdentifier.get(t.slug)
+                        if (ref) {
+                            appendLedger('todo-moved-to-done', {
+                                slug: t.slug,
+                                title: t.title,
+                                verificationRef: ref,
+                            })
+                        }
+                    }
+                }
+
                 return {
                     moved: result.moved.map(
                         (t) => `#${t.index} ${t.title} → ${t.status}`

--- a/packages/luca-mastracode/src/tools/manage-todos.ts
+++ b/packages/luca-mastracode/src/tools/manage-todos.ts
@@ -60,6 +60,12 @@ function validateVerificationRef(ref: VerificationRef | undefined): {
             message: `Criterion "${ref.criterionId}" (wave ${ref.wave}) has empty evidence. Move blocked — re-run verification with concrete evidence (file/line/test).`,
         }
     }
+    if (found.result.status !== 'PASS') {
+        return {
+            code: 'TODO_DONE_UNVERIFIED',
+            message: `Criterion "${ref.criterionId}" (wave ${ref.wave}) belongs to a verification result with status "${found.result.status}", not PASS. Cannot move the todo to done — fix the failing/stalled wave first.`,
+        }
+    }
     return null
 }
 

--- a/packages/luca-mastracode/src/tools/manage-todos.ts
+++ b/packages/luca-mastracode/src/tools/manage-todos.ts
@@ -12,7 +12,11 @@ import {
     readTodoContent,
     type TodoStatus,
 } from '../todos.js'
-import { findCriterion } from '../verification-result.js'
+import {
+    findCriterion,
+    readVerificationHistory,
+    type VerificationResult,
+} from '../verification-result.js'
 
 const verificationRefSchema = z.object({
     criterionId: z
@@ -30,7 +34,10 @@ type VerificationRef = z.infer<typeof verificationRefSchema>
  * Validate a verificationRef points at a real, met, evidence-backed criterion.
  * Returns null on success, or a structured error payload to return to the caller.
  */
-function validateVerificationRef(ref: VerificationRef | undefined): {
+function validateVerificationRef(
+    ref: VerificationRef | undefined,
+    history?: VerificationResult[]
+): {
     code: string
     message: string
 } | null {
@@ -41,7 +48,7 @@ function validateVerificationRef(ref: VerificationRef | undefined): {
                 'verificationRef is required when moving a todo to "done". Provide { criterionId, wave } pointing at a PASS criterion in verification-history.jsonl.',
         }
     }
-    const found = findCriterion(ref)
+    const found = findCriterion({ ...ref, history })
     if (!found) {
         return {
             code: 'TODO_DONE_UNVERIFIED',
@@ -250,15 +257,23 @@ export const manageTodosTool = createTool({
                         error: 'items array is required for move-batch',
                     }
                 // Atomic guard: validate every done item BEFORE any move runs.
+                // Read verification history exactly once and reuse it for every
+                // item — otherwise this is O(items × history) on disk reads.
                 const blocked: Array<{
                     identifier: string
                     code: string
                     message: string
                 }> = []
+                const historyForBatch = items.some(
+                    (it) => it.targetStatus === 'done'
+                )
+                    ? readVerificationHistory()
+                    : undefined
                 for (const it of items) {
                     if (it.targetStatus === 'done') {
                         const violation = validateVerificationRef(
-                            it.verificationRef
+                            it.verificationRef,
+                            historyForBatch
                         )
                         if (violation) {
                             blocked.push({

--- a/packages/luca-mastracode/src/tools/mode-permissions.ts
+++ b/packages/luca-mastracode/src/tools/mode-permissions.ts
@@ -22,12 +22,14 @@ export const MODE_PERMISSIONS: Record<
         workflow_state: '*',
         repo_cleanup: '*',
         pr_review: '*',
+        run_rules: '*',
     },
     fast: {
         manage_todos: '*',
         workflow_state: '*',
         repo_cleanup: ['scan', 'parse-report', 'summary'],
         pr_review: '*',
+        run_rules: '*',
     },
     plan: {
         classify_complexity: '*',
@@ -69,6 +71,7 @@ export const MODE_PERMISSIONS: Record<
         manage_todos: ['list', 'read', 'move', 'move-batch'],
         pipeline_lock: ['update'],
         run_checks: '*',
+        run_rules: ['list', 'run', 'gate'],
         verification_result: '*',
         write_planning_file: ['write', 'read'],
         confidence_journal: '*',
@@ -76,6 +79,7 @@ export const MODE_PERMISSIONS: Record<
     'luca:5-review': {
         workflow_state: ['read', 'save-review-results', 'switch-mode'],
         run_checks: '*',
+        run_rules: ['list', 'run'],
         verification_result: ['read', 'read-history', 'aggregate'],
         repo_cleanup: ['scan', 'parse-report', 'summary'],
         write_planning_file: ['write', 'read'],
@@ -99,5 +103,6 @@ export const MODE_PERMISSIONS: Record<
         confidence_journal: ['read', 'summary', 'render'],
         run_postmortem: '*',
         claim_verifier: '*',
+        run_rules: '*',
     },
 } as const

--- a/packages/luca-mastracode/src/tools/mode-permissions.ts
+++ b/packages/luca-mastracode/src/tools/mode-permissions.ts
@@ -78,6 +78,7 @@ export const MODE_PERMISSIONS: Record<
         repo_cleanup: ['scan', 'parse-report', 'summary'],
         write_planning_file: ['write', 'read'],
         confidence_journal: ['read', 'summary'],
+        claim_verifier: ['verify-text', 'verify-file'],
     },
     'luca:6-finalize': {
         workflow_state: [
@@ -95,5 +96,6 @@ export const MODE_PERMISSIONS: Record<
         repo_cleanup: '*',
         confidence_journal: ['read', 'summary', 'render'],
         run_postmortem: '*',
+        claim_verifier: '*',
     },
 } as const

--- a/packages/luca-mastracode/src/tools/mode-permissions.ts
+++ b/packages/luca-mastracode/src/tools/mode-permissions.ts
@@ -13,6 +13,8 @@
  * 2. Register the base tool in build-mode-tools.ts TOOL_REGISTRY.
  * 3. That's it — buildModeTools() handles scoping automatically.
  */
+import { MODES } from '../modes/mode-ids.js'
+
 export const MODE_PERMISSIONS: Record<
     string,
     Record<string, readonly string[] | '*'>
@@ -36,29 +38,29 @@ export const MODE_PERMISSIONS: Record<
         session_ledger: '*',
         workflow_state: ['read'],
     },
-    'luca:discuss': {
+    [MODES.discuss]: {
         session_ledger: '*',
         manage_todos: ['list', 'read'],
         workflow_state: ['read'],
         run_postmortem: ['analyze', 'list-runs'],
     },
-    'luca:1-triage': {
+    [MODES.triage]: {
         classify_complexity: '*',
         workflow_state: ['read', 'save-triage-results', 'switch-mode'],
         pipeline_lock: ['status', 'recover', 'acquire'],
         manage_todos: ['list', 'read'],
     },
-    'luca:2-research': {
+    [MODES.research]: {
         workflow_state: ['read', 'switch-mode'],
         manage_todos: ['list', 'read', 'add'],
         write_planning_file: ['write', 'read'],
     },
-    'luca:3-architect': {
+    [MODES.architect]: {
         manage_roadmap: '*',
         workflow_state: ['read', 'save-plan-artifacts', 'switch-mode'],
         write_planning_file: ['write', 'read'],
     },
-    'luca:4-execute': {
+    [MODES.execute]: {
         workflow_state: [
             'read',
             'start-phase',
@@ -76,7 +78,7 @@ export const MODE_PERMISSIONS: Record<
         write_planning_file: ['write', 'read'],
         confidence_journal: '*',
     },
-    'luca:5-review': {
+    [MODES.review]: {
         workflow_state: ['read', 'save-review-results', 'switch-mode'],
         run_checks: '*',
         run_rules: ['list', 'run'],
@@ -86,7 +88,7 @@ export const MODE_PERMISSIONS: Record<
         confidence_journal: ['read', 'summary'],
         claim_verifier: ['verify-text', 'verify-file'],
     },
-    'luca:6-finalize': {
+    [MODES.finalize]: {
         workflow_state: [
             'read',
             'reset-pipeline',

--- a/packages/luca-mastracode/src/tools/mode-permissions.ts
+++ b/packages/luca-mastracode/src/tools/mode-permissions.ts
@@ -21,11 +21,13 @@ export const MODE_PERMISSIONS: Record<
         manage_todos: '*',
         workflow_state: '*',
         repo_cleanup: '*',
+        pr_review: '*',
     },
     fast: {
         manage_todos: '*',
         workflow_state: '*',
         repo_cleanup: ['scan', 'parse-report', 'summary'],
+        pr_review: '*',
     },
     plan: {
         classify_complexity: '*',

--- a/packages/luca-mastracode/src/tools/mode-permissions.ts
+++ b/packages/luca-mastracode/src/tools/mode-permissions.ts
@@ -36,6 +36,7 @@ export const MODE_PERMISSIONS: Record<
         session_ledger: '*',
         manage_todos: ['list', 'read'],
         workflow_state: ['read'],
+        run_postmortem: ['analyze', 'list-runs'],
     },
     'luca:1-triage': {
         classify_complexity: '*',
@@ -60,6 +61,7 @@ export const MODE_PERMISSIONS: Record<
             'record-iteration',
             'advance-wave',
             'complete-phase',
+            'justify-empty-phase',
             'switch-mode',
         ],
         manage_todos: ['list', 'read', 'move', 'move-batch'],
@@ -83,6 +85,7 @@ export const MODE_PERMISSIONS: Record<
             'reset-pipeline',
             'switch-mode',
             're-enter-pipeline',
+            'justify-empty-phase',
         ],
         run_checks: '*',
         pipeline_lock: ['release'],
@@ -91,5 +94,6 @@ export const MODE_PERMISSIONS: Record<
         manage_todos: ['list', 'read', 'move', 'move-batch'],
         repo_cleanup: '*',
         confidence_journal: ['read', 'summary', 'render'],
+        run_postmortem: '*',
     },
 } as const

--- a/packages/luca-mastracode/src/tools/pipeline-lock.ts
+++ b/packages/luca-mastracode/src/tools/pipeline-lock.ts
@@ -6,6 +6,7 @@ import { z } from 'zod'
 
 import { atomicWriteSync } from '../atomic-write.js'
 import { readLucaState } from '../luca-store.js'
+import { MODES } from '../modes/mode-ids.js'
 
 const LOCK_FILE = '.planning/.luca-lock.json'
 
@@ -39,7 +40,7 @@ function determineRecovery(lock: LockInfo): {
     if (!step || step === 'init' || step === 'idle' || step === 'triage') {
         return {
             strategy: 'fresh-start',
-            resumeMode: 'luca:1-triage',
+            resumeMode: MODES.triage,
             reason: 'No meaningful pipeline progress to resume',
         }
     }
@@ -48,7 +49,7 @@ function determineRecovery(lock: LockInfo): {
     if (step === 'research') {
         return {
             strategy: 'restart-step',
-            resumeMode: 'luca:2-research',
+            resumeMode: MODES.research,
             reason: 'Crashed during research — restarting step',
         }
     }
@@ -69,7 +70,7 @@ function determineRecovery(lock: LockInfo): {
     ) {
         return {
             strategy: 'restart-step',
-            resumeMode: 'luca:3-architect',
+            resumeMode: MODES.architect,
             reason: `Crashed during ${step} — restarting architect mode`,
         }
     }
@@ -81,14 +82,14 @@ function determineRecovery(lock: LockInfo): {
         if (phaseName) {
             return {
                 strategy: 'resume-phase',
-                resumeMode: 'luca:4-execute',
+                resumeMode: MODES.execute,
                 resumePhase: phaseName,
                 reason: `Crashed during ${step} in phase "${phaseName}" wave ${wave} — resuming execution`,
             }
         }
         return {
             strategy: 'restart-step',
-            resumeMode: 'luca:4-execute',
+            resumeMode: MODES.execute,
             reason: `Crashed during ${step} — restarting execute mode`,
         }
     }
@@ -97,7 +98,7 @@ function determineRecovery(lock: LockInfo): {
     if (['review', 'review-audit', 'learn'].includes(step)) {
         return {
             strategy: 'resume-phase',
-            resumeMode: 'luca:5-review',
+            resumeMode: MODES.review,
             reason: `Crashed during ${step} — resuming review`,
         }
     }
@@ -106,7 +107,7 @@ function determineRecovery(lock: LockInfo): {
     if (['milestone', 'gap-audit', 'cleanup'].includes(step)) {
         return {
             strategy: 'advance-phase',
-            resumeMode: 'luca:6-finalize',
+            resumeMode: MODES.finalize,
             reason: `Crashed during ${step} — advancing to finalize`,
         }
     }
@@ -114,7 +115,7 @@ function determineRecovery(lock: LockInfo): {
     // Default fallback
     return {
         strategy: 'fresh-start',
-        resumeMode: 'luca:1-triage',
+        resumeMode: MODES.triage,
         reason: `Unknown step "${step}" — starting fresh`,
     }
 }

--- a/packages/luca-mastracode/src/tools/pr-review.ts
+++ b/packages/luca-mastracode/src/tools/pr-review.ts
@@ -1,0 +1,256 @@
+/**
+ * pr-review (tool) — Mastra tool wrapper for PR-review hardening primitives.
+ *
+ * Three actions:
+ *   - filter-stale: drop comments whose cited code has been changed since
+ *     the comment was filed. Used by pr-address before categorization to
+ *     stop the iteration loop from spending cycles on already-fixed issues.
+ *   - detect-convergence: group findings by location across reviewer
+ *     perspectives; auto-promote severity when >=2 perspectives flag the
+ *     same line (catches the case where Copilot + reviewer + claim-verifier
+ *     each flag the same code as "should-fix" but together it should be must-fix).
+ *   - regression-check: given pre/post fix-iteration finding snapshots and
+ *     the list of paths the iteration touched, surface findings introduced
+ *     by the iteration itself (new-on-touched-path or severity-escalated).
+ *
+ * Every call appends a `pr-review-run` ledger event so the postmortem
+ * analyzer can observe verifier activity over time.
+ */
+import { createTool } from '@mastra/core/tools'
+import { z } from 'zod'
+
+import { appendLedger } from '../session-ledger.js'
+import {
+    filterStaleComments,
+    type PrReviewComment,
+} from '../pr-review/stale-filter.js'
+import {
+    detectConvergence,
+    type ReviewFinding,
+} from '../pr-review/convergence.js'
+import {
+    checkRegression,
+    diffPaths,
+} from '../pr-review/regression.js'
+
+const reviewCommentSchema = z.object({
+    id: z.number(),
+    path: z.string(),
+    line: z.number().nullable(),
+    original_line: z.number().nullable(),
+    commit_id: z.string(),
+    original_commit_id: z.string(),
+    diff_hunk: z.string(),
+    body: z.string(),
+    in_reply_to_id: z.number().nullable().optional(),
+    user: z
+        .object({
+            login: z.string().optional(),
+            type: z.string().optional(),
+        })
+        .optional(),
+})
+
+const reviewFindingSchema = z.object({
+    id: z.string(),
+    perspective: z.string(),
+    path: z.string().optional(),
+    line: z.number().optional(),
+    severity: z.string(),
+    category: z.string().optional(),
+    summary: z.string(),
+})
+
+export const prReviewTool = createTool({
+    id: 'pr-review',
+    description:
+        'Harden the PR-address loop: filter stale Copilot comments whose cited code has been rewritten, ' +
+        'detect cross-perspective convergence (auto-promote severity when 2+ reviewers flag the same line), ' +
+        'and run iteration-N regression checks (catch findings introduced by fix commits). ' +
+        "Use 'filter-stale' before categorization, 'detect-convergence' on combined findings, " +
+        "and 'regression-check' after each fix iteration.",
+    inputSchema: z.object({
+        action: z
+            .enum(['filter-stale', 'detect-convergence', 'regression-check'])
+            .describe(
+                'filter-stale: drop comments whose cited code changed | detect-convergence: group findings, promote severity | regression-check: detect new findings introduced by fix iteration'
+            ),
+        // filter-stale
+        comments: z
+            .array(reviewCommentSchema)
+            .optional()
+            .describe('PR review comments (filter-stale only).'),
+        headSha: z
+            .string()
+            .optional()
+            .describe(
+                'Override HEAD SHA for stale-filter and regression diffs. Defaults to current git HEAD.'
+            ),
+        maxDriftLines: z
+            .number()
+            .optional()
+            .describe(
+                'Stale-filter: max line drift before treating relocated anchor as stale (default 5).'
+            ),
+        // detect-convergence
+        findings: z
+            .array(reviewFindingSchema)
+            .optional()
+            .describe('Combined findings across perspectives (detect-convergence only).'),
+        lineTolerance: z
+            .number()
+            .optional()
+            .describe(
+                'Detect-convergence: lines within +/- this distance count as the same location (default 2).'
+            ),
+        // regression-check
+        before: z
+            .array(reviewFindingSchema)
+            .optional()
+            .describe('Pre-iteration findings snapshot (regression-check only).'),
+        after: z
+            .array(reviewFindingSchema)
+            .optional()
+            .describe('Post-iteration findings snapshot (regression-check only).'),
+        touchedPaths: z
+            .array(z.string())
+            .optional()
+            .describe(
+                'Paths modified by fix commits in this iteration. If omitted but `fromSha`/`toSha` are provided, paths are computed via git diff.'
+            ),
+        fromSha: z
+            .string()
+            .optional()
+            .describe('Iteration-start SHA (regression-check, optional alternative to touchedPaths).'),
+        toSha: z
+            .string()
+            .optional()
+            .describe('Iteration-end SHA (regression-check, optional alternative to touchedPaths).'),
+    }),
+    execute: async (inputData) => {
+        const repoRoot = process.cwd()
+        const action = inputData.action
+
+        switch (action) {
+            case 'filter-stale': {
+                const comments = inputData.comments
+                if (!comments || comments.length === 0) {
+                    appendLedger('pr-review-run', {
+                        action,
+                        inputCount: 0,
+                        staleCount: 0,
+                    })
+                    return {
+                        success: true,
+                        message: 'No comments provided.',
+                        actionable: [],
+                        stale: [],
+                        replies: [],
+                    }
+                }
+                const result = filterStaleComments(comments as PrReviewComment[], {
+                    repoRoot,
+                    headSha: inputData.headSha,
+                    maxDriftLines: inputData.maxDriftLines,
+                })
+                appendLedger('pr-review-run', {
+                    action,
+                    inputCount: comments.length,
+                    actionableCount: result.actionable.length,
+                    staleCount: result.stale.length,
+                    repliesCount: result.replies.length,
+                })
+                return {
+                    success: true,
+                    message: `Filtered ${comments.length} comment(s): ${result.actionable.length} actionable, ${result.stale.length} stale, ${result.replies.length} replies.`,
+                    actionable: result.actionable,
+                    stale: result.stale,
+                    replies: result.replies,
+                    verdicts: result.verdicts,
+                }
+            }
+
+            case 'detect-convergence': {
+                const findings = inputData.findings ?? []
+                if (findings.length === 0) {
+                    appendLedger('pr-review-run', {
+                        action,
+                        inputCount: 0,
+                        convergentCount: 0,
+                    })
+                    return {
+                        success: true,
+                        message: 'No findings provided.',
+                        report: {
+                            groups: [],
+                            convergentGroups: [],
+                            promotions: [],
+                            promotedFindings: [],
+                        },
+                    }
+                }
+                const report = detectConvergence(findings as ReviewFinding[], {
+                    lineTolerance: inputData.lineTolerance,
+                })
+                appendLedger('pr-review-run', {
+                    action,
+                    inputCount: findings.length,
+                    convergentCount: report.convergentGroups.length,
+                    promotionCount: report.promotions.length,
+                })
+                return {
+                    success: true,
+                    message: `Analyzed ${findings.length} finding(s): ${report.convergentGroups.length} convergent group(s), ${report.promotions.length} promotion(s).`,
+                    report,
+                }
+            }
+
+            case 'regression-check': {
+                const before = (inputData.before ?? []) as ReviewFinding[]
+                const after = (inputData.after ?? []) as ReviewFinding[]
+                let touchedPaths = inputData.touchedPaths ?? []
+                if (
+                    touchedPaths.length === 0 &&
+                    inputData.fromSha &&
+                    inputData.toSha
+                ) {
+                    touchedPaths = diffPaths(
+                        repoRoot,
+                        inputData.fromSha,
+                        inputData.toSha
+                    )
+                }
+                const report = checkRegression({ before, after, touchedPaths })
+                appendLedger('pr-review-run', {
+                    action,
+                    beforeCount: before.length,
+                    afterCount: after.length,
+                    touchedPathCount: touchedPaths.length,
+                    regressionCount: report.regressions.length,
+                    resolvedCount: report.resolved.length,
+                })
+                if (report.regressions.length > 0) {
+                    return {
+                        success: false,
+                        code: 'PR_REVIEW_REGRESSION_DETECTED',
+                        message: `Regression check found ${report.regressions.length} regression(s) introduced by this iteration. Re-enter execute mode to address before opening additional iterations.`,
+                        report,
+                        touchedPaths,
+                    }
+                }
+                return {
+                    success: true,
+                    message: `Regression check passed: ${report.resolved.length} resolved, ${report.unchanged.length} unchanged, ${report.newButUntouched.length} new on untouched paths.`,
+                    report,
+                    touchedPaths,
+                }
+            }
+
+            default:
+                return {
+                    success: false,
+                    message: `Unknown action: ${String(action)}`,
+                }
+        }
+    },
+})

--- a/packages/luca-mastracode/src/tools/run-postmortem.ts
+++ b/packages/luca-mastracode/src/tools/run-postmortem.ts
@@ -1,0 +1,105 @@
+/**
+ * run-postmortem (tool) — Mastra tool wrapper for the postmortem analyzer.
+ *
+ * Three actions:
+ *   - analyze: return the structured PostmortemReport.
+ *   - render:  write `.planning/POSTMORTEM.md` and return the path + violation count.
+ *   - gate:    same as analyze, but returns success=false with code POSTMORTEM_VIOLATIONS
+ *              if any critical violations exist. Used by finalize as the last
+ *              gate before PR creation.
+ *
+ * The tool returns a `pitfalls` array of pre-formatted MuninnDB payloads
+ * (default vault, type=pitfall) that the calling agent should forward via
+ * `mcp__muninn__muninn_remember` so future runs can recall recurring failures.
+ */
+import { createTool } from '@mastra/core/tools'
+import { z } from 'zod'
+
+import {
+    analyzeRun,
+    writePostmortem,
+    listRuns,
+} from '../postmortem.js'
+
+export const runPostmortemTool = createTool({
+    id: 'run-postmortem',
+    description:
+        'Analyze a Luca pipeline run for silent skips, unverified todo completions, and other gaps. ' +
+        "Use 'gate' as the last call in finalize before PR creation — critical violations block the PR. " +
+        "Use 'render' to write a human-readable .planning/POSTMORTEM.md report. " +
+        "Use 'analyze' for read-only inspection. " +
+        "Use 'list-runs' to enumerate archived runs in the ledger. " +
+        'The tool returns a `pitfalls` array of pre-formatted MuninnDB payloads (default vault) — forward each via mcp__muninn__muninn_remember.',
+    inputSchema: z.object({
+        action: z
+            .enum(['analyze', 'render', 'gate', 'list-runs'])
+            .describe(
+                'analyze: structured report | render: write .planning/POSTMORTEM.md | gate: block on critical violations | list-runs: enumerate archived runs'
+            ),
+        runId: z
+            .string()
+            .optional()
+            .describe(
+                'Optional run ID to analyze. Defaults to the current run.'
+            ),
+    }),
+    execute: async (inputData) => {
+        const { action, runId } = inputData
+
+        switch (action) {
+            case 'analyze': {
+                const report = analyzeRun(runId)
+                return {
+                    success: true,
+                    message: `Run ${report.runId}: ${report.violations.length} violation(s) (${report.violations.filter((v) => v.severity === 'critical').length} critical)`,
+                    report,
+                }
+            }
+            case 'render': {
+                const report = analyzeRun(runId)
+                const { path, bytes } = writePostmortem(report)
+                return {
+                    success: true,
+                    message: `Wrote ${path} (${bytes} bytes). ${report.violations.length} violation(s).`,
+                    path,
+                    violationCount: report.violations.length,
+                    pitfalls: report.pitfalls,
+                }
+            }
+            case 'gate': {
+                const report = analyzeRun(runId)
+                const critical = report.violations.filter(
+                    (v) => v.severity === 'critical'
+                )
+                if (critical.length > 0) {
+                    return {
+                        success: false,
+                        code: 'POSTMORTEM_VIOLATIONS',
+                        message: `Postmortem gate failed: ${critical.length} critical violation(s). Re-enter pipeline at execute or review and resolve before finalizing.`,
+                        violations: report.violations,
+                        pitfalls: report.pitfalls,
+                    }
+                }
+                return {
+                    success: true,
+                    message: `Postmortem gate passed. ${report.violations.length} warning(s) (no criticals).`,
+                    violations: report.violations,
+                    pitfalls: report.pitfalls,
+                }
+            }
+            case 'list-runs': {
+                const runs = listRuns()
+                return {
+                    success: true,
+                    message: `${runs.length} run(s) in ledger`,
+                    runs,
+                }
+            }
+            default:
+                return {
+                    success: false,
+                    message: `Unknown action: ${String(action)}`,
+                }
+        }
+    },
+})

--- a/packages/luca-mastracode/src/tools/run-postmortem.ts
+++ b/packages/luca-mastracode/src/tools/run-postmortem.ts
@@ -20,6 +20,7 @@ import {
     writePostmortem,
     listRuns,
 } from '../postmortem.js'
+import { listArchivedRuns } from '../session-ledger.js'
 
 export const runPostmortemTool = createTool({
     id: 'run-postmortem',
@@ -53,6 +54,7 @@ export const runPostmortemTool = createTool({
                     success: true,
                     message: `Run ${report.runId}: ${report.violations.length} violation(s) (${report.violations.filter((v) => v.severity === 'critical').length} critical)`,
                     report,
+                    pitfalls: report.pitfalls,
                 }
             }
             case 'render': {
@@ -88,10 +90,25 @@ export const runPostmortemTool = createTool({
                 }
             }
             case 'list-runs': {
-                const runs = listRuns()
+                const liveRuns = listRuns()
+                const liveIds = new Set(liveRuns.map((r) => r.runId))
+                const archivedOnly = listArchivedRuns()
+                    .filter((id) => !liveIds.has(id))
+                    .map((runId) => ({
+                        runId,
+                        firstEvent: '',
+                        lastEvent: '',
+                        eventCount: 0,
+                        archived: true as const,
+                    }))
+                const live = liveRuns.map((r) => ({
+                    ...r,
+                    archived: false as const,
+                }))
+                const runs = [...live, ...archivedOnly]
                 return {
                     success: true,
-                    message: `${runs.length} run(s) in ledger`,
+                    message: `${runs.length} run(s) (live: ${live.length}, archived-only: ${archivedOnly.length})`,
                     runs,
                 }
             }

--- a/packages/luca-mastracode/src/tools/run-rules.ts
+++ b/packages/luca-mastracode/src/tools/run-rules.ts
@@ -1,7 +1,7 @@
 /**
  * run-rules (tool) — Mastra tool wrapper for the repo-local rule pack engine.
  *
- * Three actions:
+ * Four actions:
  *   - list:  discover rules in `.luca/rules/` and return their metadata
  *            without executing them. Useful for confirming what rules a
  *            repo has loaded before running them.
@@ -13,6 +13,10 @@
  *            `code: RULE_VIOLATIONS_DETECTED`) when any finding has
  *            severity `must-fix`. Used by execute-verify before declaring
  *            a wave passing.
+ *   - suggest: scan postmortems for recurring pitfalls and render draft
+ *            rules to `.planning/SUGGESTED-RULES.md`. Promotes pitfalls
+ *            seen in N or more distinct runs (default 3) into rule
+ *            templates the user can finalize.
  *
  * Every call appends a `rules-run` ledger event with totals so the
  * postmortem analyzer can observe rule activity over time.

--- a/packages/luca-mastracode/src/tools/run-rules.ts
+++ b/packages/luca-mastracode/src/tools/run-rules.ts
@@ -1,0 +1,170 @@
+/**
+ * run-rules (tool) — Mastra tool wrapper for the repo-local rule pack engine.
+ *
+ * Three actions:
+ *   - list:  discover rules in `.luca/rules/` and return their metadata
+ *            without executing them. Useful for confirming what rules a
+ *            repo has loaded before running them.
+ *   - run:   discover, load, and execute all rules. Returns the full
+ *            RuleRunReport including findings, timings, and any
+ *            load/execution errors. Non-blocking (returns success: true
+ *            with the report; the caller decides how to act on findings).
+ *   - gate:  same as `run` but blocks (`success: false`,
+ *            `code: RULE_VIOLATIONS_DETECTED`) when any finding has
+ *            severity `must-fix`. Used by execute-verify before declaring
+ *            a wave passing.
+ *
+ * Every call appends a `rules-run` ledger event with totals so the
+ * postmortem analyzer can observe rule activity over time.
+ */
+import { createTool } from '@mastra/core/tools'
+import { z } from 'zod'
+
+import {
+    detectRecurringPitfalls,
+    renderSuggestedRulesMarkdown,
+    writeSuggestedRules,
+} from '../rules/recurrence.js'
+import { discoverAndRun, loadRules } from '../rules/runner.js'
+import { appendLedger } from '../session-ledger.js'
+
+export const runRulesTool = createTool({
+    id: 'run-rules',
+    description:
+        'Discover, load, and run repo-local rule packs from `.luca/rules/`. ' +
+        "Use 'list' to inspect what rules are present without running them, " +
+        "'run' to execute all rules and collect findings (non-blocking), " +
+        "and 'gate' to block on any must-fix findings (used at execute-verify time). " +
+        'Repo-local rules encode the project-specific "house rules" that recur in ' +
+        'PR review feedback (Convex anti-patterns, auth requirements, naming conventions, etc.).',
+    inputSchema: z.object({
+        action: z
+            .enum(['list', 'run', 'gate', 'suggest'])
+            .describe(
+                'list: discover and return rule metadata only | run: execute all rules, return findings | gate: execute and block on must-fix findings | suggest: scan postmortems for recurring pitfalls and render draft rules to .planning/SUGGESTED-RULES.md'
+            ),
+        rulesDir: z
+            .string()
+            .optional()
+            .describe(
+                'Override the rules directory (default: `.luca/rules/` relative to the repo root).'
+            ),
+        threshold: z
+            .number()
+            .optional()
+            .describe(
+                'suggest: minimum number of distinct runs a pitfall must appear in to be promoted (default 3).'
+            ),
+        write: z
+            .boolean()
+            .optional()
+            .describe(
+                'suggest: when true (default), write SUGGESTED-RULES.md to .planning/. When false, return the rendered markdown without writing.'
+            ),
+    }),
+    execute: async (inputData) => {
+        const repoRoot = process.cwd()
+        const action = inputData.action
+
+        if (action === 'suggest') {
+            const threshold = inputData.threshold ?? 3
+            const report = detectRecurringPitfalls({ threshold })
+            const shouldWrite = inputData.write !== false
+            let writePath: string | undefined
+            let bytes = 0
+            if (shouldWrite) {
+                const result = writeSuggestedRules({ repoRoot, report })
+                writePath = result.path
+                bytes = result.bytes
+            }
+            const markdown = shouldWrite
+                ? undefined
+                : renderSuggestedRulesMarkdown(report)
+            appendLedger('rules-run', {
+                action,
+                runsScanned: report.runsScanned,
+                threshold,
+                recurring: report.recurring.length,
+                wrote: shouldWrite,
+            })
+            return {
+                success: true,
+                message:
+                    report.recurring.length === 0
+                        ? `No recurring pitfalls met the threshold (>= ${threshold} runs) across ${report.runsScanned} run(s).`
+                        : `Found ${report.recurring.length} recurring pitfall(s) at threshold ${threshold}. ${
+                              shouldWrite
+                                  ? `Wrote ${bytes} bytes to ${writePath}.`
+                                  : 'Markdown returned inline.'
+                          }`,
+                report,
+                writePath,
+                markdown,
+            }
+        }
+
+        if (action === 'list') {
+            const rulesDir =
+                inputData.rulesDir ?? `${repoRoot}/.luca/rules`
+            const { rules, filesDiscovered, loadErrors } = await loadRules(
+                { rulesDir }
+            )
+            appendLedger('rules-run', {
+                action,
+                filesDiscovered,
+                rulesLoaded: rules.length,
+                loadErrors: loadErrors.length,
+            })
+            return {
+                success: true,
+                message: `Discovered ${filesDiscovered} rule file(s), loaded ${rules.length} rule(s).`,
+                rules: rules.map((r) => ({
+                    id: r.id,
+                    severity: r.severity,
+                    description: r.description,
+                    scope: r.scope,
+                    category: r.category,
+                })),
+                loadErrors,
+            }
+        }
+
+        const report = await discoverAndRun({
+            repoRoot,
+            rulesDir: inputData.rulesDir,
+        })
+
+        const mustFixFindings = report.findings.filter(
+            (f) => f.severity === 'must-fix'
+        )
+
+        appendLedger('rules-run', {
+            action,
+            filesDiscovered: report.rulesFilesDiscovered,
+            rulesLoaded: report.rulesLoaded,
+            findings: report.findings.length,
+            mustFix: mustFixFindings.length,
+            loadErrors: report.loadErrors.length,
+            executionErrors: report.executionErrors.length,
+        })
+
+        if (action === 'gate' && mustFixFindings.length > 0) {
+            return {
+                success: false,
+                code: 'RULE_VIOLATIONS_DETECTED',
+                message: `Rule gate failed: ${mustFixFindings.length} must-fix finding(s) across ${report.rulesLoaded} loaded rule(s). Re-enter execute mode to address before completing this phase.`,
+                report,
+                mustFix: mustFixFindings,
+            }
+        }
+
+        return {
+            success: true,
+            message:
+                action === 'gate'
+                    ? `Rule gate passed: ${report.rulesLoaded} rule(s) executed, ${report.findings.length} non-blocking finding(s).`
+                    : `Ran ${report.rulesLoaded} rule(s): ${report.findings.length} finding(s) (${mustFixFindings.length} must-fix).`,
+            report,
+        }
+    },
+})

--- a/packages/luca-mastracode/src/tools/workflow-state.ts
+++ b/packages/luca-mastracode/src/tools/workflow-state.ts
@@ -776,6 +776,21 @@ export const workflowStateTool = createTool({
                         raw
                     )
                     const justState = readLucaState()
+                    const currentPhaseName = justState.currentPhaseName
+                    if (!currentPhaseName) {
+                        return {
+                            success: false,
+                            code: 'NO_PHASE_IN_PROGRESS',
+                            message: `Cannot justify empty phase: no phase is currently in progress. Call workflowState(action: "start-phase", ...) first.`,
+                        }
+                    }
+                    if (phase !== currentPhaseName) {
+                        return {
+                            success: false,
+                            code: 'PHASE_MISMATCH',
+                            message: `Cannot justify empty phase: provided phase "${phase}" does not match the in-progress phase "${currentPhaseName}". Justifications can only be recorded for the active phase.`,
+                        }
+                    }
                     const existing = justState.emptyPhaseJustifications ?? {}
                     const merged = {
                         ...existing,
@@ -836,6 +851,9 @@ export const workflowStateTool = createTool({
                         phaseResults: undefined,
                         // Phase-diff snapshots (Step 2 of the postmortem plan)
                         currentPhaseStartSnapshot: undefined,
+                        // Empty-phase justifications — must clear so prior-run
+                        // justifications can't unblock complete-phase in a new run
+                        emptyPhaseJustifications: undefined,
                         // Run identity — clear so startNewRun mints a fresh ID
                         runId: undefined,
                     })

--- a/packages/luca-mastracode/src/tools/workflow-state.ts
+++ b/packages/luca-mastracode/src/tools/workflow-state.ts
@@ -13,7 +13,17 @@ import {
     type LucaWorkflowState,
 } from '../luca-store.js'
 import { switchModeRef, contextRefresherRef } from '../refs.js'
-import { appendLedger } from '../session-ledger.js'
+import {
+    appendLedger,
+    archivePriorRun,
+    startNewRun,
+} from '../session-ledger.js'
+import {
+    snapshotWorkingTree,
+    computePhaseDiff,
+    type PhaseSnapshot,
+} from '../phase-diff.js'
+import { readVerificationResult } from '../verification-result.js'
 
 const VALID_MODES = Object.keys(MODE_PERMISSIONS)
 
@@ -148,6 +158,30 @@ const saveReviewResultsAction = z.object({
     reviewIteration: z.number().optional().describe('Review iteration number'),
 })
 
+const EMPTY_PHASE_CATEGORIES = [
+    'docs-only-in-muninn',
+    'investigation-confirmed-no-change-needed',
+    'config-only-no-tracked-files',
+    'dependency-bump-via-lockfile-only',
+    'no-op-by-design',
+] as const
+
+const justifyEmptyPhaseAction = z.object({
+    action: z.literal('justify-empty-phase'),
+    phase: z.string().describe('Phase name (must match the in-progress phase).'),
+    category: z
+        .enum(EMPTY_PHASE_CATEGORIES)
+        .describe(
+            'Why this phase legitimately has no diff. Used to unblock the empty-phase guard on complete-phase.'
+        ),
+    reasoning: z
+        .string()
+        .min(20, 'Reasoning must be at least 20 characters')
+        .describe(
+            'Concrete explanation of why no code changed. Surfaces in the postmortem report for human review.'
+        ),
+})
+
 const RE_ENTER_TARGETS = ['luca:4-execute', 'luca:5-review'] as const
 
 const reEnterPipelineAction = z.object({
@@ -173,6 +207,7 @@ export const WORKFLOW_STATE_ACTIONS = [
     'record-iteration',
     'advance-wave',
     'complete-phase',
+    'justify-empty-phase',
     'save-triage-results',
     'save-plan-artifacts',
     'save-review-results',
@@ -301,6 +336,26 @@ const workflowStateInputSchema = z.object({
         .optional()
         .describe(
             "Why the pipeline is being re-entered (required for 're-enter-pipeline'). Stored in state as reEntryReason."
+        ),
+
+    // justify-empty-phase
+    phase: z
+        .string()
+        .optional()
+        .describe(
+            "Phase name (required for 'justify-empty-phase'). Must match the in-progress phase."
+        ),
+    category: z
+        .enum(EMPTY_PHASE_CATEGORIES)
+        .optional()
+        .describe(
+            "Empty-phase category (required for 'justify-empty-phase'). One of: docs-only-in-muninn | investigation-confirmed-no-change-needed | config-only-no-tracked-files | dependency-bump-via-lockfile-only | no-op-by-design."
+        ),
+    reasoning: z
+        .string()
+        .optional()
+        .describe(
+            "Concrete reasoning for why no code changed (required for 'justify-empty-phase'). Surfaces in postmortem report."
         ),
 })
 
@@ -494,6 +549,18 @@ export const workflowStateTool = createTool({
                     const { phaseName } = parseAction(startPhaseAction, raw)
                     const phaseState = startPhase({ name: phaseName })
                     appendLedger('phase-start', { phase: phaseName })
+
+                    // Snapshot working tree as proof-of-work baseline.
+                    const snapshot: PhaseSnapshot =
+                        snapshotWorkingTree(phaseName)
+                    writeLucaState({ currentPhaseStartSnapshot: snapshot })
+                    appendLedger('phase-snapshot', {
+                        phase: phaseName,
+                        headSha: snapshot.headSha,
+                        dirtyFileCount: snapshot.dirtyFiles.length,
+                        gitAvailable: snapshot.gitAvailable,
+                    })
+
                     return {
                         success: true,
                         message: `Started phase "${phaseName}" (wave 1, iteration 0)`,
@@ -524,6 +591,28 @@ export const workflowStateTool = createTool({
                     }
                 }
                 case 'advance-wave': {
+                    // Guard: refuse to advance unless the current wave has a
+                    // verification result on file. Prevents waves from being
+                    // closed silently without proof of work.
+                    const preWaveState = readLucaState()
+                    const currentWave = preWaveState.currentWave ?? 1
+                    const verification = readVerificationResult()
+                    if (
+                        !verification ||
+                        verification.wave !== currentWave
+                    ) {
+                        appendLedger('wave-advance-blocked', {
+                            phase: preWaveState.currentPhaseName,
+                            wave: currentWave,
+                            reason: 'no verification-result for current wave',
+                        })
+                        return {
+                            success: false,
+                            code: 'WAVE_ADVANCE_NO_VERIFICATION',
+                            message: `Cannot advance wave: no verification-result.json for wave ${currentWave}. Call verificationResult(action: "write", ...) before advance-wave.`,
+                        }
+                    }
+
                     const waveState = advanceWave()
                     appendLedger('wave-advance', {
                         phase: waveState.currentPhaseName,
@@ -550,18 +639,68 @@ export const workflowStateTool = createTool({
                         completePhaseAction,
                         raw
                     )
+
+                    // ── Guard 1: diff-based phase proof ─────────────────────
+                    const preState = readLucaState()
+                    const phaseName = preState.currentPhaseName ?? '<unknown>'
+                    const startSnapshot =
+                        preState.currentPhaseStartSnapshot ?? null
+                    const diff = computePhaseDiff(startSnapshot)
+                    appendLedger('phase-diff-summary', {
+                        phase: phaseName,
+                        filesChanged: diff.filesChanged,
+                        commitsAdded: diff.commitsAdded,
+                        isEmpty: diff.isEmpty,
+                        indeterminate: diff.indeterminate,
+                    })
+
+                    if (diff.isEmpty) {
+                        const justifications =
+                            preState.emptyPhaseJustifications ?? {}
+                        const j = justifications[phaseName]
+                        if (!j) {
+                            return {
+                                success: false,
+                                code: 'EMPTY_PHASE_BLOCKED',
+                                message: `Phase "${phaseName}" has zero file changes and zero commits. Either (a) call workflowState(action: "justify-empty-phase", phase: "${phaseName}", category: <category>, reasoning: "<why>") if this is intentional, or (b) re-enter execute mode to do the work.`,
+                            }
+                        }
+                    }
+
+                    // ── Guard 2: verification result must exist for current wave ──
+                    const verification = readVerificationResult()
+                    const currentWave = preState.currentWave ?? 1
+                    if (
+                        verificationPassed !== false &&
+                        (!verification ||
+                            verification.wave !== currentWave ||
+                            verification.status !== 'PASS')
+                    ) {
+                        return {
+                            success: false,
+                            code: 'PHASE_COMPLETE_NO_VERIFICATION',
+                            message: `Phase "${phaseName}" cannot be completed: no PASS verification-result.json for wave ${currentWave}. Call verificationResult(action: "write", ...) with a PASS verdict before complete-phase, or pass verificationPassed: false to record a failed completion.`,
+                        }
+                    }
+
                     const phaseResult = completePhase({
                         verificationPassed,
                         reviewPassed,
                     })
+
+                    // Clear snapshot now that the phase is closed.
+                    writeLucaState({ currentPhaseStartSnapshot: undefined })
+
                     appendLedger('phase-complete', {
-                        phase: phaseResult.completedPhaseName,
+                        phase: phaseName,
                         verificationPassed: verificationPassed ?? null,
                         reviewPassed: reviewPassed ?? null,
+                        filesChanged: diff.filesChanged.length,
+                        commitsAdded: diff.commitsAdded.length,
                     })
                     return {
                         success: true,
-                        message: `Completed phase "${phaseResult.completedPhaseName}" (${phaseResult.completedPhases}/${phaseResult.totalPhases} phases done)`,
+                        message: `Completed phase "${phaseName}" (${diff.filesChanged.length} files changed, ${diff.commitsAdded.length} commits)`,
                         state: phaseResult,
                     }
                 }
@@ -631,7 +770,44 @@ export const workflowStateTool = createTool({
                         state: reviewState,
                     }
                 }
+                case 'justify-empty-phase': {
+                    const { phase, category, reasoning } = parseAction(
+                        justifyEmptyPhaseAction,
+                        raw
+                    )
+                    const justState = readLucaState()
+                    const existing = justState.emptyPhaseJustifications ?? {}
+                    const merged = {
+                        ...existing,
+                        [phase]: {
+                            category,
+                            reasoning,
+                            at: new Date().toISOString(),
+                        },
+                    }
+                    const updatedState = writeLucaState({
+                        emptyPhaseJustifications: merged,
+                    })
+                    appendLedger('phase-empty-justification', {
+                        phase,
+                        category,
+                        reasoning,
+                    })
+                    return {
+                        success: true,
+                        message: `Recorded empty-phase justification for "${phase}" (category: ${category}). complete-phase will now accept this phase.`,
+                        state: updatedState,
+                    }
+                }
                 case 'reset-pipeline': {
+                    // Archive the prior run's ledger artifacts BEFORE wiping
+                    // state, so we don't lose audit trail when starting fresh.
+                    const priorRunId = readLucaState().runId as
+                        | string
+                        | undefined
+                    if (priorRunId) {
+                        archivePriorRun(priorRunId)
+                    }
                     const freshState = writeLucaState({
                         pipelineStep: 'idle',
                         // Triage output — stale intent is the #1 cause of session hijack
@@ -658,12 +834,20 @@ export const workflowStateTool = createTool({
                         startedAt: undefined,
                         assignedTodos: undefined,
                         phaseResults: undefined,
+                        // Phase-diff snapshots (Step 2 of the postmortem plan)
+                        currentPhaseStartSnapshot: undefined,
+                        // Run identity — clear so startNewRun mints a fresh ID
+                        runId: undefined,
                     })
-                    appendLedger('pipeline-reset', {})
+                    const newRunId = startNewRun()
+                    appendLedger('pipeline-reset', {
+                        priorRunId: priorRunId ?? null,
+                        newRunId,
+                    })
                     return {
                         success: true,
-                        message: 'Pipeline reset to idle state',
-                        state: freshState,
+                        message: `Pipeline reset to idle state (run ${newRunId})`,
+                        state: { ...freshState, runId: newRunId },
                     }
                 }
                 case 're-enter-pipeline': {

--- a/packages/luca-mastracode/src/tools/workflow-state.ts
+++ b/packages/luca-mastracode/src/tools/workflow-state.ts
@@ -1,6 +1,7 @@
 import { createTool } from '@mastra/core/tools'
 import { z } from 'zod'
 
+import { MODES } from '../modes/mode-ids.js'
 import { MODE_PERMISSIONS } from './mode-permissions.js'
 
 import {
@@ -46,12 +47,12 @@ const VALID_MODES = Object.keys(MODE_PERMISSIONS)
  * for mode ID renames; update separately if IDs change.
  */
 export const PIPELINE_ORDER: Record<string, string | undefined> = {
-    'luca:1-triage': 'luca:2-research',
-    'luca:2-research': 'luca:3-architect',
-    'luca:3-architect': 'luca:4-execute',
-    'luca:4-execute': 'luca:5-review',
-    'luca:5-review': 'luca:6-finalize',
-    'luca:6-finalize': undefined,
+    [MODES.triage]: MODES.research,
+    [MODES.research]: MODES.architect,
+    [MODES.architect]: MODES.execute,
+    [MODES.execute]: MODES.review,
+    [MODES.review]: MODES.finalize,
+    [MODES.finalize]: undefined,
 }
 
 /**
@@ -61,8 +62,8 @@ export const PIPELINE_ORDER: Record<string, string | undefined> = {
  * - Finalize → Execute:   gap-detected rework (finalize.md Step 4)
  */
 const ALLOWED_BACKWARD_TRANSITIONS: Record<string, Set<string>> = {
-    'luca:5-review': new Set(['luca:4-execute']),
-    'luca:6-finalize': new Set(['luca:3-architect', 'luca:4-execute']),
+    [MODES.review]: new Set([MODES.execute]),
+    [MODES.finalize]: new Set([MODES.architect, MODES.execute]),
 }
 
 /**
@@ -182,7 +183,7 @@ const justifyEmptyPhaseAction = z.object({
         ),
 })
 
-const RE_ENTER_TARGETS = ['luca:4-execute', 'luca:5-review'] as const
+const RE_ENTER_TARGETS = [MODES.execute, MODES.review] as const
 
 const reEnterPipelineAction = z.object({
     action: z.literal('re-enter-pipeline'),
@@ -434,7 +435,7 @@ export const workflowStateTool = createTool({
                     // --- Stale state detection on pipeline entry ---
                     const prevState = readLucaState()
                     if (
-                        targetMode === 'luca:1-triage' &&
+                        targetMode === MODES.triage &&
                         hasStaleState(prevState)
                     ) {
                         return {
@@ -480,8 +481,8 @@ export const workflowStateTool = createTool({
                         if (targetMode !== expectedNext) {
                             // Allow triage → architect skip when skipResearch is set
                             if (
-                                currentStep === 'luca:1-triage' &&
-                                targetMode === 'luca:3-architect' &&
+                                currentStep === MODES.triage &&
+                                targetMode === MODES.architect &&
                                 prevState.skipResearch
                             ) {
                                 // Skip-ahead allowed

--- a/packages/luca-mastracode/src/verification-result.ts
+++ b/packages/luca-mastracode/src/verification-result.ts
@@ -134,6 +134,34 @@ export function readVerificationHistory(): VerificationResult[] {
 }
 
 /**
+ * Find a specific criterion in the verification history by wave + criterionId.
+ * Returns the matching criterion (with the result it belongs to) or null.
+ *
+ * Used by `manageTodos(move → done)` to verify that a todo's claimed
+ * verification reference actually exists and was met.
+ */
+export function findCriterion({
+    criterionId,
+    wave,
+}: {
+    criterionId: string
+    wave: number
+}): {
+    criterion: VerificationCriterion
+    result: VerificationResult
+} | null {
+    const history = readVerificationHistory()
+    // Iterate newest → oldest so the most recent verdict wins.
+    for (let i = history.length - 1; i >= 0; i--) {
+        const r = history[i]
+        if (!r || r.wave !== wave) continue
+        const c = r.criteria.find((cc) => cc.criterionId === criterionId)
+        if (c) return { criterion: c, result: r }
+    }
+    return null
+}
+
+/**
  * Aggregate verification results for milestone validation.
  * Returns overall pass/fail and summary stats.
  */

--- a/packages/luca-mastracode/src/verification-result.ts
+++ b/packages/luca-mastracode/src/verification-result.ts
@@ -9,6 +9,8 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 
+import { getCurrentRunId } from './session-ledger.js'
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -40,6 +42,13 @@ export interface CheckResult {
 export interface VerificationResult {
     /** ISO 8601 timestamp */
     timestamp: string
+    /**
+     * Run that produced this result. Stamped on write; validated on read.
+     * A stale result from a prior run (mismatched runId) is treated as
+     * absent so it can't satisfy wave/phase guards in the new run.
+     * Optional for back-compat with results written before runId stamping.
+     */
+    runId?: string
     /** Pipeline phase (e.g. "Phase 1: Setup") */
     phase?: string
     /** Wave/iteration number */
@@ -87,13 +96,27 @@ function ensurePlanningDir(): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Read the latest verification result. Returns null if no result exists.
+ * Read the latest verification result. Returns null if no result exists,
+ * if the file is unparseable, or if the stamped `runId` doesn't match the
+ * current run (defense against a prior run's stale snapshot satisfying
+ * the new run's wave/phase guards). Results without a `runId` field are
+ * treated as legacy and accepted for back-compat.
  */
 export function readVerificationResult(): VerificationResult | null {
     const p = resultPath()
     if (!existsSync(p)) return null
     try {
-        return JSON.parse(readFileSync(p, 'utf-8'))
+        const parsed = JSON.parse(
+            readFileSync(p, 'utf-8'),
+        ) as VerificationResult
+        if (
+            typeof parsed.runId === 'string' &&
+            parsed.runId.length > 0 &&
+            parsed.runId !== getCurrentRunId()
+        ) {
+            return null
+        }
+        return parsed
     } catch {
         return null
     }
@@ -101,12 +124,18 @@ export function readVerificationResult(): VerificationResult | null {
 
 /**
  * Write a verification result (overwrites latest, appends to history).
+ * Stamps the current `runId` so a stale snapshot from a prior run can't
+ * silently satisfy the new run's wave/phase guards.
  */
 export function writeVerificationResult(result: VerificationResult): void {
     ensurePlanningDir()
-    writeFileSync(resultPath(), JSON.stringify(result, null, 2), 'utf-8')
+    const stamped: VerificationResult = {
+        ...result,
+        runId: result.runId ?? getCurrentRunId(),
+    }
+    writeFileSync(resultPath(), JSON.stringify(stamped, null, 2), 'utf-8')
     // Append to history (one JSON object per line)
-    const line = JSON.stringify(result) + '\n'
+    const line = JSON.stringify(stamped) + '\n'
     const hp = historyPath()
     if (existsSync(hp)) {
         const existing = readFileSync(hp, 'utf-8')

--- a/packages/luca-mastracode/src/verification-result.ts
+++ b/packages/luca-mastracode/src/verification-result.ts
@@ -139,21 +139,27 @@ export function readVerificationHistory(): VerificationResult[] {
  *
  * Used by `manageTodos(move → done)` to verify that a todo's claimed
  * verification reference actually exists and was met.
+ *
+ * Pass a preloaded `history` array when validating many criteria in a row
+ * (e.g. `move-batch`) to avoid re-reading and re-parsing the JSONL file
+ * once per item.
  */
 export function findCriterion({
     criterionId,
     wave,
+    history,
 }: {
     criterionId: string
     wave: number
+    history?: VerificationResult[]
 }): {
     criterion: VerificationCriterion
     result: VerificationResult
 } | null {
-    const history = readVerificationHistory()
+    const records = history ?? readVerificationHistory()
     // Iterate newest → oldest so the most recent verdict wins.
-    for (let i = history.length - 1; i >= 0; i--) {
-        const r = history[i]
+    for (let i = records.length - 1; i >= 0; i--) {
+        const r = records[i]
         if (!r || r.wave !== wave) continue
         const c = r.criteria.find((cc) => cc.criterionId === criterionId)
         if (c) return { criterion: c, result: r }


### PR DESCRIPTION
## Summary

A single combined release covering five phases of harness hardening, derived from a cross-corpus PR-review audit identifying the highest-frequency repeat-offender failure classes in full-auto pipeline runs.

Ships as one PR / one release because each phase touches the same surface area (finalize.md, postmortem.ts, instructions, tool registry) and stacking them keeps the merge-and-publish surface small.

## Phases

### Phase 1: Run observability + postmortem gate (✅ in this branch)

Closes the silent-skip hole where full-auto runs could move every todo to `done` without execute mode firing.

**Hard gates** at the tool layer:
- `workflowState(complete-phase)` rejects with `EMPTY_PHASE_BLOCKED` when a phase has zero file changes / zero commits and no `phase-empty-justification` ledger entry exists. New `justify-empty-phase` action lets the agent declare an intentional no-op.
- `workflowState(advance-wave)` rejects with `WAVE_ADVANCE_NO_VERIFICATION` when no `verification-result.json` exists for the current wave.
- `manageTodos(move|move-batch → done)` requires a `verificationRef` pointing to a passing criterion in `verification-history.jsonl`; rejects with `TODO_DONE_UNVERIFIED` otherwise.

**Diff-based phase proof** (`phase-diff.ts`): snapshots working tree at `start-phase`, computes diff at `complete-phase`, surfaces via `phase-diff-summary` ledger event.

**Run identity & archiving** (`session-ledger.ts`): every ledger entry stamped with per-run `runId`. Pipeline reset archives prior `session-ledger.jsonl`, `verification-history.jsonl`, `confidence-journal.jsonl`, `routing-history.jsonl` to `.planning/runs/<priorRunId>/`.

**Postmortem analyzer & gate** (`postmortem.ts`, `tools/run-postmortem.ts`): new `runPostmortem` Mastra tool with `analyze | render | gate | list-runs` actions. Reads four append-only JSONL artifacts; produces structured report covering empty phases, unverified todo completions, forced transitions, low-confidence decisions, missing wave verifications, pipeline re-entries, idle-bypass anomalies. Returns pre-formatted MuninnDB pitfall payloads.

**Finalize wiring**: new Step 4 "Postmortem Gate" calls `runPostmortem(action: "gate")` before PR creation; critical violations block the PR and re-enter the pipeline. Step 6 calls `runPostmortem(action: "render")` to write `.planning/POSTMORTEM.md` for the PR body.

### Phase 2: Doc-drift defense (✅ in this branch)

Catches the #1 PR-review failure class: changesets, PR bodies, and PLAN.md citing symbols / file paths / counts that don't exist in the working tree.

**`claim-verifier.ts`** (pure data layer): extracts three claim types — backticked symbols, repo-relative file paths, `<N> <countable-noun>` quantitative claims. Verifies via `git grep --untracked --fixed-strings` (filesystem walk fallback for non-git repos). ±1 tolerance on counts. 30s total / 5s per-claim budget with explicit timeout failures.

**`tools/claim-verifier.ts`** (Mastra tool): three actions — `verify-text`, `verify-file`, `gate` (returns `code: CLAIM_VERIFICATION_FAILED` if any input has unverifiable claims). Every call appends `claim-verifier-run` ledger event for postmortem visibility.

**Finalize integration**:
- **Step 3c** — PLAN.md reconciliation in gap detection. Failures attached to *complete* tasks block re-entry to execute; failures on incomplete tasks (forward-looking prose) are allowed.
- **Step 5b.1** — write changeset/release-notes AFTER review iteration converges, not before. Process change with near-zero implementation cost.
- **Step 5b.2** — `claimVerifier(gate)` over changeset and PR body draft before `gh pr create`.

**Review-mode advisory** (`review.md`): optional non-blocking self-check on MUST-FIX/SHOULD-FIX entries.

**Mode permissions**: `luca:5-review` gets `verify-text`/`verify-file` (advisory); `luca:6-finalize` gets `*`.

### Phase 3: PR-address comment hardening (planned)

Addresses the iteration-loop tax from stale Copilot comments (~57% stale rate measured across the corpus) and missed cross-perspective convergence.

- **Stale-comment filter**: re-fetch file at comment path/line, compare diffHunk against current working-tree state. Filter out comments where the cited code has already changed since the review SHA.
- **Cross-perspective convergence detector**: when 2+ reviewer perspectives flag the same file/line, auto-promote severity to MUST-FIX.
- **Iteration-N regression check**: after each fix iteration, re-run the original perspective set against touched paths to catch fixes that introduce new findings.

### Phase 4: Repo-local rule-pack engine (planned)

Repos accumulate "house rules" (e.g. Convex anti-patterns, internal RPC conventions, auth-provider sibling-path requirements) currently held only in PR-review folklore. No machine-checkable encoding exists.

- **Rules runner** (`rules-runner.ts`): execute `.luca/rules/*.ts` files during verify phase.
- **`run-rules` tool**: tool wrapper, integrated into verify mode.
- **`defineRule` schema**: typed rule definitions with location/severity/evidence.
- **Recurrence-driven promotion**: when MuninnDB reports a pitfall with `recurrence_count >= 3`, postmortem suggests a draft rule for that repo's `.luca/rules/`. Zero domain rules ship in `luca-mastracode` itself — all rules are repo-local.

### Phase 5: Harness hygiene (planned)

- **Mode-name single source of truth**: `MODES` constant; eliminate stringly-typed mode names from instructions and tool gates.
- **Silent-catch ledger writes**: every `try/catch` that swallows an error must append a ledger event so postmortem can see it.
- **Milestone memory after PR creation**: defer MuninnDB milestone writes until after `gh pr create` succeeds, so failed PRs don't leave orphaned milestones.
- **Finalize hard-gate ordering**: `mark-finalize-gates-passed` action + `complete-pipeline` precondition check, so the order Gap Detection → Postmortem Gate → Claim Gate → PR is enforced in code, not just in instructions.

## Test plan

Each phase ships with smoke tests against real artifacts and fixture inputs. End-to-end: run a full pipeline and confirm the gates fire (and don't false-positive) at each stage.

## Why one PR

Each phase touches finalize.md, postmortem.ts, the tool registry, and mode permissions — ordering them as separate PRs would mean rebasing those files four times. One combined PR ships as one npm release per package (luca-framework, luca-mastracode), which matches the project's "deploy on merge to main" pipeline.

## Changesets

One changeset per phase under `.changeset/`. Changesets aggregates them into one version bump per package while preserving per-phase release notes.

## Supersedes

Closes #195 (Phase 1 work, fully included in this branch) and #197 (alternate stacking for Phase 2, folded in here).
