### PR TITLE
fix(harness): remove dead writeFileTool patch + skill/command updates

### DIFF
--- a/.changeset/pr-address-stale-convergence-regression.md
+++ b/.changeset/pr-address-stale-convergence-regression.md
@@ -1,0 +1,15 @@
+---
+'@alecsibilia/luca-framework': patch
+'@alecsibilia/luca-mastracode': patch
+---
+
+Harden the `/pr-address` command with three new defensive steps that wire into the existing `prReview` tool, plus a small grammar fix in the caveman skill.
+
+**`/pr-address` enhancements** (`.mastracode/commands/pr-address.md`):
+
+- **Step 1.5 — Filter Stale Comments.** Calls `prReview(action: "filter-stale", ...)` immediately after fetching PR comments. Comments whose cited code has been rewritten, removed, or relocated by more than 5 lines are bucketed as `stale` and skipped from categorization; the agent posts a reply pointing at the addressing commit instead of treating them as actionable. Prevents wasted iteration cycles on already-fixed feedback.
+- **Step 2.5 — Detect Cross-Perspective Convergence.** Calls `prReview(action: "detect-convergence", findings, lineTolerance: 2)` over the categorized comments combined with findings from other perspectives (claim-verifier output, reviewer-agent MUST-FIX/SHOULD-FIX entries). When two or more independent reviewers flag the same location, severity is auto-promoted to **must-fix** regardless of original category. Surfaces convergence count in the audit summary.
+- **Step 7 — Iteration-N Regression Check.** Snapshots `iterationStartSha` at Step 1, then after fixes are pushed re-fetches comments and runs `prReview(action: "regression-check", before, after, fromSha, toSha)`. New findings introduced by fix commits block iteration completion and re-enter Step 3 (Plan Fixes) with the regressions as input. Cycle is bounded: 3 consecutive failed iterations escalate to the user. Catches fix-induced regressions that would otherwise only surface in the next review pass.
+- Old "Step 7 — Store Learnings" renumbered to Step 8.
+
+**Caveman skill** (`.mastracode/skills/caveman/SKILL.md`): single-word grammar fix in the destructive-op resume example to match caveman speech pattern (`exists` → `exist`).

--- a/.changeset/remove-dead-writefile-patch.md
+++ b/.changeset/remove-dead-writefile-patch.md
@@ -1,0 +1,11 @@
+---
+"@alecsibilia/luca-mastracode": patch
+---
+
+Remove dead writeFileTool FileNotFoundError patch from launch.ts
+
+The patch targeted an upstream `@mastra/core@1.28.0` bug where `FileNotFoundError`
+lacked a `code` property, causing `isEnoentError()` to fail during the `expectedMtime`
+precheck for new file writes. This bug was fixed in `@mastra/core@1.29.0` — both
+installed versions (1.29.0 and 1.29.1) have the fix. The patch's fallback path was
+also broken (AI SDK never populates `context.workspace`), making it fully dead code.

--- a/.mastracode/commands/pr-address.md
+++ b/.mastracode/commands/pr-address.md
@@ -35,6 +35,25 @@ Parse and group comments:
 
 Build a comment map with fields: `commentId, author, body, file, line, inReplyTo, isDuplicate, duplicateGroupId`.
 
+**Snapshot the iteration boundary.** Record the current `git rev-parse HEAD` SHA as `iterationStartSha`. The regression check at Step 7 will use this to compute the set of paths the iteration modified and the before/after finding deltas.
+
+### Step 1.5 — Filter Stale Comments
+
+Comments filed against an earlier commit may already be addressed by subsequent fix commits on the branch. Treating them as actionable wastes iteration cycles and produces confused replies.
+
+Run the stale-comment filter:
+
+```
+prReview(action: "filter-stale", comments: <all comments fetched in Step 1>)
+```
+
+The tool returns three buckets:
+- **`actionable`** — comments whose cited code still exists in the working tree at the same location. Continue with categorization for these.
+- **`stale`** — comments whose cited code has been rewritten, removed, or relocated by more than 5 lines. **Skip categorization for these — they cannot be acted on.** When responding (Step 5), post a reply explaining the comment is stale and pointing at the commit that addressed the underlying code.
+- **`replies`** — comments with `in_reply_to_id` set; pass through, not first-class findings.
+
+Append a note to the comment audit summary at Step 2: `Stale: <n> comments (skipped from categorization)`.
+
 ### Step 2 — Categorize Comments
 
 Unless `--skip-validation` is set, classify each unique comment (deduplicated):
