### PR TITLE
feat(claim-verifier): doc-drift defense for finalize PR creation

### DIFF
--- a/.changeset/claim-verifier-doc-drift.md
+++ b/.changeset/claim-verifier-doc-drift.md
@@ -1,0 +1,37 @@
+---
+'@alecsibilia/luca-mastracode': minor
+'@alecsibilia/luca-framework': patch
+---
+
+Defend against doc-claim drift — when changesets, PR bodies, and PLAN.md cite symbols, file paths, or quantitative counts that don't match the shipped code.
+
+**New `claimVerifier` tool** (`tools/claim-verifier.ts`, `claim-verifier.ts`) — extracts factual claims from any text artifact:
+
+- `symbol` — backtick-wrapped identifiers (`` `myFunction` ``)
+- `file-path` — repo-relative paths matching common project layouts
+- `quantitative` — `<N> <countable-noun>` patterns from a small allow-list of countable nouns
+
+For each claim, it greps the working tree (`git grep --untracked` for tracked + new files; filesystem fallback for non-git repos) and reports failures with stable evidence strings. Tolerance ±1 on quantitative counts. 30s total budget, 5s per claim, with timeout failures explicit.
+
+Three actions:
+
+- `verify-text` — verify an inline string (e.g. PR body draft).
+- `verify-file` — verify a file on disk (resolves to repo root, then `.planning/`).
+- `gate` — verify multiple inputs; returns `code: "CLAIM_VERIFICATION_FAILED"` if any input has unverifiable claims.
+
+Every call appends a `claim-verifier-run` ledger event for postmortem visibility.
+
+**Finalize integration** (`instructions/finalize.md`):
+
+- **Step 3c** (PLAN.md reconciliation) — runs `claimVerifier(action: "verify-file", path: ".planning/PLAN.md")` during gap detection; failures attached to *complete* tasks block re-entry to execute, failures on incomplete tasks are allowed.
+- **Step 5b.1** (write release artifacts AFTER review iteration converged) — moves changeset/release-note authoring to *after* the final review iteration. Writing release artifacts before this point is the upstream cause of doc-drift; only the post-convergence tree is a trustworthy source for descriptions of shipped work.
+- **Step 5b.2** (verify artifact claims) — runs `claimVerifier(action: "gate", paths: [...], texts: [...])` over the changeset and PR body draft before `gh pr create`. The gate blocks the PR until every cited symbol, path, and count is verified against the working tree.
+
+**Review-mode advisory** (`instructions/review.md`) — non-blocking self-check: reviewers may run `claimVerifier(action: "verify-text", ...)` over their own MUST-FIX/SHOULD-FIX entries to catch hallucinated symbols early.
+
+**Mode permissions** (`tools/mode-permissions.ts`):
+
+- `luca:5-review`: `verify-text`, `verify-file` (advisory).
+- `luca:6-finalize`: full access (gate before PR).
+
+Catches the failure class where changesets cite renamed/removed symbols, design docs drift from shipped code, or PR bodies describe quantities that don't match the diff — failure modes that previously were only caught post-merge by reviewers.

