### PR TITLE
chore: promote 11.4.0-alpha.0 to stable 11.4.0 release

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "alpha",
   "initialVersions": {
     "@alecsibilia/luca-framework": "11.3.0",


### PR DESCRIPTION
## Summary

Exits changeset prerelease (alpha) mode so the next version PR promotes `@alecsibilia/luca-framework` from `11.4.0-alpha.0` to `11.4.0` (latest).

The alpha (published from PR #215) has been baked in for ~13 hours with no reported issues. The new symlink-based bundled-asset install was the meaningful change in this version, and it's been validated end-to-end.

## What happens after merge

1. Release workflow triggers on push to `main` and opens a version PR bumping `luca-framework` to `11.4.0` and consuming both pending changesets (`bundled-assets-install-ordering`, `zero-footprint-bundled-assets`)
2. Merging that version PR publishes `@alecsibilia/luca-framework@11.4.0` to npm with `--tag latest` (the prerelease detection in `release.yml` only adds `--tag alpha` when the version contains `-`, so a stable `11.4.0` publishes as `latest` automatically)
3. `@alecsibilia/luca-mastracode` is `private: true` and does not publish — its version is bumped in the workspace but never hits npm

## Changes

- `.changeset/pre.json`: `mode` changed from `"pre"` to `"exit"`

## Install after promotion

```
bun add @alecsibilia/luca-framework@latest   # → 11.4.0
```
