### PR TITLE
refactor(skills): rework gh-prepare as post-work shipping tool

### DIFF
--- a/.changeset/gh-prepare-review-fixes.md
+++ b/.changeset/gh-prepare-review-fixes.md
@@ -1,0 +1,5 @@
+---
+"@alecsibilia/luca-mastracode": patch
+---
+
+Fix gh-prepare skill spec: use defaultBranch variable consistently, add branch-f reset after checkout, replace brittle ls|grep with find, align frontmatter with draft PR behavior

--- a/packages/luca-mastracode/commands/gh-prepare.md
+++ b/packages/luca-mastracode/commands/gh-prepare.md
@@ -1,6 +1,6 @@
 ---
 name: gh-prepare
-description: Create a linked GitHub issue, feature branch, and draft PR — all wired together
+description: Ship committed work — ensure changeset, push feature branch, open draft PR
 ---
 
 Activate the `gh-prepare` skill with these arguments:

--- a/packages/luca-mastracode/skills/arch-audit/SKILL.md
+++ b/packages/luca-mastracode/skills/arch-audit/SKILL.md
@@ -1,0 +1,152 @@
+---
+description: "Find deepening opportunities — shallow modules, premature abstractions, misplaced seams. Uses deletion test and promotion model to surface architectural friction. Use when user says \"audit architecture\", \"find refactoring opportunities\", \"what's shallow\", \"improve structure\", or invokes /arch-audit."
+---
+
+# arch-audit
+
+Surface architectural friction and propose deepening opportunities — refactors that turn shallow modules into deep ones, improve testability, and increase locality of change.
+
+## Vocabulary
+
+Use these terms exactly in every finding. Consistent language prevents drift into vague terms like "component," "service," or "boundary."
+
+- **Module** — anything with an interface and implementation (function, class, file, package). Scale-agnostic.
+- **Interface** — what a caller must know: types, invariants, error modes, ordering. Not just the type signature.
+- **Depth** — leverage at the interface. **Deep** = significant behavior behind a small interface. **Shallow** = interface nearly as complex as the implementation.
+- **Seam** — where behavior can be altered without editing in place. A boundary that accepts different adapters.
+- **Deletion test** — imagine deleting the module. Complexity vanishes → pass-through (shallow). Complexity reappears across callers → earning its keep (deep).
+- **Promotion tier** — where code lives based on caller count. Tier 1 (single caller, private). Tier 2 (shared within feature). Tier 3 (shared across features).
+
+## Step 1: Recall architectural context
+
+Query MuninnDB for past decisions so you don't re-suggest rejected refactors:
+
+```
+mcp__muninn__muninn_recall(
+  vault: "<repo_vault>",
+  context: ["architectural decisions", "rejected refactors", "module structure"],
+  tags: ["decision"],
+  limit: 15
+)
+```
+
+Vault from `.planning/config.json` → `muninn.vault`, fallback `"default"`.
+
+If `.planning/CONTEXT.md` exists, read it for project constraints and domain terminology.
+
+**Guard**: if a past decision explicitly rejected a refactor you'd otherwise suggest, skip it. Only resurface if friction has materially worsened since the decision was recorded.
+
+## Step 2: Explore for friction
+
+Spawn one or more **explore** subagents to walk the codebase. Provide this brief:
+
+> Walk the codebase and report friction. Look for:
+>
+> 1. **Shallow modules** — interface nearly as complex as implementation. Apply the deletion test: would removing this module concentrate complexity (earning its keep) or just redistribute it (pass-through)?
+> 2. **Concept bouncing** — understanding one concept requires reading across many small files
+> 3. **Premature abstractions** — interfaces/abstract types with a single implementation
+> 4. **Leaked coupling** — tightly-coupled modules that share internal details across their seam
+> 5. **Misplaced code** — helpers/utilities at promotion tier 3 (shared across features) that have only 1-2 callers
+> 6. **Untestable surfaces** — code that's hard to test through its current public interface
+>
+> For each finding, report: file path, what the friction is, deletion test result (if applicable), caller count.
+
+If the codebase is large, scope the exploration to specific areas the user mentions, or split into multiple focused subagents (e.g., one per package in a monorepo).
+
+Do NOT follow rigid heuristics. Explore organically. Note where you experience friction — where understanding breaks down, where you bounce between files, where interfaces feel heavier than what they hide.
+
+## Step 3: Present deepening candidates
+
+Synthesize subagent findings into a numbered list of **deepening opportunities**. For each candidate:
+
+```
+### <N>. <Short description>
+
+- **Files**: <paths involved>
+- **Problem**: <what the friction is — use vocabulary precisely>
+- **Deletion test**: <result — "vanishes" or "reappears across N callers">
+- **Promotion check**: <current tier vs appropriate tier based on caller count>
+- **Proposed direction**: <one sentence — what "deeper" looks like here>
+- **Risk**: <what could go wrong if refactored>
+```
+
+Order by impact (most friction first). Limit to 5-7 candidates — more than that is noise.
+
+**Do NOT propose interfaces or implementations yet.** Present candidates only.
+
+Ask: "Which of these would you like to explore?"
+
+## Step 4: Design alternatives (design-it-twice)
+
+For the candidate the user selects:
+
+1. **Frame the problem** — write a short explanation for the user:
+   - What constraints any new interface must satisfy
+   - What dependencies exist and their nature
+   - A rough illustrative sketch (not a proposal — just grounding)
+
+2. **Spawn 2-3 explore/plan subagents in parallel** — each must produce a *radically different* interface design for the deepened module. Brief each subagent with:
+   - File paths and current coupling
+   - Caller list and their expectations
+   - The vocabulary (Module, Interface, Depth, Seam)
+   - Constraint: "Your design must be fundamentally different from the others"
+
+3. **Present designs sequentially** — let the user absorb each one:
+   - Interface signature (public surface)
+   - Usage example (how callers use it)
+   - What it hides (complexity kept internal)
+   - Trade-offs (what this design makes easy vs hard)
+
+4. **Compare and recommend** — contrast by:
+   - Depth (leverage at the interface)
+   - Locality (where change concentrates)
+   - Seam placement (where behavior can be swapped)
+   - Testability (how easy to test through the interface)
+
+   Give your recommendation. If elements from different designs combine well, propose a hybrid.
+
+5. **User decides** — they pick a design (or request iteration).
+
+## Step 5: Record the outcome
+
+After the user decides, store the result in MuninnDB:
+
+**If refactor is accepted:**
+```
+mcp__muninn__muninn_remember(
+  vault: "<repo_vault>",
+  concept: "decision:arch-audit-<descriptive-slug>",
+  content: "Accepted deepening: <what was refactored, which design was chosen, why>. Files: <paths>. Date: <ISO>.",
+  tags: ["decision", "architecture", "refactor"]
+)
+```
+
+**If refactor is rejected:**
+```
+mcp__muninn__muninn_remember(
+  vault: "<repo_vault>",
+  concept: "decision:arch-audit-rejected-<descriptive-slug>",
+  content: "Rejected deepening of <module>. Reason: <user's reason>. Friction level at time of rejection: <description>. Re-evaluate if: <conditions that would change the decision>.",
+  tags: ["decision", "architecture", "rejected"]
+)
+```
+
+The rejected decision prevents re-suggestion on future runs (Step 1 guard).
+
+## Step 6: Plan the refactor (optional)
+
+If the user wants to proceed with implementation:
+
+- Ask: "Want me to create a plan for this refactor, or do it directly?"
+- If plan → suggest invoking `/lu` with the chosen design as context
+- If direct → proceed with implementation in the current session
+
+The chosen interface from Step 4 becomes the first test's target (interface-first task boundaries).
+
+## Behavioral Notes
+
+- **This is ad-hoc** — invoked when the user feels friction, not on a schedule
+- **No file dependencies** — everything lives in MuninnDB or is inlined in this skill
+- **Scope** — if user doesn't specify an area, ask before exploring the entire codebase. For monorepos, start with one package.
+- **Vocabulary discipline** — use Module/Interface/Depth/Seam/Deletion Test consistently. Don't drift into "component," "service," "API," "boundary," "layer."
+- **Don't be prescriptive about tooling** — the skill identifies friction and proposes designs. It doesn't force a specific architecture style (DDD, hexagonal, etc.) unless the project already uses one.