@@ -63,6 +82,37 @@ Total: N unique comments (N duplicates grouped)
 ```
 
 If `--dry-run`, stop here.
+
+### Step 2.5 — Detect Cross-Perspective Convergence
+
+When two or more independent reviewer perspectives flag the same location, that location is materially more likely to be a real issue. Auto-promote severity so converged findings are treated as MUST-FIX rather than as independent SHOULD-FIX items.
+
+Build a `findings` array from the categorized comments — one entry per actionable comment, plus any findings from other perspectives this iteration has access to (e.g. `claim-verifier` output, the reviewer agent's MUST-FIX/SHOULD-FIX entries from `.planning/REVIEW-*.md`). Map each to:
+
+```
+{
+  id:         <stable id, e.g. comment id or "claim-verifier:<n>">,
+  perspective:<who produced it, e.g. "Copilot", "claim-verifier", "reviewer-agent">,
+  path:       <file path>,
+  line:       <line number>,
+  severity:   <"must-fix"|"should-fix"|"nit"|"style"|"improvement"|...>,
+  category:   <"security"|"bug"|"style"|...>,
+  summary:    <short description>,
+}
+```
+
+Run convergence detection:
+
+```
+prReview(action: "detect-convergence", findings: <array>, lineTolerance: 2)
+```
+
+For each promotion the tool returns:
+- Find the corresponding categorized comment in your audit map.
+- Update its category to **must-fix** (regardless of its original category) and add a note: `Promoted via convergence with <other perspectives>`.
+- Surface the promotion in the comment audit summary: `Converged: <n> findings promoted to must-fix via 2+ perspectives`.
+
+Continue to Step 3 with the promoted categorization.
 
 ### Step 3 — Plan Fixes
 
@@ -112,7 +162,35 @@ gh api repos/{owner}/{repo}/issues/<number>/comments -f body="<reply>"
    ```
    Check that every comment thread has a reply. Report any gaps.
 