--- a/packages/luca-mastracode/src/claim-verifier.ts
+++ b/packages/luca-mastracode/src/claim-verifier.ts
@@ -1,0 +1,583 @@
+/**
+ * Claim verifier — deterministic check that text artifacts (changesets, PR
+ * bodies, PLAN.md task entries) cite symbols, file paths, and counts that
+ * actually exist in the working tree.
+ *
+ * Targets the #1 repeat offender across PR-review corpus: changesets that
+ * cite renamed/removed symbols, design docs that drift from shipped code,
+ * VERIFICATION.md with stale index/trigger names, etc. The pattern is
+ * artifacts written before the final review iteration, never reconciled.
+ *
+ * Three claim types extracted from text:
+ *   - symbol:       backtick-wrapped identifier   →  git grep, fail if 0 hits
+ *   - file-path:    repo-relative path with ext   →  existsSync, fail if missing
+ *   - quantitative: "<N> <countable-noun>"        →  grep noun, ±1 tolerance
+ *
+ * Pure data layer. Tool wrapper lives in tools/claim-verifier.ts.
+ */
+import { spawnSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ClaimType = 'symbol' | 'file-path' | 'quantitative'
+
+export interface ExtractedClaim {
+    type: ClaimType
+    /** Raw matched text (e.g. "`MyFunction`", "src/foo.ts", "5 indexes") */
+    text: string
+    /** For quantitative: numeric value */
+    number?: number
+    /** For quantitative: counted noun, lowercase, singular */
+    noun?: string
+    /** Identifier extracted from a backtick wrapper (symbols only) */
+    identifier?: string
+    /** Path resolved against repo root (file-path only) */
+    path?: string
+    /** 1-indexed line number in source artifact */
+    sourceLine: number
+    /** Up to 1 line of context around the match */
+    sourceContext: string
+}
+
+export type FailureReason =
+    | 'symbol-not-found'
+    | 'file-not-found'
+    | 'count-mismatch'
+    | 'timeout'
+    | 'artifact-unreadable'
+
+export interface ClaimFailure {
+    claim: ExtractedClaim
+    reason: FailureReason
+    evidence: string
+}
+
+export interface ClaimVerificationReport {
+    passed: boolean
+    totalClaims: number
+    failures: ClaimFailure[]
+    extractedBreakdown: {
+        symbols: number
+        filePaths: number
+        quantitative: number
+    }
+    /** True when the budget was exhausted; remaining claims are not verified */
+    timedOut: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Stopwords + allow-lists
+// ---------------------------------------------------------------------------
+
+/** Backtick-wrapped tokens to skip (CLI tool names, pure prose, primitives). */
+const SYMBOL_STOPWORDS = new Set([
+    'true',
+    'false',
+    'null',
+    'undefined',
+    'void',
+    'any',
+    'unknown',
+    'never',
+    'string',
+    'number',
+    'boolean',
+    'object',
+    'array',
+    'bun',
+    'npm',
+    'pnpm',
+    'yarn',
+    'git',
+    'gh',
+    'pr',
+    'ci',
+    'cd',
+    'repo',
+    'main',
+    'master',
+    'dev',
+    'build',
+    'test',
+    'lint',
+    'tsc',
+    'eslint',
+    'todo',
+    'fixme',
+    'note',
+    'warn',
+    'info',
+    'log',
+    'http',
+    'https',
+    'json',
+    'yaml',
+    'toml',
+    'env',
+    'src',
+    'dist',
+    'lib',
+    'app',
+    'apps',
+])
+
+/**
+ * Nouns that count as "real countable things" for quantitative claims.
+ * Conservative on purpose — false negatives are fine, false positives bite.
+ */
+const COUNTABLE_NOUNS = new Set([
+    'file',
+    'files',
+    'test',
+    'tests',
+    'table',
+    'tables',
+    'index',
+    'indexes',
+    'indices',
+    'function',
+    'functions',
+    'endpoint',
+    'endpoints',
+    'route',
+    'routes',
+    'mutation',
+    'mutations',
+    'query',
+    'queries',
+    'action',
+    'actions',
+    'tool',
+    'tools',
+    'mode',
+    'modes',
+    'phase',
+    'phases',
+    'wave',
+    'waves',
+    'commit',
+    'commits',
+    'package',
+    'packages',
+    'module',
+    'modules',
+    'class',
+    'classes',
+    'method',
+    'methods',
+    'component',
+    'components',
+    'hook',
+    'hooks',
+])
+
+/** Singularize a counted noun for grep purposes (cheap heuristic). */
+function singularize(noun: string): string {
+    const lower = noun.toLowerCase()
+    if (lower === 'indices') return 'index'
+    if (lower === 'queries') return 'query'
+    if (lower === 'classes') return 'class'
+    if (lower === 'indexes') return 'index'
+    if (lower.endsWith('ies') && lower.length > 3)
+        return lower.slice(0, -3) + 'y'
+    if (lower.endsWith('s') && !lower.endsWith('ss')) return lower.slice(0, -1)
+    return lower
+}
+
+// ---------------------------------------------------------------------------
+// Extraction
+// ---------------------------------------------------------------------------
+
+const BACKTICK_RE = /`([^`\n]+)`/g
+const FILE_PATH_RE =
+    /(?:^|[\s(`'"])((?:packages|src|apps|lib|tests?|docs?|\.planning|\.luca|\.changeset|\.github)\/[\w./-]+\.[\w]+)(?=[\s)`'".,;!?]|$)/g
+const QUANTITATIVE_RE = /\b(\d+)\s+([a-zA-Z]+)\b/g
+const IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+/**
+ * Extract all claims from a text artifact.
+ *
+ * Returns an empty array for empty input. Deduplicates by (type, key) so a
+ * symbol cited 5× yields one claim. The first-seen sourceLine wins.
+ */
+export function extractClaims(text: string): ExtractedClaim[] {
+    if (!text) return []
+
+    const lines = text.split('\n')
+    const seen = new Set<string>()
+    const claims: ExtractedClaim[] = []
+
+    const pushIfNew = (key: string, claim: ExtractedClaim) => {
+        if (seen.has(key)) return
+        seen.add(key)
+        claims.push(claim)
+    }
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i] ?? ''
+        const sourceLine = i + 1
+        const sourceContext = line.trim().slice(0, 240)
+
+        // Symbols — backtick-wrapped identifiers
+        for (const match of line.matchAll(BACKTICK_RE)) {
+            const inner = (match[1] ?? '').trim()
+
+            // File-path-shaped backticks → handled by FILE_PATH_RE branch below
+            if (inner.includes('/') && /\.\w+(?:[#?:]|$)/.test(inner)) continue
+
+            if (!IDENTIFIER_RE.test(inner)) continue
+            if (inner.length < 3) continue
+            if (SYMBOL_STOPWORDS.has(inner.toLowerCase())) continue
+
+            const key = `symbol:${inner}`
+            pushIfNew(key, {
+                type: 'symbol',
+                text: match[0],
+                identifier: inner,
+                sourceLine,
+                sourceContext,
+            })
+        }
+
+        // File paths
+        for (const match of line.matchAll(FILE_PATH_RE)) {
+            const path = match[1]
+            if (!path) continue
+            const key = `path:${path}`
+            pushIfNew(key, {
+                type: 'file-path',
+                text: path,
+                path,
+                sourceLine,
+                sourceContext,
+            })
+        }
+
+        // Quantitative claims
+        for (const match of line.matchAll(QUANTITATIVE_RE)) {
+            const numStr = match[1]
+            const noun = match[2]
+            if (!numStr || !noun) continue
+
+            // Skip version-shaped (v1, 1.0 already filtered by \b boundary).
+            // Skip 4-digit years.
+            if (numStr.length === 4) {
+                const n = Number(numStr)
+                if (n >= 1900 && n <= 2200) continue
+            }
+
+            const lowerNoun = noun.toLowerCase()
+            if (!COUNTABLE_NOUNS.has(lowerNoun)) continue
+
+            const num = Number(numStr)
+            if (!Number.isFinite(num)) continue
+
+            const key = `count:${num}:${lowerNoun}`
+            pushIfNew(key, {
+                type: 'quantitative',
+                text: `${numStr} ${noun}`,
+                number: num,
+                noun: singularize(lowerNoun),
+                sourceLine,
+                sourceContext,
+            })
+        }
+    }
+
+    return claims
+}
+
+// ---------------------------------------------------------------------------
+// Verification
+// ---------------------------------------------------------------------------
+
+interface VerifyOpts {
+    repoRoot: string
+    /** Total budget in ms across all grep/fs operations. Default 30000. */
+    totalBudgetMs?: number
+    /** Per-claim budget in ms. Default 5000. */
+    perClaimBudgetMs?: number
+}
+
+interface GrepResult {
+    ok: boolean
+    matchedFiles: string[]
+    timedOut: boolean
+}
+
+function gitAvailable(repoRoot: string): boolean {
+    const r = spawnSync(
+        'git',
+        ['-C', repoRoot, 'rev-parse', '--is-inside-work-tree'],
+        { encoding: 'utf-8' }
+    )
+    return r.status === 0
+}
+
+function gitGrepFiles(
+    repoRoot: string,
+    needle: string,
+    timeoutMs: number
+): GrepResult {
+    // `--untracked` is critical: at finalize time, newly-authored files may
+    // be untracked (or only staged) but the symbols they contain are still
+    // valid claims. Without it, fresh files yield false-positive failures.
+    const r = spawnSync(
+        'git',
+        [
+            '-C',
+            repoRoot,
+            'grep',
+            '--untracked',
+            '-l',
+            '--fixed-strings',
+            needle,
+        ],
+        { encoding: 'utf-8', timeout: timeoutMs }
+    )
+
+    if (r.signal === 'SIGTERM' || r.error?.message?.includes('ETIMEDOUT')) {
+        return { ok: false, matchedFiles: [], timedOut: true }
+    }
+
+    // git grep exits 0 with matches, 1 without, >1 on error.
+    if (r.status === 1) return { ok: true, matchedFiles: [], timedOut: false }
+    if (r.status !== 0) return { ok: false, matchedFiles: [], timedOut: false }
+
+    const matchedFiles = (r.stdout ?? '')
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    return { ok: true, matchedFiles, timedOut: false }
+}
+
+/**
+ * Filesystem-walk fallback for non-git environments. Slow but correct.
+ * Walks repoRoot, skips node_modules + .git + dist, greps each file.
+ */
+function fsGrepFiles(
+    repoRoot: string,
+    needle: string,
+    timeoutMs: number
+): GrepResult {
+    const start = Date.now()
+    const matchedFiles: string[] = []
+
+    // Avoid shell injection on the needle: pass via xargs grep -F with the
+    // needle on grep's argv, not interpolated into the command string.
+    const r = spawnSync(
+        'sh',
+        [
+            '-c',
+            // Skip vendor/build dirs, pipe through grep -lF with the needle
+            // delivered via argv ($1) to keep it free of shell quoting.
+            `find "${repoRoot.replace(/"/g, '\\"')}" -type d \\( -name node_modules -o -name .git -o -name dist -o -name build -o -name .next \\) -prune -o -type f -print0 | xargs -0 grep -lF -- "$1" 2>/dev/null`,
+            'sh',
+            needle,
+        ],
+        { encoding: 'utf-8', timeout: timeoutMs }
+    )
+
+    if (r.signal === 'SIGTERM' || r.error?.message?.includes('ETIMEDOUT')) {
+        return { ok: false, matchedFiles: [], timedOut: true }
+    }
+
+    if (r.stdout) {
+        for (const line of r.stdout.split('\n')) {
+            const trimmed = line.trim()
+            if (trimmed) matchedFiles.push(trimmed)
+        }
+    }
+    return {
+        ok: true,
+        matchedFiles,
+        timedOut: Date.now() - start > timeoutMs,
+    }
+}
+
+function searchFiles(
+    repoRoot: string,
+    needle: string,
+    timeoutMs: number,
+    useGit: boolean
+): GrepResult {
+    if (useGit) return gitGrepFiles(repoRoot, needle, timeoutMs)
+    return fsGrepFiles(repoRoot, needle, timeoutMs)
+}
+
+/**
+ * Verify a list of claims against the repo. Stops early when the total
+ * budget is exhausted; remaining claims are returned as `timeout` failures.
+ */
+export function verifyClaims(
+    claims: ExtractedClaim[],
+    opts: VerifyOpts
+): ClaimVerificationReport {
+    const totalBudgetMs = opts.totalBudgetMs ?? 30_000
+    const perClaimBudgetMs = opts.perClaimBudgetMs ?? 5_000
+    const useGit = gitAvailable(opts.repoRoot)
+    const start = Date.now()
+    const failures: ClaimFailure[] = []
+    let timedOut = false
+
+    const breakdown = {
+        symbols: 0,
+        filePaths: 0,
+        quantitative: 0,
+    }
+
+    for (const claim of claims) {
+        if (claim.type === 'symbol') breakdown.symbols++
+        else if (claim.type === 'file-path') breakdown.filePaths++
+        else breakdown.quantitative++
+
+        if (Date.now() - start > totalBudgetMs) {
+            timedOut = true
+            failures.push({
+                claim,
+                reason: 'timeout',
+                evidence: `Total budget ${totalBudgetMs}ms exhausted before this claim was checked.`,
+            })
+            continue
+        }
+
+        if (claim.type === 'symbol' && claim.identifier) {
+            const r = searchFiles(
+                opts.repoRoot,
+                claim.identifier,
+                perClaimBudgetMs,
+                useGit
+            )
+            if (r.timedOut) {
+                timedOut = true
+                failures.push({
+                    claim,
+                    reason: 'timeout',
+                    evidence: `Search for symbol "${claim.identifier}" exceeded ${perClaimBudgetMs}ms.`,
+                })
+                continue
+            }
+            if (!r.ok || r.matchedFiles.length === 0) {
+                failures.push({
+                    claim,
+                    reason: 'symbol-not-found',
+                    evidence: `git grep for "${claim.identifier}" returned 0 hits.`,
+                })
+            }
+            continue
+        }
+
+        if (claim.type === 'file-path' && claim.path) {
+            const abs = join(opts.repoRoot, claim.path)
+            if (!existsSync(abs)) {
+                failures.push({
+                    claim,
+                    reason: 'file-not-found',
+                    evidence: `Path "${claim.path}" does not exist (resolved to ${abs}).`,
+                })
+            }
+            continue
+        }
+
+        if (
+            claim.type === 'quantitative' &&
+            claim.noun &&
+            typeof claim.number === 'number'
+        ) {
+            const r = searchFiles(
+                opts.repoRoot,
+                claim.noun,
+                perClaimBudgetMs,
+                useGit
+            )
+            if (r.timedOut) {
+                timedOut = true
+                failures.push({
+                    claim,
+                    reason: 'timeout',
+                    evidence: `Search for noun "${claim.noun}" exceeded ${perClaimBudgetMs}ms.`,
+                })
+                continue
+            }
+            if (!r.ok) {
+                // Treat a hard error as count-mismatch with 0 hits.
+                failures.push({
+                    claim,
+                    reason: 'count-mismatch',
+                    evidence: `grep for "${claim.noun}" failed; cannot verify "${claim.text}".`,
+                })
+                continue
+            }
+            const found = r.matchedFiles.length
+            const claimed = claim.number
+            // ±1 tolerance — prose variation is expected.
+            if (Math.abs(found - claimed) > 1) {
+                failures.push({
+                    claim,
+                    reason: 'count-mismatch',
+                    evidence: `Claim says "${claim.text}", repo has ${found} file(s) mentioning "${claim.noun}" (tolerance ±1).`,
+                })
+            }
+            continue
+        }
+    }
+
+    return {
+        passed: failures.length === 0,
+        totalClaims: claims.length,
+        failures,
+        extractedBreakdown: breakdown,
+        timedOut,
+    }
+}
+
+/**
+ * End-to-end: extract + verify a text artifact in one call.
+ */
+export function verifyTextArtifact(
+    text: string,
+    opts: VerifyOpts
+): ClaimVerificationReport {
+    const claims = extractClaims(text)
+    return verifyClaims(claims, opts)
+}
+
+/**
+ * Convenience: load a file from disk and verify it. Returns
+ * a synthetic `artifact-unreadable` failure if the file can't be read.
+ */
+export function verifyFile(
+    filePath: string,
+    opts: VerifyOpts
+): ClaimVerificationReport {
+    let text: string
+    try {
+        text = readFileSync(filePath, 'utf-8')
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        return {
+            passed: false,
+            totalClaims: 0,
+            failures: [
+                {
+                    claim: {
+                        type: 'file-path',
+                        text: filePath,
+                        path: filePath,
+                        sourceLine: 0,
+                        sourceContext: '',
+                    },
+                    reason: 'artifact-unreadable',
+                    evidence: `Could not read "${filePath}": ${msg}`,
+                },
+            ],
+            extractedBreakdown: { symbols: 0, filePaths: 0, quantitative: 0 },
+            timedOut: false,
+        }
+    }
+    return verifyTextArtifact(text, opts)
+}

--- a/packages/luca-mastracode/src/instructions/finalize.md
+++ b/packages/luca-mastracode/src/instructions/finalize.md
@@ -18,13 +18,13 @@ You receive control from **Review mode**. Read the latest `.planning/REVIEW-*.md
 
 1. **Milestone boundary** — capture learnings, prune patterns, archive session
 2. **Shadow debt scan** — advisory scan for AI-session debris before PR
-3. **Gap detection** — verify all planned work was completed
+3. **Gap detection** — verify all planned work was completed; reconcile PLAN.md against shipped code
 4. **Postmortem gate** — block on critical pipeline violations before PR
-5. **PR creation** — create pull request if git workflow was used (only after gap + postmortem checks pass)
+5. **PR creation** — write changeset post-convergence, run claim verifier, then create pull request
 6. **Cross-milestone continuation** — loop back if roadmap has remaining phases
 7. **Session cleanup** — release locks, summarize work
 
-> **Ordering matters.** Gap detection and the postmortem gate run *before* PR creation. A failing gate must re-enter the pipeline rather than ship a PR.
+> **Ordering matters.** Gap detection, postmortem gate, and claim verifier all run *before* `gh pr create`. The changeset is written **after** review iteration converges, not before — pre-convergence drafts are the #1 source of doc drift. A failing gate must re-enter the pipeline rather than ship a PR.
 
 ---
 
@@ -36,6 +36,8 @@ task_write(tasks: [
   { content: "Run shadow debt scan", status: "pending", activeForm: "Running shadow debt scan" },
   { content: "Run gap detection audit", status: "pending", activeForm: "Running gap detection audit" },
   { content: "Run postmortem gate", status: "pending", activeForm: "Running postmortem gate" },
+  { content: "Write changeset and draft PR body", status: "pending", activeForm: "Writing changeset and PR body" },
+  { content: "Run claim verifier gate", status: "pending", activeForm: "Running claim verifier gate" },
   { content: "Create pull request", status: "pending", activeForm: "Creating pull request" },
   { content: "Clean up and summarize", status: "pending", activeForm: "Cleaning up session artifacts" }
 ])
@@ -165,6 +167,28 @@ Verify all planned work was completed **before** opening a PR:
   3. **STOP.** Review mode handles from here, iterating Execute → Review as needed.
   - If user prefers not to fix: track as follow-up issues, proceed to the postmortem gate
 
+### Step 3c — PLAN.md reconciliation
+
+Run the claim verifier against `.planning/PLAN.md`:
+
+```
+claimVerifier(action: "verify-file", path: ".planning/PLAN.md")
+```
+
+Failures here are NOT blocking by themselves — PLAN.md is allowed to contain forward-looking language for incomplete tasks. But:
+
+- **Symbol-not-found** failures cited in tasks marked **complete** → block, re-enter execute (the task references a symbol that doesn't exist in the working tree).
+- **File-not-found** failures cited in tasks marked **complete** → block, re-enter execute.
+- **Count-mismatch** failures → warn only, surface in PR body Follow-Up section.
+
+Cross-reference each failure against PLAN.md task status before deciding to block. A failed claim attached to an incomplete task is expected; a failed claim attached to a completed task is drift.
+
+If blocking:
+
+```
+workflowState(action: "re-enter-pipeline", targetMode: "luca:4-execute", reason: "PLAN.md reconciliation: completed task cites missing symbol/path: <summary>")
+```
+
 ## Step 4: Postmortem Gate
 
 **Always runs before PR creation.** Catches silent-skip incidents (execute mode skipped but todos moved to done), unverified completions, and forced transitions.
@@ -228,7 +252,31 @@ mcp__muninn__muninn_recall(
 
 Use recalled conventions to determine: version number, title format (`type(scope): vX.Y.Z #issue description`), milestone linkage, and PR body structure. If no version memory exists, check `packages/luca-mastracode/package.json` for current version and determine the appropriate bump.
 
-### 5b. Create PR
+### 5b.1. Write release artifacts (AFTER review iteration converged)
+
+Now — and only now, after every review iteration is resolved — write the changeset (`.changeset/<slug>.md`) and any release notes. **Writing these before this point is the #1 cause of drift between artifact claims and shipped code.** Symbols rename mid-review, schemas evolve, counts shift; only the post-convergence tree is trustworthy as the source of truth for release artifacts.
+
+If a changeset already exists from earlier in the session: re-read it now, reconcile against the current branch, and rewrite it. Do not assume it's still accurate.
+
+### 5b.2. Verify artifact claims
+
+Run the claim verifier across the changeset and PR body draft **before** calling `gh pr create`:
+
+```
+claimVerifier(action: "gate", paths: [".changeset/<slug>.md"], texts: [<pr_body_draft>])
+```
+
+If it returns `code: CLAIM_VERIFICATION_FAILED`:
+
+- Each failure is a backticked symbol, file path, or quantitative count cited in your draft that doesn't exist in the working tree.
+- For `symbol-not-found` / `file-not-found`: the draft is wrong (renamed/removed since drafting) **or** the code is wrong (the work isn't actually shipped). Inspect both.
+- For `count-mismatch`: numbers drifted. Re-count or rephrase.
+- Fix the draft (or the code) and re-run the gate until it passes.
+- **Do not open the PR with unverified claims.**
+
+After the gate passes, proceed.
+
+### 5b.3. Create PR
 
 1. **Push** feature branch to remote
 2. **Create PR** with:
@@ -384,9 +432,11 @@ Read `workflowState(action: "read")` for:
 - Plan and research data for gap detection
 
 ## Tool Coordination
-Sequence: (1) `runChecks` → (2) spawn shadow-scanner → (3) `verificationResult(write)` → (4) `runPostmortem(gate)` → (5) `manageTodos(move-batch → done)` with `verificationRef` for every item, in one call.
+Sequence: (1) `runChecks` → (2) spawn shadow-scanner → (3) `verificationResult(write)` → (4) `runPostmortem(gate)` → (5) write changeset + draft PR body → (6) `claimVerifier(gate)` over changeset + PR body → (7) `manageTodos(move-batch → done)` with `verificationRef` for every item, in one call → (8) `gh pr create`.
 
 **Critical:** `manageTodos` will reject any `move → done` without a valid `verificationRef: { criterionId, wave }` pointing at a PASS criterion in `verification-history.jsonl`. Capture the criterion IDs from your `verificationResult(write)` call and pass them through.
+
+**Also critical:** `claimVerifier(gate)` runs *after* the changeset is written and *before* `gh pr create`. A failure here means the draft cites symbols/paths/counts that don't exist on the branch — either the draft is stale (rewrite) or the code didn't actually land (re-enter execute).
 
 ## Luca Reminders
 Obey `<luca-reminder>` tags when they appear in conversation — they contain authoritative mid-session guidance that supersedes stale context.

--- a/packages/luca-mastracode/src/instructions/review.md
+++ b/packages/luca-mastracode/src/instructions/review.md
@@ -181,6 +181,16 @@ Write to `.planning/REVIEW-{wave}.md` via **writePlanningFile** (action: "write"
 
 - **[{perspective}]** {description}
 
+### Optional: Self-check review claims
+
+Before finalizing the verdict, optionally run the claim verifier across your own MUST-FIX/SHOULD-FIX entries to catch hallucinated symbols or stale file paths in your own output:
+
+```
+claimVerifier(action: "verify-text", text: <full-review-output-as-string>)
+```
+
+If the verifier flags `symbol-not-found` for a symbol you cited in a finding, that finding is suspect — the symbol you're citing doesn't exist in the working tree. Either fix the citation or drop the finding. Non-blocking: this is a self-check, not a gate.
+
 ## Verdict
 
 {CLEAN | ISSUES_FOUND}

--- a/packages/luca-mastracode/src/tools/build-mode-tools.ts
+++ b/packages/luca-mastracode/src/tools/build-mode-tools.ts
@@ -1,5 +1,6 @@
 import type { Tool } from '@mastra/core/tools'
 
+import { claimVerifierTool } from './claim-verifier.js'
 import { classifyComplexityTool } from './classify-complexity.js'
 import { confidenceJournalTool } from './confidence-journal.js'
 import { createScopedTool } from './create-scoped-tool.js'
@@ -57,6 +58,10 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
     run_postmortem: {
         tool: runPostmortemTool,
         record_key: 'runPostmortem',
+    },
+    claim_verifier: {
+        tool: claimVerifierTool,
+        record_key: 'claimVerifier',
     },
 }
 

--- a/packages/luca-mastracode/src/tools/claim-verifier.ts
+++ b/packages/luca-mastracode/src/tools/claim-verifier.ts
@@ -1,0 +1,191 @@
+/**
+ * claim-verifier (tool) — Mastra tool wrapper for the claim verifier.
+ *
+ * Three actions:
+ *   - verify-text: verify claims in an inline text string (e.g. PR body draft).
+ *   - verify-file: verify claims in a file on disk (e.g. .changeset/<slug>.md).
+ *   - gate: verify across multiple paths/texts; returns CLAIM_VERIFICATION_FAILED
+ *           if any input has unverifiable claims. Used by finalize before PR creation.
+ *
+ * Every call appends a `claim-verifier-run` ledger event with totals so
+ * the postmortem analyzer can observe verifier activity over time.
+ */
+import { existsSync } from 'node:fs'
+import { isAbsolute, join } from 'node:path'
+
+import { createTool } from '@mastra/core/tools'
+import { z } from 'zod'
+
+import {
+    verifyFile,
+    verifyTextArtifact,
+    type ClaimVerificationReport,
+} from '../claim-verifier.js'
+import { appendLedger } from '../session-ledger.js'
+
+const PLANNING_DIR = '.planning'
+
+/**
+ * Resolve an artifact path. Tries:
+ *   1. The path as-is (absolute or repo-relative).
+ *   2. The path under .planning/ as a fallback.
+ */
+function resolveArtifactPath(repoRoot: string, p: string): string {
+    if (isAbsolute(p)) return p
+    const direct = join(repoRoot, p)
+    if (existsSync(direct)) return direct
+    const planning = join(repoRoot, PLANNING_DIR, p)
+    if (existsSync(planning)) return planning
+    return direct
+}
+
+interface SourcedReport {
+    source: string
+    report: ClaimVerificationReport
+}
+
+export const claimVerifierTool = createTool({
+    id: 'claim-verifier',
+    description:
+        'Verify factual claims (symbols, file paths, quantitative counts) in narrative artifacts ' +
+        '(changesets, PR bodies, PLAN.md, REVIEW-*.md) against the working tree. ' +
+        "Use 'verify-text' for inline strings, 'verify-file' for on-disk artifacts, " +
+        "and 'gate' as a pre-PR finalize check that blocks on any unverifiable claim. " +
+        'Catches doc-claim drift before it ships.',
+    inputSchema: z.object({
+        action: z
+            .enum(['verify-text', 'verify-file', 'gate'])
+            .describe(
+                'verify-text: verify an inline string | verify-file: verify a file path | gate: verify multiple inputs and block on failures'
+            ),
+        text: z
+            .string()
+            .optional()
+            .describe('Inline text to verify (verify-text only).'),
+        path: z
+            .string()
+            .optional()
+            .describe(
+                'Path to verify (verify-file only). Resolved relative to repo root, then .planning/.'
+            ),
+        paths: z
+            .array(z.string())
+            .optional()
+            .describe(
+                'Multiple file paths to verify (gate action). Each is resolved like verify-file.'
+            ),
+        texts: z
+            .array(z.string())
+            .optional()
+            .describe(
+                'Multiple inline texts to verify (gate action). Tagged "text-0", "text-1", ...'
+            ),
+    }),
+    execute: async (inputData) => {
+        const { action, text, path, paths, texts } = inputData
+        const repoRoot = process.cwd()
+
+        switch (action) {
+            case 'verify-text': {
+                if (!text) {
+                    return {
+                        success: false,
+                        message: 'verify-text requires `text`',
+                    }
+                }
+                const report = verifyTextArtifact(text, { repoRoot })
+                appendLedger('claim-verifier-run', {
+                    action,
+                    totalClaims: report.totalClaims,
+                    failureCount: report.failures.length,
+                    paths: [],
+                })
+                return {
+                    success: report.passed,
+                    message: report.passed
+                        ? `Verified ${report.totalClaims} claim(s), all passed.`
+                        : `Verified ${report.totalClaims} claim(s), ${report.failures.length} failure(s).`,
+                    report,
+                    pitfalls: [],
+                }
+            }
+            case 'verify-file': {
+                if (!path) {
+                    return {
+                        success: false,
+                        message: 'verify-file requires `path`',
+                    }
+                }
+                const resolved = resolveArtifactPath(repoRoot, path)
+                const report = verifyFile(resolved, { repoRoot })
+                appendLedger('claim-verifier-run', {
+                    action,
+                    totalClaims: report.totalClaims,
+                    failureCount: report.failures.length,
+                    paths: [path],
+                })
+                return {
+                    success: report.passed,
+                    message: report.passed
+                        ? `Verified ${report.totalClaims} claim(s) in ${path}, all passed.`
+                        : `Verified ${report.totalClaims} claim(s) in ${path}, ${report.failures.length} failure(s).`,
+                    report,
+                    pitfalls: [],
+                }
+            }
+            case 'gate': {
+                const reports: SourcedReport[] = []
+                const ledgerPaths: string[] = []
+                let totalClaims = 0
+                let totalFailures = 0
+
+                for (const p of paths ?? []) {
+                    const resolved = resolveArtifactPath(repoRoot, p)
+                    const report = verifyFile(resolved, { repoRoot })
+                    reports.push({ source: p, report })
+                    ledgerPaths.push(p)
+                    totalClaims += report.totalClaims
+                    totalFailures += report.failures.length
+                }
+
+                for (let i = 0; i < (texts ?? []).length; i++) {
+                    const t = (texts ?? [])[i] ?? ''
+                    const tag = `text-${i}`
+                    const report = verifyTextArtifact(t, { repoRoot })
+                    reports.push({ source: tag, report })
+                    totalClaims += report.totalClaims
+                    totalFailures += report.failures.length
+                }
+
+                appendLedger('claim-verifier-run', {
+                    action,
+                    totalClaims,
+                    failureCount: totalFailures,
+                    paths: ledgerPaths,
+                })
+
+                if (totalFailures > 0) {
+                    return {
+                        success: false,
+                        code: 'CLAIM_VERIFICATION_FAILED',
+                        message: `Claim verifier gate failed: ${totalFailures} failure(s) across ${reports.length} input(s). Fix the draft (or the code) until claims match the working tree.`,
+                        reports,
+                        pitfalls: [],
+                    }
+                }
+
+                return {
+                    success: true,
+                    message: `Claim verifier gate passed: ${totalClaims} claim(s) verified across ${reports.length} input(s).`,
+                    reports,
+                    pitfalls: [],
+                }
+            }
+            default:
+                return {
+                    success: false,
+                    message: `Unknown action: ${String(action)}`,
+                }
+        }
+    },
+})

--- a/packages/luca-mastracode/src/tools/mode-permissions.ts
+++ b/packages/luca-mastracode/src/tools/mode-permissions.ts
@@ -78,6 +78,7 @@ export const MODE_PERMISSIONS: Record<
         repo_cleanup: ['scan', 'parse-report', 'summary'],
         write_planning_file: ['write', 'read'],
         confidence_journal: ['read', 'summary'],
+        claim_verifier: ['verify-text', 'verify-file'],
     },
     'luca:6-finalize': {
         workflow_state: [
@@ -95,5 +96,6 @@ export const MODE_PERMISSIONS: Record<
         repo_cleanup: '*',
         confidence_journal: ['read', 'summary', 'render'],
         run_postmortem: '*',
+        claim_verifier: '*',
     },
 } as const


### PR DESCRIPTION
## Summary

Defends against the #1 repeat-offender failure class across the PR-review corpus: changesets, PR bodies, and PLAN.md citing symbols, file paths, and counts that don't actually exist in the working tree.

The pattern is structural — artifacts get drafted before the final review iteration, then never reconciled when symbols rename or schemas evolve mid-review. This PR closes the loop with one process change and one code gate.

## Changes

**`claim-verifier.ts` (new, pure data layer)**

Extracts three claim types from any text artifact:

- `symbol` — backtick-wrapped identifiers (`` `myFunction` ``)
- `file-path` — repo-relative paths matching common project layouts
- `quantitative` — `<N> <countable-noun>` patterns from a small allow-list

For each claim it greps the working tree (`git grep` when available, filesystem walk fallback) and reports failures with stable evidence strings. ±1 tolerance on counts. 30s total / 5s per-claim budget with explicit timeout failures.

**`tools/claim-verifier.ts` (new, Mastra tool wrapper)**

Three actions: `verify-text`, `verify-file`, `gate`. The `gate` action returns `code: CLAIM_VERIFICATION_FAILED` if any input has unverifiable claims, blocking the caller. Every call appends a `claim-verifier-run` ledger event for postmortem visibility.

**`instructions/finalize.md` (process + gate integration)**

- **Step 3c** — PLAN.md reconciliation. Runs `verify-file` on PLAN.md during gap detection. Failures attached to *complete* tasks block re-entry to execute; failures on incomplete tasks (forward-looking prose) are allowed.
- **Step 5b.1** — write release artifacts AFTER review iteration converged. Moves changeset/release-note authoring to *after* the final review iteration. This alone catches a large fraction of drift, since pre-convergence drafts are the upstream cause.
- **Step 5b.2** — run `claimVerifier(gate)` over the changeset and PR body draft before `gh pr create`. The gate blocks the PR until every cited symbol, path, and count is verified against the working tree.

**`instructions/review.md` (advisory hook)**

Optional non-blocking self-check: reviewers may run `verify-text` over their own MUST-FIX/SHOULD-FIX entries to catch hallucinated symbols early.

**Mode permissions**

- `luca:5-review` — `verify-text`, `verify-file` (advisory only).
- `luca:6-finalize` — full access (gate before PR).

## Verification

- Type check: clean (`bunx --bun tsc --noEmit`).
- Build: clean (`bun run build`).
- Smoke test: 13 fixture cases covering symbol extraction, stopword filtering, file path detection, quantitative extraction, year-shaped number rejection, end-to-end verify against real and fake symbols/paths, and PLAN.md reconciliation simulation. All pass.

## Test plan

- Run a real pipeline through finalize and confirm the gate fires when a changeset cites a symbol that doesn't exist on the branch.
- Confirm the gate passes on clean changesets (no false positives on legitimate prose).
- Confirm Step 5b.1 reordering keeps changesets accurate when symbols rename mid-review.

## Stack

This PR sits on top of #195 (run observability + postmortem gate). Once #195 merges, this rebases onto main cleanly.

## Out of scope (deferred)

- PR-2: stale-Copilot-comment filter, cross-perspective convergence detector, iteration-N regression check.
- PR-3: repo-local rule-pack engine (`.luca/rules/*.ts`) with MuninnDB recurrence-driven promotion.
- PR-4: harness hygiene (mode-name single source of truth, silent-catch ledger writes, milestone-write-after-PR, finalize hard-gate ordering).
