### PR TITLE
fix(luca-mastracode): handle multi-line input after custom slash commands + document MuninnDB MCP wiring

### DIFF
--- a/.changeset/multiline-slash-command-fix.md
+++ b/.changeset/multiline-slash-command-fix.md
@@ -1,0 +1,5 @@
+---
+"@alecsibilia/luca-mastracode": patch
+---
+
+Fix: custom slash commands followed by multi-line pasted text no longer fail with "Unknown command". Upstream's slash dispatcher parses with a single-line regex (`/^(\/\/?)(.*)$/`, no `s` flag), so any newline in the input caused the regex to miss and the dispatcher fell through to the unknown-command branch. Added an upstream patch that monkey-patches `tui.handleSlashCommand` to collapse newline-spanning whitespace in slash inputs to single spaces before dispatch — matches the behavior of `processSlashCommand`'s `args.join(' ')` arg substitution, so no information is lost.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,32 @@ Luca integrates with [MuninnDB](https://github.com/asibilia/muninn) for persiste
 - **Release conventions** — versioning, PR format, publish procedures
 - **Entity graph** — named entities and relationships across the codebase
 
-MuninnDB tools are available in all modes via MCP integration.
+#### Wiring MuninnDB into the Mastracode harness
+
+MuninnDB tools (`mcp__muninn__*`) reach the harness via MCP — and Mastracode does **not** auto-configure this. After `luca init` installs and starts MuninnDB, you have to add an MCP server entry yourself.
+
+Mastracode loads MCP config from three locations, highest priority first:
+
+1. `<project>/.mastracode/mcp.json` — project-scoped
+2. `~/.mastracode/mcp.json` — user-global (recommended for MuninnDB)
+3. `<project>/.claude/settings.local.json` — Claude Code compat
+
+For most users, configure once globally and every project picks it up. Create `~/.mastracode/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "muninn": {
+      "url": "http://localhost:8750/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-muninn-api-key>"
+      }
+    }
+  }
+}
+```
+
+Use the same API key that `luca vault:init` prompted for (or read it from your project's `.env`'s `MUNINN_DB_API_KEY`). Restart the harness, then run `/mcp` inside the TUI to confirm the `muninn` server is connected. The `mcp__muninn__*` tools become available to mode agents and to subagents that opt in (researcher, planner, executor, verifier, reviewer, learner, discussion).
 
 ### Prompt Engineering
 

--- a/README.md
+++ b/README.md
@@ -100,13 +100,15 @@ Luca integrates with [MuninnDB](https://github.com/asibilia/muninn) for persiste
 
 MuninnDB tools (`mcp__muninn__*`) reach the harness via MCP — and Mastracode does **not** auto-configure this. After `luca init` installs and starts MuninnDB, you have to add an MCP server entry yourself.
 
-Mastracode loads MCP config from three locations, highest priority first:
+Mastracode loads MCP config from three locations, highest priority first (where `<home>` is `$HOME` on macOS/Linux and `%USERPROFILE%` on Windows):
 
 1. `<project>/.mastracode/mcp.json` — project-scoped
-2. `~/.mastracode/mcp.json` — user-global (recommended for MuninnDB)
+2. `<home>/.mastracode/mcp.json` — user-global (recommended for MuninnDB)
+   - macOS/Linux: `~/.mastracode/mcp.json`
+   - Windows: `%USERPROFILE%\.mastracode\mcp.json`
 3. `<project>/.claude/settings.local.json` — Claude Code compat
 
-For most users, configure once globally and every project picks it up. Create `~/.mastracode/mcp.json`:
+For most users, configure once globally and every project picks it up. Create the user-global file at `<home>/.mastracode/mcp.json`:
 
 ```json
 {

--- a/packages/luca-framework/src/commands/init.ts
+++ b/packages/luca-framework/src/commands/init.ts
@@ -204,9 +204,12 @@ export const initCommand = defineCommand({
             '  To expose MuninnDB to the harness: add an MCP server entry to'
         )
         readout.push(
-            '    ~/.mastracode/mcp.json — see README → "Wiring MuninnDB into'
+            '    <home>/.mastracode/mcp.json (macOS/Linux: ~/.mastracode/mcp.json;'
         )
-        readout.push('    the Mastracode harness".')
+        readout.push(
+            '    Windows: %USERPROFILE%\\.mastracode\\mcp.json) — see README →'
+        )
+        readout.push('    "Wiring MuninnDB into the Mastracode harness".')
 
         p.note(readout.join('\n'), 'Setup Complete')
 

--- a/packages/luca-framework/src/commands/init.ts
+++ b/packages/luca-framework/src/commands/init.ts
@@ -200,6 +200,13 @@ export const initCommand = defineCommand({
             '  To set up a project vault: cd <project> && luca vault:init'
         )
         readout.push('  To launch the harness:     luca run')
+        readout.push(
+            '  To expose MuninnDB to the harness: add an MCP server entry to'
+        )
+        readout.push(
+            '    ~/.mastracode/mcp.json — see README → "Wiring MuninnDB into'
+        )
+        readout.push('    the Mastracode harness".')
 
         p.note(readout.join('\n'), 'Setup Complete')
 

--- a/packages/luca-mastracode/src/orchestration/upstream-patches.ts
+++ b/packages/luca-mastracode/src/orchestration/upstream-patches.ts
@@ -10,11 +10,12 @@
  *      pi-tui width assertion crashes (issue #173)
  *   2. Double-slash autocomplete prefix — strip leading `/` from custom
  *      command names to prevent `//command` rendering
- *   3. Multiline slash-command parsing — collapse trailing newlines to
- *      spaces so `/cmd <pasted multi-line text>` doesn't produce
- *      "Unknown command: /cmd". Upstream's `/^(\/\/?)(.*)$/` regex (no `s`
- *      flag) fails on multiline input, leaving the literal `/cmd` as the
- *      command name and falling through to the unknown-command branch.
+ *   3. Multiline slash-command parsing — collapse any whitespace run that
+ *      spans a newline (anywhere in the input) into a single space, so
+ *      `/cmd <pasted multi-line text>` doesn't produce "Unknown command:
+ *      /cmd". Upstream's `/^(\/\/?)(.*)$/` regex (no `s` flag) fails on
+ *      multiline input, leaving the literal `/cmd` as the command name and
+ *      falling through to the unknown-command branch.
  *   4. Model-pack-on-login override — re-apply user's active model pack
  *      after login resets to provider default
  *
@@ -237,7 +238,6 @@ function patchDoubleSlashAutocomplete(tui: unknown): void {
  * Exported for unit testing.
  */
 export function normalizeMultilineSlashCommand(input: string): string {
-    if (typeof input !== 'string') return input
     if (!input.includes('\n')) return input
     // Only act on inputs that look like a slash command after trimming
     // leading whitespace. We don't trim the actual input — upstream still

--- a/packages/luca-mastracode/src/orchestration/upstream-patches.ts
+++ b/packages/luca-mastracode/src/orchestration/upstream-patches.ts
@@ -10,7 +10,12 @@
  *      pi-tui width assertion crashes (issue #173)
  *   2. Double-slash autocomplete prefix — strip leading `/` from custom
  *      command names to prevent `//command` rendering
- *   3. Model-pack-on-login override — re-apply user's active model pack
+ *   3. Multiline slash-command parsing — collapse trailing newlines to
+ *      spaces so `/cmd <pasted multi-line text>` doesn't produce
+ *      "Unknown command: /cmd". Upstream's `/^(\/\/?)(.*)$/` regex (no `s`
+ *      flag) fails on multiline input, leaving the literal `/cmd` as the
+ *      command name and falling through to the unknown-command branch.
+ *   4. Model-pack-on-login override — re-apply user's active model pack
  *      after login resets to provider default
  *
  * Extracted from launch.ts for maintainability — no behavioral changes.
@@ -206,7 +211,82 @@ function patchDoubleSlashAutocomplete(tui: unknown): void {
 }
 
 // ---------------------------------------------------------------------------
-// Patch 3: Model-pack-on-login
+// Patch 3: Multiline slash-command parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a slash-command input so upstream's single-line regex parser
+ * can recognize the command name when the user pastes multi-line text after
+ * it (e.g. `/lu some\ncopied\ntext`).
+ *
+ * Upstream parses with `/^(\/\/?)(.*)$/` (no `s` flag), so any newline in
+ * the input causes the regex to fail; the dispatcher then treats the
+ * entire blob as the command name and reports "Unknown command: /lu".
+ *
+ * Behavior:
+ *   - Inputs that don't start with `/` (after leading whitespace) pass
+ *     through unchanged — non-slash messages are not our concern.
+ *   - Inputs without newlines pass through unchanged — preserves all
+ *     existing single-line semantics byte-for-byte.
+ *   - Multiline slash inputs have any run of whitespace containing at
+ *     least one newline collapsed to a single space. This matches what
+ *     `processSlashCommand` does anyway: it splits args on spaces and
+ *     joins them back with `args.join(' ')` for `$ARGUMENTS` substitution,
+ *     so newlines were never preserved past arg parsing.
+ *
+ * Exported for unit testing.
+ */
+export function normalizeMultilineSlashCommand(input: string): string {
+    if (typeof input !== 'string') return input
+    if (!input.includes('\n')) return input
+    // Only act on inputs that look like a slash command after trimming
+    // leading whitespace. We don't trim the actual input — upstream still
+    // calls `.trim()` itself.
+    if (!/^\s*\/\/?/.test(input)) return input
+    // Collapse any whitespace run that spans a newline into a single space.
+    // Tabs, CRs, and inner spaces in such runs are all swallowed together.
+    return input.replace(/[ \t]*(?:\r?\n[ \t]*)+/g, ' ')
+}
+
+function patchMultilineSlashCommand(tui: unknown): void {
+    const tuiAny = tui as unknown as {
+        handleSlashCommand?: (input: string) => Promise<boolean>
+    }
+    if (typeof tuiAny.handleSlashCommand !== 'function') {
+        console.warn(
+            '[luca] multiline slash-command patch skipped: ' +
+                'tui.handleSlashCommand is not a function ' +
+                '(upstream mastracode internals may have changed).'
+        )
+        return
+    }
+
+    const LUCA_MULTILINE_SLASH_PATCHED = Symbol.for(
+        'luca.slash_command.multiline_normalize'
+    )
+    const tuiRecord = tuiAny as unknown as Record<symbol, unknown>
+    if (tuiRecord[LUCA_MULTILINE_SLASH_PATCHED]) return
+
+    const original = tuiAny.handleSlashCommand.bind(tui)
+    tuiAny.handleSlashCommand = async (input: string) => {
+        let normalized = input
+        try {
+            normalized = normalizeMultilineSlashCommand(input)
+        } catch (err) {
+            // Defensive: never block command dispatch on a normalization bug.
+            console.error(
+                '[luca] multiline slash-command normalize failed:',
+                err
+            )
+            normalized = input
+        }
+        return original(normalized)
+    }
+    tuiRecord[LUCA_MULTILINE_SLASH_PATCHED] = true
+}
+
+// ---------------------------------------------------------------------------
+// Patch 4: Model-pack-on-login
 // ---------------------------------------------------------------------------
 
 function patchModelPackOnLogin({
@@ -296,5 +376,6 @@ export function applyUpstreamPatches({
 }): void {
     patchAskUserLabelTruncation(tui)
     patchDoubleSlashAutocomplete(tui)
+    patchMultilineSlashCommand(tui)
     patchModelPackOnLogin({ tui, authStorage })
 }


### PR DESCRIPTION
## Summary

Two unrelated paper-cut fixes — bundled together since they were both queued on a dirty `main`.

## 1. Multi-line input after custom slash commands (bugfix)

**Symptom:** Pasting multi-line text after a custom slash command (e.g. `/lu <pasted multi-line ticket body>`) produced `Unknown command: /lu` and the user's pasted content vanished.

**Root cause:** Upstream's slash dispatcher parses input with `/^(\/\/?)(.*)$/` — a single-line regex with no `s` flag. Any newline in the input causes the regex to fail, the dispatcher falls through to the unknown-command branch, and the entire blob is reported as the command name.

**Fix:** New Patch 3 in `orchestration/upstream-patches.ts`:

- `normalizeMultilineSlashCommand(input)` — passes through non-slash inputs and single-line inputs unchanged; for multi-line slash inputs, collapses any whitespace run containing a newline into a single space.
- `patchMultilineSlashCommand(tui)` — monkey-patches `tui.handleSlashCommand` to normalize input before dispatch.

**Why this is safe:** `processSlashCommand` already does `args.join(' ')` for `$ARGUMENTS` substitution, so newlines were never preserved past arg parsing. We're just normalizing earlier so the regex match succeeds. The patch is Symbol-keyed (re-applying is a no-op) and the normalize call is wrapped in try/catch (a normalization bug can never block command dispatch — falls back to the original input).

Wired into `applyUpstreamPatches()` between Patch 2 and Patch 4.

Changeset: patch bump for `@alecsibilia/luca-mastracode`.

## 2. Document MuninnDB ↔ Mastracode MCP wiring (docs)

**Problem:** `luca init` installs and starts MuninnDB, but Mastracode does **not** auto-configure the MCP server entry that exposes the `mcp__muninn__*` tools. Until the user creates `~/.mastracode/mcp.json` themselves, no MuninnDB tools are reachable inside the harness — and nothing in the README or `init` output tells them this.

**Fix:**

- `README.md` — new "Wiring MuninnDB into the Mastracode harness" subsection. Documents the three MCP config locations (`<project>/.mastracode/mcp.json` → `~/.mastracode/mcp.json` → `<project>/.claude/settings.local.json`) with their precedence, gives a copy-pasteable global config, points users at `/mcp` inside the TUI to verify connectivity.
- `packages/luca-framework/src/commands/init.ts` — third bullet in the setup-complete readout pointing at the new README section, so users see the wiring step at the same moment they see the `vault:init` and `run` steps.

No code-behavior change — just docs and CLI output text. No changeset (docs-only for `luca-framework`'s readout; the published surface is unchanged).

## Test Plan

- ✅ `tsc -b --noEmit` clean monorepo-wide
- ✅ `bun test` 81/81 pass in `luca-mastracode` (existing tests still green; no new tests added — the regex-match path is exercised manually via the TUI)
- ✅ Manual verification of slash fix: paste a multi-line block after `/lu` in the TUI and confirm command dispatches instead of erroring
- ✅ README MCP example matches the actual `mastracode` config-resolution order

## Commits

1. `fix(luca-mastracode): handle multi-line input after custom slash commands` — slash fix + changeset
2. `docs: explain how to wire MuninnDB into the Mastracode harness via MCP` — README + init readout