-### Step 7 — Store Learnings
+### Step 7 — Iteration-N Regression Check
+
+Fix commits sometimes introduce new issues that the original review didn't flag. Without this check, those new findings only surface in the *next* review pass, costing another full iteration. Catch them now.
+
+1. **Snapshot the post-iteration findings.** Re-fetch all PR comments:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/<number>/comments?per_page=100
+   ```
+   If the PR has automated reviewer hooks (Copilot, CodeRabbit, etc.) configured to re-run on push, allow a brief settle window (~30s) before re-fetching.
+
+2. **Build before/after finding arrays.** The `before` array is the same `findings` array you built at Step 2.5 (pre-iteration state). The `after` array is built the same way from the freshly-fetched comments — but include only comments authored *at or after* `iterationStartSha` to filter out persistent prior findings.
+
+3. **Compute touched paths** between the iteration boundary and the current HEAD:
+   ```
+   prReview(
+     action: "regression-check",
+     before:  <pre-iteration findings>,
+     after:   <post-iteration findings>,
+     fromSha: <iterationStartSha>,
+     toSha:   "HEAD"
+   )
+   ```
+
+4. **Handle the verdict.**
+
+   - `success: true` → iteration complete. Report `<n> resolved, <n> unchanged, <n> new on untouched paths` in the final summary.
+   - `success: false` (`PR_REVIEW_REGRESSION_DETECTED`) → fix commits introduced new findings. **Do not declare the iteration complete.** Re-enter Step 3 (Plan Fixes) with `report.regressions` as the input set. The regression cycle is bounded — if 3 consecutive iterations fail this check, escalate to the user with a summary of what's regressing and pause the loop.
+
+### Step 8 — Store Learnings
 
 Store **recurring patterns** in MuninnDB (skip one-off fixes):
 

--- a/.mastracode/commands/pr-address.md
+++ b/.mastracode/commands/pr-address.md
@@ -35,7 +35,7 @@ Parse and group comments:
 
 Build a comment map with fields: `commentId, author, body, file, line, inReplyTo, isDuplicate, duplicateGroupId`.
 
-**Snapshot the iteration boundary.** Record the current `git rev-parse HEAD` SHA as `iterationStartSha`. The regression check at Step 7 will use this to compute the set of paths the iteration modified and the before/after finding deltas.
+**Snapshot the iteration boundary.** Record the current `git rev-parse HEAD` SHA as `iterationStartSha` and the current time as `iterationStartTime` (ISO-8601). The regression check at Step 7 will use the SHA to compute the set of paths the iteration modified and the timestamp to filter post-iteration comments.
 
 ### Step 1.5 — Filter Stale Comments
 
@@ -109,14 +109,14 @@ prReview(action: "detect-convergence", findings: <array>, lineTolerance: 2)
 
 For each promotion the tool returns:
 - Find the corresponding categorized comment in your audit map.
-- Update its category to **must-fix** (regardless of its original category) and add a note: `Promoted via convergence with <other perspectives>`.
-- Surface the promotion in the comment audit summary: `Converged: <n> findings promoted to must-fix via 2+ perspectives`.
+- Promote its severity to **must-fix** while preserving its original category, and add a note: `Promoted via convergence with <other perspectives>`.
+- Surface the promotion in the comment audit summary: `Converged: <n> findings promoted to must-fix severity via 2+ perspectives`.
 
-Continue to Step 3 with the promoted categorization.
+Continue to Step 3 with the promoted severity and original category preserved.
 
 ### Step 3 — Plan Fixes
 
-For comments categorized as **must fix** and **should fix**:
+For comments with severity **must-fix** and **should-fix**:
 1. Group by file for efficient execution
 2. Determine the fix approach for each comment
 3. Order by severity: security → bug → requirement → style → improvement
@@ -166,13 +166,13 @@ gh api repos/{owner}/{repo}/issues/<number>/comments -f body="<reply>"
 
 Fix commits sometimes introduce new issues that the original review didn't flag. Without this check, those new findings only surface in the *next* review pass, costing another full iteration. Catch them now.
 
-1. **Snapshot the post-iteration findings.** Re-fetch all PR comments:
+1. **Snapshot the post-iteration findings.** Re-fetch all PR comments. When you start the iteration, record both `iterationStartSha` **and** `iterationStartTime` (an ISO-8601 timestamp captured at the same moment) so the regression check has both a code boundary and a time boundary:
    ```bash
-   gh api repos/{owner}/{repo}/pulls/<number>/comments?per_page=100
+   gh api repos/{owner}/{repo}/pulls/<number>/comments --paginate
    ```
    If the PR has automated reviewer hooks (Copilot, CodeRabbit, etc.) configured to re-run on push, allow a brief settle window (~30s) before re-fetching.
 
-2. **Build before/after finding arrays.** The `before` array is the same `findings` array you built at Step 2.5 (pre-iteration state). The `after` array is built the same way from the freshly-fetched comments — but include only comments authored *at or after* `iterationStartSha` to filter out persistent prior findings.
+2. **Build before/after finding arrays.** The `before` array is the same `findings` array you built at Step 2.5 (pre-iteration state). The `after` array is built the same way from the freshly-fetched comments — but include only comments whose `created_at` is **at or after** `iterationStartTime` to filter out persistent prior findings.
 
 3. **Compute touched paths** between the iteration boundary and the current HEAD:
    ```

--- a/.mastracode/skills/caveman/SKILL.md
+++ b/.mastracode/skills/caveman/SKILL.md
@@ -51,7 +51,7 @@ Example — destructive op:
 > ```sql
 > DROP TABLE users;
 > ```
-> Caveman resume. Verify backup exists first.
+> Caveman resume. Verify backup exist first.
 
 ## Boundaries
 

--- a/packages/luca-mastracode/src/launch.ts
+++ b/packages/luca-mastracode/src/launch.ts
@@ -7,7 +7,7 @@
  */
 import { existsSync, readFileSync } from 'node:fs'
 
-import { WORKSPACE_TOOLS, writeFileTool } from '@mastra/core/workspace'
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace'
 import { createMastraCode } from 'mastracode'
 import { MastraTUI } from 'mastracode/tui'
 
@@ -663,74 +663,6 @@ export async function main(): Promise<void> {
             }
             return workspace
         }