--- a/packages/luca-mastracode/skills/gh-prepare/SKILL.md
+++ b/packages/luca-mastracode/skills/gh-prepare/SKILL.md
@@ -1,98 +1,117 @@
 ---
 name: gh-prepare
 description: >
-  Create a linked GitHub issue, feature branch, and draft PR for the current work — all wired
-  together. Works standalone (outside the Luca pipeline) or within it. Use when user says
-  "prepare", "set up branch and issue", "create issue and PR", "prepare github",
-  "link issue to PR", or invokes /gh-prepare.
+  Ship committed work: ensure changeset, push feature branch, open PR.
+  Works standalone (outside the Luca pipeline) or within it. Use when user says
+  "prepare", "ship this", "open a PR", "push and PR", or invokes /gh-prepare.
 ---
 
 # GH Prepare
 
-Create a linked GitHub issue + feature branch + draft PR in one shot. The PR body references
-`Closes #<issue>` so merging auto-closes the issue. This is the standalone version of what the
-Luca pipeline's architect mode does in Step 1 — use it when working outside the pipeline.
+Ship committed work to GitHub. Handles the mechanical steps between "code is done" and
+"PR is open": branch hygiene, changeset, push, and PR creation. No issue creation — that's
+external ideation handled by `gh-issue-triage`.
 
 ## Process
 
 ### 1. Detect Context
 
 ```bash
-git remote -v              # confirm GitHub remote exists
-git branch --show-current  # current branch
+git remote -v                  # confirm GitHub remote exists
+git branch --show-current      # current branch
 git rev-parse --abbrev-ref origin/HEAD 2>/dev/null || echo main  # default branch
-git status --porcelain     # dirty tree check
+git status --porcelain         # dirty tree check
+git log --oneline origin/main..HEAD 2>/dev/null  # unpushed commits
 ```
 
