### PR TITLE
chore: promote 11.3.0-alpha.0 to stable 11.3.0 release

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "alpha",
   "initialVersions": {
     "@alecsibilia/luca-framework": "11.2.1",


### PR DESCRIPTION
## Summary

Exits changeset prerelease (alpha) mode so the next version PR promotes both packages from `11.3.0-alpha.0` to `11.3.0` (latest).

The alpha has been baked in since May 1 with no reported issues.

## What happens after merge

1. Release workflow triggers and opens a version PR bumping to `11.3.0`
2. Merging that version PR publishes both packages to npm with `--tag latest`

## Changes

- `.changeset/pre.json`: `mode` changed from `"pre"` to `"exit"`