-    }
-
-    // --- Workaround for upstream @mastra/core bug (tracked: issue #173) ---
-    //
-    // `LocalFilesystem.writeFile()` in `@mastra/core@1.28.0` calls `stat()` to
-    // honor the optional `expectedMtime` precheck. When the target file doesn't
-    // yet exist, `stat()` throws a custom `FileNotFoundError` that has no
-    // `code` property, so the surrounding `isEnoentError(err)` check (which
-    // compares `err.code === 'ENOENT'`) returns false and the error is
-    // rethrown — even though "file does not exist" is the normal case for a
-    // new write.
-    //
-    // We wrap the singleton `writeFileTool`'s `execute` to detect the precheck
-    // failure and fall back to calling the workspace filesystem's `writeFile()`
-    // directly, bypassing the broken precheck path entirely. We also create
-    // parent directories first so the fallback behaves like the tool would
-    // have. Idempotent via a Symbol marker. Remove once upstream is fixed.
-    const LUCA_WRITE_FILE_PATCHED = Symbol.for('luca.write_file.patched')
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const wft = writeFileTool as any
-    if (
-        wft &&
-        typeof wft.execute === 'function' &&
-        !wft[LUCA_WRITE_FILE_PATCHED]
-    ) {
-        const originalExecute = wft.execute
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        wft.execute = async function patchedExecute(input: any, context: any) {
-            try {
-                return await originalExecute.call(this, input, context)
-            } catch (error) {
-                const name = error instanceof Error ? error.name : ''
-                const msg = error instanceof Error ? error.message : ''
-                const isPrecheckFnf =
-                    name === 'FileNotFoundError' || /^File not found:/.test(msg)
-                if (!isPrecheckFnf) throw error
-
-                // Fallback: bypass the broken tool path and call the workspace
-                // filesystem directly. `path` is the only required input; the
-                // tool layer would normally also create parent dirs, so we do
-                // the same here.
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const fs = (context as any)?.workspace?.filesystem
-                if (
-                    !fs ||
-                    typeof fs.writeFile !== 'function' ||
-                    typeof fs.mkdir !== 'function'
-                ) {
-                    // No filesystem to fall back to — surface the original
-                    // error rather than silently dropping the write.
-                    throw error
-                }
-                const path = input?.path as string | undefined
-                const content = input?.content as string | undefined
-                if (typeof path !== 'string' || typeof content !== 'string') {
-                    throw error
-                }
-                const dir = path.includes('/')
-                    ? path.slice(0, path.lastIndexOf('/'))
-                    : ''
-                if (dir) {
-                    await fs.mkdir(dir, { recursive: true }).catch(() => {})
-                }
-                await fs.writeFile(path, content)
-                return `Wrote ${Buffer.byteLength(content, 'utf-8')} bytes to ${path}`
-            }
-        }
-        wft[LUCA_WRITE_FILE_PATCHED] = true
     }
 
     // Also enforce on the cached workspace when modes change outside the request


### PR DESCRIPTION
## Summary

Removes a dead workaround patch from the mastracode harness and ships minor skill/command improvements.

### Changes

**writeFileTool patch removal** (`packages/luca-mastracode/src/launch.ts`)
- Removed 67 lines of dead code that patched `writeFileTool` to work around an upstream `@mastra/core@1.28.0` bug where `FileNotFoundError` lacked a `code` property
- The bug was fixed in `@mastra/core@1.29.0` — both installed versions (1.29.0 and 1.29.1) have the fix
- The patch's fallback path was also broken (AI SDK never populates `context.workspace`), making it fully inert
- Removed the now-unused `writeFileTool` import

**pr-address command** (`.mastracode/commands/pr-address.md`)
- Added Step 1.5: stale-comment filter
- Added Step 2.5: cross-perspective convergence detection
- Added Step 7: iteration-N regression check (renumbers old Step 7 → Step 8)

**caveman skill** (`.mastracode/skills/caveman/SKILL.md`)
- Grammar fix: `exists` → `exist`

## Test Plan

- `bunx --bun tsc --noEmit` passes clean on `packages/luca-mastracode`
- Static analysis confirmed the upstream bug fix is present in both installed `@mastra/core` versions
- No behavioral change — the removed patch was dead code