-If working tree is dirty, warn but don't block — the user may want to prepare before committing.
+Gather:
+- `currentBranch` — the branch we're on
+- `defaultBranch` — usually `main`
+- `hasDirtyTree` — uncommitted changes exist
+- `unpushedCommits` — commits ahead of `origin/main`
+- `hasRemote` — GitHub remote exists
 
 If no GitHub remote detected, stop and tell the user.
 
-### 2. Parse Arguments
+If working tree is dirty, warn: "You have uncommitted changes. Commit or stash them first."
+Do not proceed with dirty tree — changeset and PR diffs will be wrong.
 
-Accept freeform description from `$ARGUMENTS`. Infer:
+If no unpushed commits exist (HEAD matches origin/main), stop: "Nothing to ship — HEAD is
+up to date with origin/main."
 
-- **Type**: `feat` / `fix` / `refactor` / `chore` (default `feat`)
-- **Title**: concise summary for the issue
-- **Labels**: inferred from type + description (e.g., `bug` for fix, `enhancement` for feat)
+### 2. Branch Hygiene
 
-Optional flags:
-- `--no-pr` — skip PR creation (issue + branch only)
-- `--no-issue` — skip issue creation (branch + PR only, for when issue already exists)
-- `--no-branch` — skip branch creation (issue only)
-- `--type=<type>` — override inferred type
-- `--issue=<number>` — link to an existing issue instead of creating one
+**If on `main` or `defaultBranch`:**
 
-### 3. Check for Existing Work
-
-Before creating anything:
-
-1. If already on a feature branch (e.g., `feat/42-...`), ask: reuse this branch or create a new one?
-2. If `--issue=<N>` provided, verify the issue exists via `gh issue view <N>` and use it directly
-
-### 4. Create GitHub Issue
-
-Skip if `--no-issue` or `--issue=<N>` provided.
+The commits shouldn't have been made directly to main. Create a feature branch and move
+the commits onto it:
 
 ```bash
-gh issue create \
-  --title "<title>" \
-  --label "<labels>" \
-  --body "<body>"
+# Determine branch name from commit messages
+# Parse type from conventional commit prefix (feat, fix, refactor, chore)
+# Slugify the first commit's subject for the branch name
+git checkout -b <type>/<slug>
+# main now needs to be reset to match origin/main
+# But we're already on the new branch with the commits, so main is untouched
 ```
 
-Issue body template:
+Check if the branch name already exists on the remote:
+```bash
+git ls-remote --heads origin <branch-name>
+```
+If it exists, warn and ask the user whether to reuse or pick a different name.
 
-```markdown
-## Problem
+**If already on a feature branch:**
 
-<what needs to change and why, derived from the user's description>
+Use the current branch as-is. No action needed.
 
-## Proposed Solution
+### 3. Changeset (if applicable)
 
-<high-level approach>
-
-## Acceptance Criteria
-
-- [ ] <criterion derived from description>
+Check if the repo uses changesets:
+```bash
+test -f .changeset/config.json
 ```
 
-Capture the issue number from the output.
+If yes:
+1. Check if a changeset already exists for this work:
+   ```bash
+   ls .changeset/*.md | grep -v README
+   ```
+2. If no changeset exists, create one:
+   - Determine bump level from branch prefix or commit types: `feat` → minor, `fix`/`chore`/`refactor` → patch
+   - Read package names from `.changeset/config.json` `"fixed"` groups or workspace `package.json` files
+   - Write `.changeset/<slug>.md` with the appropriate bump level and summary
+   - `git add .changeset/<slug>.md && git commit -m "chore: add changeset"`
+3. If a changeset already exists, verify it looks correct (right packages, right bump level). Don't duplicate.
 
-### 5. Create Feature Branch
+Skip if `--no-changeset` flag is provided or if no `.changeset/config.json` exists.
 
-Skip if `--no-branch`.
+### 4. Push Branch
 
 ```bash
-git checkout -b <type>/<issue-number>-<slug>
-git push -u origin <type>/<issue-number>-<slug>
+git push -u origin <branch-name>
 ```
 
-Branch naming follows project conventions: `feat/42-add-webhook-support`, `fix/17-null-check`.
+If the push fails (e.g., branch already exists with divergent history), report the error
+and stop. Do not force push.
+
+### 5. Discover Linked Issue
+
+Check if this work originated from a triaged GitHub issue:
+
+1. **From todo source field**: Look in `.planning/todos/{pending,backlog,done}/` for a
+   todo whose work matches the current branch. If the todo has `source: gh-issue-#<N>`,
+   that's the linked issue.
+2. **From MuninnDB**: Recall recent `gh-prepare` or pipeline state that references an
+   issue number for this branch.
+3. **From branch name**: If the branch is named `feat/42-something`, extract `#42` as a
+   candidate and verify it exists: `gh issue view 42 --json state`.
+4. **From commit messages**: Scan for `#N` references in commit messages.
+
+If an issue is found, `Closes #<N>` goes in the PR body.
+If no issue is found, that's fine — not all work originates from an issue.
 
 ### 6. Create Draft PR
-
-Skip if `--no-pr`.
 
 ```bash
 gh pr create --draft \
@@ -103,72 +122,73 @@ gh pr create --draft \
 PR body template:
 
 ```markdown
-Closes #<issue-number>
+<Closes #N if linked issue found>
 
 ## What
 
-<summary of the change>
+<summary derived from commit messages — what changed>
 
 ## Why
 
-<problem being solved, links to issue>
+<problem being solved, derived from commit messages and branch context>
 
 ## How
 
-_TBD — will be filled as implementation progresses._
+<brief technical approach, derived from diff stats>
 
 ## Test Plan
 
-_TBD_
+<how to verify — inferred from test files changed, or "Manual verification" if none>
 ```
 
-The `Closes #<issue>` line is **mandatory** — it's the link between PR and issue.
+The title should be a conventional commit format. Derive `type` from the branch prefix
+or dominant commit type. Derive `scope` from the primary package or area changed.
 
-### 7. Changeset (if applicable)
+### 7. Store in MuninnDB
 
-If the repo uses changesets (`.changeset/config.json` exists), create one:
-
-```bash
-# Check for changeset config
-if [ -f .changeset/config.json ]; then
-  # Determine bump level from type: feat → minor, fix → patch, chore → patch
-  # Read package names from config.json "fixed" or workspace package.json files
-fi
-```
-
-Write `.changeset/<slug>.md` with the appropriate bump level and summary. Include it in the commit or amend the branch's first commit.
-
-Skip if `--no-changeset` flag is provided or if no `.changeset/config.json` exists.
-
-### 8. Store in MuninnDB
-
-Remember for later recall (by finalize mode, other sessions, or `/gh-prepare` dedup):
+Remember for later recall (by finalize mode, other sessions, or dedup):
 
 ```
 mcp__muninn__muninn_remember(
   vault: "<repo_vault>",
   concept: "gh-prepare",
-  content: "GitHub setup: issue #<N> (<url>), branch <name>, PR #<M> (<url>). Work: <description>",
-  tags: ["gh-prepare", "issue", "branch", "pr"],
+  content: "Shipped: branch <name>, PR #<M> (<url>). <Closes #N if linked.> Work: <description>",
+  tags: ["gh-prepare", "branch", "pr"],
   entities: [
-    { name: "issue-<N>", type: "github-issue" },
     { name: "pr-<M>", type: "github-pr" },
     { name: "<branch-name>", type: "git-branch" }
   ]
 )
 ```
 
-### 9. Pipeline Integration
+### 8. Pipeline Integration
 
-If `.planning/luca-state.json` exists (Luca pipeline is active), also update workflow state with the issue number and branch name so finalize mode can find them. If not active, skip — the skill works independently.
+If `.planning/luca-state.json` exists (Luca pipeline is active), update workflow state
+with the PR number and branch name so finalize mode can find them. If not active, skip —
+the skill works independently.
 
-### 10. Report
+### 9. Report
 
 Print a clean summary:
 
 ```
-Issue:  #42 — https://github.com/<owner>/<repo>/issues/42
-Branch: feat/42-add-webhook-support
+Branch: feat/42-add-webhook-support (pushed)
 PR:     #43 (draft) — https://github.com/<owner>/<repo>/pull/43
-        PR auto-closes #42 on merge.
+Issue:  Closes #42 on merge
 ```
+
+Or if no linked issue:
+
+```
+Branch: feat/add-webhook-support (pushed)
+PR:     #43 (draft) — https://github.com/<owner>/<repo>/pull/43
+```
+
+## Flags
+
+| Flag | Effect |
+|------|--------|
+| `--no-changeset` | Skip changeset creation even if `.changeset/config.json` exists |
+| `--no-pr` | Push branch only, skip PR creation |
+| `--title="..."` | Override the PR title |
+| `--issue=<N>` | Explicitly link to issue #N instead of auto-discovering |

--- a/packages/luca-mastracode/skills/gh-prepare/SKILL.md
+++ b/packages/luca-mastracode/skills/gh-prepare/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gh-prepare
 description: >
-  Ship committed work: ensure changeset, push feature branch, open PR.
+  Ship committed work: ensure changeset, push feature branch, open draft PR.
   Works standalone (outside the Luca pipeline) or within it. Use when user says
   "prepare", "ship this", "open a PR", "push and PR", or invokes /gh-prepare.
 ---
@@ -21,14 +21,15 @@ git remote -v                  # confirm GitHub remote exists
 git branch --show-current      # current branch
 git rev-parse --abbrev-ref origin/HEAD 2>/dev/null || echo main  # default branch
 git status --porcelain         # dirty tree check
-git log --oneline origin/main..HEAD 2>/dev/null  # unpushed commits
+git log --oneline origin/<defaultBranch>..HEAD 2>/dev/null  # commits ahead of default branch
 ```
 
 Gather:
 - `currentBranch` — the branch we're on
 - `defaultBranch` — usually `main`
 - `hasDirtyTree` — uncommitted changes exist
-- `unpushedCommits` — commits ahead of `origin/main`
+- `commitsAheadOfDefault` — commits ahead of `origin/<defaultBranch>`
+- `hasUpstream` — whether the current branch has a tracking upstream (`git rev-parse --abbrev-ref @{u}`)
 - `hasRemote` — GitHub remote exists
 
 If no GitHub remote detected, stop and tell the user.
@@ -36,8 +37,13 @@ If no GitHub remote detected, stop and tell the user.
 If working tree is dirty, warn: "You have uncommitted changes. Commit or stash them first."
 Do not proceed with dirty tree — changeset and PR diffs will be wrong.
 
-If no unpushed commits exist (HEAD matches origin/main), stop: "Nothing to ship — HEAD is
-up to date with origin/main."
+If `hasUpstream` is true and there are no unpushed commits relative to the upstream
+(`@{u}..HEAD` is empty), AND the branch is already pushed, stop: "Nothing to ship — branch
+is up to date with its upstream."
+
+If on the default branch and `commitsAheadOfDefault` is empty (HEAD matches
+`origin/<defaultBranch>`), stop: "Nothing to ship — HEAD is up to date with
+origin/<defaultBranch>."
 
 ### 2. Branch Hygiene
 
@@ -51,8 +57,9 @@ the commits onto it:
 # Parse type from conventional commit prefix (feat, fix, refactor, chore)
 # Slugify the first commit's subject for the branch name
 git checkout -b <type>/<slug>
-# main now needs to be reset to match origin/main
-# But we're already on the new branch with the commits, so main is untouched
+# The commits are now on the new branch; move local defaultBranch back to origin
+git branch -f <defaultBranch> origin/<defaultBranch>
+# This only rewrites the local branch ref; do not force-push
 ```
 
 Check if the branch name already exists on the remote:
@@ -75,7 +82,7 @@ test -f .changeset/config.json
 If yes:
 1. Check if a changeset already exists for this work:
    ```bash
-   ls .changeset/*.md | grep -v README
+   find .changeset -maxdepth 1 -type f -name '*.md' ! -name 'README.md'
    ```
 2. If no changeset exists, create one:
    - Determine bump level from branch prefix or commit types: `feat` → minor, `fix`/`chore`/`refactor` → patch

--- a/packages/luca-mastracode/src/instructions/architect.md
+++ b/packages/luca-mastracode/src/instructions/architect.md
@@ -225,6 +225,55 @@ Each task must be:
 
 Match wave count to complexity. Not every plan needs many waves.
 
+### Step 4.5: Architectural Quality Check
+
+Before submitting the plan for review, evaluate each planned module/file against these principles. Flag violations inline (as comments in the plan) and revise where possible.
+
+#### Vocabulary
+
+Use these terms precisely in plan descriptions and review feedback:
+
+- **Module** — anything with an interface and implementation (function, class, file, package). Scale-agnostic.
+- **Interface** — what a caller must know: types, invariants, error modes, ordering. Not just the type signature.
+- **Depth** — leverage at the interface. **Deep** = significant behavior behind a small interface. **Shallow** = interface nearly as complex as the implementation.
+- **Seam** — where behavior can be altered without editing in place. A boundary that accepts different adapters.
+- **Deletion test** — imagine deleting the module. Complexity vanishes → pass-through (shallow). Complexity reappears across callers → earning its keep (deep).
+
+#### Principles
+
+**1. Depth over extraction.** Prefer deep modules — small public surface hiding significant complexity. Don't plan file extractions unless the result concentrates complexity behind a simpler interface. A 300-line file with a 3-function public surface is better than 6 files with pass-through wrappers.
+
+**2. Promotion model (deletion test applied).** Code placement follows caller count — start local, promote when real consumers appear:
+
+| Callers | Placement |
+|---------|-----------|
+| 1 | Private to the caller (inline function or local helper) |
+| 2+ within same feature | Shared file within that feature's directory |
+| 2+ across features | Promoted to shared utility/package |
+
+Never preemptively place at a higher tier. When planning a new helper/utility, check: "who calls this today?" If one module → it lives inside that module. Flag planned files that would be pass-throughs under the deletion test.
+
+**3. Concrete first.** Don't plan TypeScript interfaces or abstract types for single implementations. Write the concrete module. Plan the abstraction only when the user explicitly requests multi-backend support, or a second adapter is concretely needed within the same milestone. One adapter = hypothetical seam (don't abstract). Two adapters = real seam (abstract).
+
+**4. Locality of change.** Group related behavior so changes concentrate in one module. If a planned feature touches many files with small edits each, flag it: the plan may need to consolidate related logic into fewer, deeper modules first. Tight locality means bugs, changes, and knowledge live in one place.
+
+**5. Interface-first task boundaries.** Each task delivers a testable public surface — the thing callers actually use. The interface IS the test surface. Task boundary = module's public API = test surface. Internal helpers exist inside the module, not as separate tasks.
+
+- ✅ "Implement `processOrder()` — accepts OrderInput, returns ProcessedOrder" (testable interface)
+- ❌ "Write date formatting helper" then "Wire helper into order processor" (internal plumbing as tasks)
+
+#### Applying the check
+
+For each new file/module the plan creates, ask:
+
+1. **Is it a helper, utility, or extraction?** (exists to serve other code, not to deliver a feature directly)
+   - If yes → apply deletion test. Would deleting it redistribute complexity across callers? If not, inline it.
+   - If no (it's a feature leaf: route, component, command, tool) → skip, it's earning its keep by definition.
+2. **Does it have a single caller today?** → start at tier 1 (private to caller). Don't promote preemptively.
+3. **Does the task produce a testable interface?** If the task's deliverable is "internal wiring" rather than a usable public surface, restructure the task.
+
+Revise the plan to address violations before proceeding to Step 5.
+
 ### Progress Tracking
 
 Use `task_write` for user visibility:
@@ -252,6 +301,7 @@ Spawn a **plan-reviewer** subagent to validate:
 4. **Verification**: Every task has concrete, testable verification criteria?
 5. **Feasibility**: Tasks realistic given codebase state?
 6. **Gap detection**: Anything from research missing?
+7. **Architectural quality**: No shallow extractions, promotion model respected, no premature abstractions, tasks deliver testable interfaces?
 
 ### Step 5.5: Capture Raw Review Findings
 


### PR DESCRIPTION
## What

Reworks `gh-prepare` from a pre-work setup tool into a post-work shipping tool.

## Why

The previous `gh-prepare` was designed for pre-work setup (create GitHub issue → branch → empty draft PR → start coding), but in practice the skill is always invoked **after** work is done — when commits exist and need to be shipped as a PR.

Additionally, the old skill created GitHub issues as part of the shipping flow, which contradicts our workflow model where GitHub issues are external ideation ingested via `gh-issue-triage`.

## How

The reworked skill handles the mechanical steps between "code is done" and "PR is open":

1. **Detect context** — branch, commits, dirty tree, remote
2. **Branch hygiene** — if on `main`, move commits to a feature branch
3. **Changeset** — add if `.changeset/config.json` exists and none present
4. **Push** — push branch to remote
5. **Discover linked issue** — from todo `source` field, MuninnDB, branch name, or commit messages
6. **Draft PR** — open with `Closes #N` if linked issue found
7. **MuninnDB** — store for later recall

No issue creation. No arguments required. Reads git state to figure everything out.

## Test Plan

Manual verification — invoke `/gh-prepare` with committed work on a feature branch and on `main`.