### PR TITLE
feat(mastracode): project preferences foundation (tool + skill + sentinel + tests)

### DIFF
--- a/.changeset/phase-a-project-preferences-foundation.md
+++ b/.changeset/phase-a-project-preferences-foundation.md
@@ -1,0 +1,47 @@
+---
+"@alecsibilia/luca-mastracode": minor
+"@alecsibilia/luca-framework": patch
+---
+
+Project preferences foundation: consult conventions instead of hardcoded defaults
+
+## What's new
+
+- **projectPreferences Mastra tool** — actions: `consult`, `consult-section`, `seed`, `update` for reading and seeding project conventions (branching strategy, commit convention, PR title format, release tool, issue tracker kind) to local cache.
+- **luca-init skill** — probing wizard that runs on first triage when preferences not yet seeded. Detects branching/commit/release conventions from git history, asks user to confirm, seeds to local cache and MuninnDB.
+- **ProjectPreferencesSchema (Zod)** — structured type with sections: branching (types, template, default, guarded branches), commits (convention, scopes), pr (titleFormat, baseBranch), release (tool, versionBump), tracker (kind, issuePrefix). All fields optional with sensible defaults.
+- **Triage sentinel (Step 1.6)** — new early step in triage mode calls `projectPreferences(action: 'consult', fallback: false)`. If prefs missing and `preferencesSeeded !== true`, invokes `/luca-init` skill. Otherwise proceeds to complexity classification.
+- **Vault helper** — moved `sanitizeVaultName()` to shared mastracode package, both packages import from there. `resolveProjectVault()` reads vault name from config with fallback.
+
+## Key design decisions
+
+1. **Loop-safe consult**: after successful seed, `preferencesSeeded: true` flag ensures that if the on-disk preferences file is removed or unparseable, consult returns `DEFAULT_PREFERENCES` instead of `null`, preventing infinite re-init loops.
+2. **Tool vs skill division**: Tool manages local cache and `preferencesSeeded` state flag (TS layer). Skill handles all MuninnDB I/O and user interaction (agent layer), since tools cannot invoke MCP.
+3. **Backward compat**: `DEFAULT_PREFERENCES.branching.types` matches existing `BRANCH_TYPES` array from ensure-feature-branch.ts; `consult(fallback: true)` returns these defaults when no prefs file exists, so existing repos continue to work.
+4. **Security**: all free-form preference fields (branching template, commit scopes, PR title format, etc.) that flow into agent instructions are validated against allowlist regex (alphanumeric + whitespace + structural punctuation, max 64 chars). Prevents prompt injection from malicious git history in cloned repos.
+
+## Files changed
+
+New:
+- `packages/luca-mastracode/src/state/vault.ts` — vault resolution helpers
+- `packages/luca-mastracode/src/state/project-preferences.ts` — schema, defaults, load/write
+- `packages/luca-mastracode/src/tools/project-preferences.ts` — consult/seed/update actions
+- `packages/luca-mastracode/skills/luca-init/SKILL.md` — detection and seeding skill
+- `packages/luca-mastracode/src/__tests__/project-preferences.test.ts` — comprehensive test coverage including sentinel-loop safety
+
+Modified:
+- `packages/luca-framework/src/utils/vault-setup.ts` — re-export sanitizeVaultName from mastracode
+- `packages/luca-mastracode/src/tools/tool-manifest.ts` — register projectPreferences with mode-scoped permissions
+- `packages/luca-mastracode/src/tools/index.ts` — export projectPreferences tool
+- `packages/luca-mastracode/src/instructions/triage.md` — inject Step 1.6 sentinel
+- `packages/luca-mastracode/src/state/luca-store.ts` — add preferencesSeeded field to LucaWorkflowState
+- `packages/luca-framework/src/commands/init.ts` — document /luca-init skill in help text
+- `README.md` — add /luca-init reference
+
+## Review notes
+
+Phase A passed 2 code review iterations:
+- Iteration 1: 5 MUST-FIX findings (prompt-injection hardening, type safety, runtime scope guard). All resolved in commit 5443aad92.
+- Iteration 2: clean gate, all MUST-FIX verified resolved, no regressions.
+
+Tests: 133/133 pass, tsc clean, rule gate clean. Phase B (branching policy refactor) and Phase C (PR/release/commit conventions) build on this foundation.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Luca integrates with [MuninnDB](https://github.com/asibilia/muninn) for persiste
 - **Learnings** — patterns, pitfalls, and insights from completed milestones
 - **Decisions** — architectural decisions with rationale and alternatives considered
 - **Release conventions** — versioning, PR format, publish procedures
+- **Project preferences** — branching, commits, PR titles, release tooling, tracker (seeded by `/luca-init` inside `luca run`)
 - **Entity graph** — named entities and relationships across the codebase
 
 #### Wiring MuninnDB into the Mastracode harness

--- a/packages/luca-framework/src/commands/init.ts
+++ b/packages/luca-framework/src/commands/init.ts
@@ -201,6 +201,15 @@ export const initCommand = defineCommand({
         )
         readout.push('  To launch the harness:     luca run')
         readout.push(
+            '  To seed project conventions:        invoke /luca-init inside `luca run`'
+        )
+        readout.push(
+            '    (probes branching/commits/PR/release/tracker conventions and'
+        )
+        readout.push(
+            '     stores them in MuninnDB; downstream pipeline modes consult them)'
+        )
+        readout.push(
             '  To expose MuninnDB to the harness: add an MCP server entry to'
         )
         readout.push(

--- a/packages/luca-framework/src/utils/vault-setup.ts
+++ b/packages/luca-framework/src/utils/vault-setup.ts
@@ -28,6 +28,7 @@
  */
 import { chmodSync, existsSync } from 'node:fs'
 
+import { sanitizeVaultName } from '@alecsibilia/luca-mastracode'
 import * as p from '@clack/prompts'
 import { join, basename } from 'pathe'
 import { z } from 'zod'
@@ -35,6 +36,9 @@ import { z } from 'zod'
 import { checkMuninndbService } from './muninndb-health'
 import { resolveMuninndbPort } from './muninndb-schemas'
 import { sanitizeJsonParse } from './sanitize'
+
+// Re-export for backward compatibility with framework consumers.
+export { sanitizeVaultName }
 
 import type { ProjectContext } from '../types'
 
@@ -88,29 +92,6 @@ export function suggestVaultName(
 ): string {
     const raw = context.projectName ?? basename(cwd)
     return sanitizeVaultName(raw)
-}
-
-/**
- * Sanitize a string into a valid vault name (lowercase kebab-case).
- *
- * Converts to lowercase, replaces non-alphanumeric characters with dashes,
- * collapses consecutive dashes, and trims leading/trailing dashes.
- *
- * @param name - Raw input string to sanitize.
- * @returns A cleaned vault name.
- *
- * @example
- * ```typescript
- * sanitizeVaultName("My Cool App!")  // "my-cool-app"
- * sanitizeVaultName("@scope/pkg")    // "scope-pkg"
- * ```
- */
-export function sanitizeVaultName(name: string): string {
-    return name
-        .toLowerCase()
-        .replace(/[^a-z0-9-]/g, '-')
-        .replace(/-+/g, '-')
-        .replace(/^-|-$/g, '')
 }
 
 /**

--- a/packages/luca-mastracode/skills/luca-init/SKILL.md
+++ b/packages/luca-mastracode/skills/luca-init/SKILL.md
@@ -66,14 +66,14 @@ ask_user(
   options: [
     { label: "Approve", description: "Seed these preferences as-is." },
     { label: "Edit section", description: "Adjust one or more sections before seeding." },
-    { label: "Abort", description: "Don't seed; clear preferencesSeeded if previously set." }
+    { label: "Abort", description: "Don't seed. Triage proceeds with DEFAULT_PREFERENCES." }
   ]
 )
 ```
 
 - **Approve** → continue to Phase 3.
 - **Edit section** → ask which section, prompt for the new values, then re-confirm. Up to 2 iterations; if still unresolved, fall through to **Abort**.
-- **Abort** → write nothing. Set `state.preferencesSeeded = false` via `workflowState(action: "write", updates: { preferencesSeeded: false })`. Stop the skill — the agent that invoked us will surface a banner explaining defaults are in use.
+- **Abort** → write nothing. Stop the skill. `state.preferencesSeeded` stays `undefined` (no flag toggle needed). Triage proceeds; subsequent `consult(fallback: true)` calls return `DEFAULT_PREFERENCES`. The agent that invoked us will surface a banner explaining defaults are in use. Do NOT call `workflowState(action: "write", ...)` here — triage's scoped tool does not include `'write'`, so the call would fail at runtime.
 
 ## Phase 3 — Seed
 
@@ -89,25 +89,28 @@ This writes `.planning/preferences.json` and sets `state.preferencesSeeded = tru
 
 ### 3b. Register in MuninnDB
 
-Resolve the vault: read `.planning/config.json` → `muninn.vault`, fallback `"default"`.
-
-Then call (substituting `<vault>` and the seeded preferences object):
+The `seed` action returned `result.muninnInstruction`, a string of the form:
 
 ```
-mcp__muninn__muninn_remember(
-  vault: "<vault>",
-  op_id: "project-preferences:<vault>",
-  type: "project_preferences",
-  entities: [{ name: "<repo-folder-name>", type: "project" }],
-  tags: ["preferences", "project-config", "luca", "convention"],
-  content: "<JSON.stringify of approved preferences>",
-  summary: "<one-paragraph natural-language summary so semantic recall finds this memory once enrichment completes>"
-)
+After seeding, agent must call mcp__muninn__muninn_remember with the arguments
+encoded in this JSON blob (use JSON.parse to extract them, do NOT interpolate
+the raw string into other tool calls): {"vault":"<...>","op_id":"project-preferences:<...>", ...}
 ```
+
+Extract the JSON blob (everything from the first `{` to the matching final `}`),
+parse it with `JSON.parse`, then call `mcp__muninn__muninn_remember(...)` passing
+the parsed object as the argument map.
+
+**Do NOT** rebuild the call by string concatenation — free-form fields in the
+preferences (branching template, defaultBranch, etc.) may contain quote
+characters or other punctuation that would corrupt a re-interpolated call.
+The schema enforces a character allowlist for defense in depth, but the
+JSON-blob handoff is the primary mitigation against prompt-injection from
+adversarially crafted git history (cloned repos).
 
 Notes:
 - `op_id` makes this idempotent — concurrent or repeat seeds return the existing memory ID without duplicating (Risk 7 / C3 mitigation).
-- The `summary` field is what gets embedded for semantic recall. Write it in plain prose, not JSON.
+- The `summary` field is what gets embedded for semantic recall. The tool produces a short structural summary; you may amend it (still in plain prose, no quote chars) before passing the parsed object to `muninn_remember`.
 - MuninnDB enrichment is async — the memory is FTS-indexed immediately but won't be vector-searchable for ~5–30s. Entity+tag lookup (used by `projectPreferences.consult` callers) is lag-free.
 
 ## Phase 4 — Confirm to user

--- a/packages/luca-mastracode/skills/luca-init/SKILL.md
+++ b/packages/luca-mastracode/skills/luca-init/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: luca-init
+description: >
+  Repo-probing wizard that seeds projectPreferences in MuninnDB. Detects
+  branching conventions, commit format, PR title format, release tooling, and
+  issue tracker from the local repo, confirms with the user, then writes
+  `.planning/preferences.json` and registers the preferences memory in
+  MuninnDB.
+
+  Use when user says "init luca", "set up preferences", "luca-init",
+  "configure conventions", or invokes `/luca-init`. Auto-invoked by triage
+  Step 1.6 when `projectPreferences(action: "consult", fallback: false)`
+  returns `preferences: null` AND `state.preferencesSeeded !== true`.
+---
+
+# luca-init Skill
+
+Seed repo-level project conventions so the Luca pipeline branches, commits, and ships PRs the way this team already does.
+
+## When to run
+
+- Triage sentinel detects no preferences (auto-invocation).
+- User explicitly invokes `/luca-init` or asks to reset preferences.
+- After `luca init` (CLI) succeeds and the user wants to seed conventions next.
+
+## Phase 1 — Probe
+
+Read existing repo signal **before** asking any questions. Per grill-me principle: explore the codebase first, ask only for what cannot be inferred.
+
+Heuristics (run each, fail soft if a signal is unavailable):
+
+1. **Branching**
+   - `git branch -r --no-color | head -50` → detect prefix patterns (`feat/`, `feature/`, `fix/`, `ENG-*`, `PT-*`, etc.).
+   - `git symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null` → default branch (fallback `main`).
+2. **Commits**
+   - `git log --oneline -50` → check for conventional-commit prefixes (`feat:`, `fix:`, `chore:` etc.).
+   - Recurring scopes (e.g. `feat(api):`) → suggested `commits.scopes`.
+3. **PR title format**
+   - `gh pr list --state merged --limit 20 --json title -q '.[].title' 2>/dev/null` (skip on auth failure).
+   - Pattern-match against `{type}({scope}): {description}`.
+4. **Release tooling**
+   - `.changeset/config.json` exists → `release.tool = "changesets"`.
+   - `.releaserc*` / `release.config.*` → `"semantic-release"`.
+   - Otherwise `"none"`.
+5. **Tracker**
+   - Issue refs in commits (`#123`, `ENG-456`, `PT-789`) → infer `github` / `linear` / `jira`.
+   - `gh repo view --json owner,name 2>/dev/null` → confirms GitHub.
+
+Build a candidate `ProjectPreferences` object from the probe results, falling back to `DEFAULT_PREFERENCES` for any unknown field.
+
+## Phase 2 — Confirm
+
+Read `state.oversight` from `workflowState(action: "read")`.
+
+### Headless / CI path
+
+If `state.oversight === "full-auto"`, **skip `ask_user`**. Proceed directly to Phase 3 with the probed candidate. Log a single line summarising the auto-seeded values.
+
+### Interactive path
+
+Otherwise show the detected values and ask exactly once:
+
+```
+ask_user(
+  question: "Detected preferences:\n<rendered candidate>\n\nApprove and seed?",
+  options: [
+    { label: "Approve", description: "Seed these preferences as-is." },
+    { label: "Edit section", description: "Adjust one or more sections before seeding." },
+    { label: "Abort", description: "Don't seed; clear preferencesSeeded if previously set." }
+  ]
+)
+```
+
+- **Approve** → continue to Phase 3.
+- **Edit section** → ask which section, prompt for the new values, then re-confirm. Up to 2 iterations; if still unresolved, fall through to **Abort**.
+- **Abort** → write nothing. Set `state.preferencesSeeded = false` via `workflowState(action: "write", updates: { preferencesSeeded: false })`. Stop the skill — the agent that invoked us will surface a banner explaining defaults are in use.
+
+## Phase 3 — Seed
+
+Two writes, in order:
+
+### 3a. Local cache + state flag
+
+```
+projectPreferences(action: "seed", payload: <approved candidate object>)
+```
+
+This writes `.planning/preferences.json` and sets `state.preferencesSeeded = true`. The tool returns a `muninnInstruction` string that contains the canonical MuninnDB call you must execute next.
+
+### 3b. Register in MuninnDB
+
+Resolve the vault: read `.planning/config.json` → `muninn.vault`, fallback `"default"`.
+
+Then call (substituting `<vault>` and the seeded preferences object):
+
+```
+mcp__muninn__muninn_remember(
+  vault: "<vault>",
+  op_id: "project-preferences:<vault>",
+  type: "project_preferences",
+  entities: [{ name: "<repo-folder-name>", type: "project" }],
+  tags: ["preferences", "project-config", "luca", "convention"],
+  content: "<JSON.stringify of approved preferences>",
+  summary: "<one-paragraph natural-language summary so semantic recall finds this memory once enrichment completes>"
+)
+```
+
+Notes:
+- `op_id` makes this idempotent — concurrent or repeat seeds return the existing memory ID without duplicating (Risk 7 / C3 mitigation).
+- The `summary` field is what gets embedded for semantic recall. Write it in plain prose, not JSON.
+- MuninnDB enrichment is async — the memory is FTS-indexed immediately but won't be vector-searchable for ~5–30s. Entity+tag lookup (used by `projectPreferences.consult` callers) is lag-free.
+
+## Phase 4 — Confirm to user
+
+Print a one-line confirmation:
+
+```
+✓ Project preferences seeded — branching=<types[]>, commits=<convention>, release=<tool>, tracker=<kind>.
+  Edit later with `/luca-init` or `projectPreferences(action: "update", payload: ...)`.
+```
+
+Return control to the calling agent (triage in the sentinel case).
+
+## Failure modes
+
+| Signal | Action |
+|---|---|
+| `git` unavailable | Use defaults for branching/commits sections; warn user. |
+| `gh` not authenticated | Skip PR-title probe; use default `{type}({scope}): {description}`. |
+| MuninnDB unreachable in Phase 3b | Local cache still wrote successfully; warn user that semantic recall will be unavailable until MuninnDB is up. Set `state.preferencesSeeded = true` regardless — the local cache is authoritative. |
+| Zod parse failure on payload | Skill aborts, surfaces the parse error verbatim. Caller may retry with corrected values. |

--- a/packages/luca-mastracode/src/__tests__/project-preferences.test.ts
+++ b/packages/luca-mastracode/src/__tests__/project-preferences.test.ts
@@ -137,8 +137,14 @@ describe('projectPreferences:seed', () => {
         expect(result.muninnInstruction).toContain(
             'mcp__muninn__muninn_remember'
         )
+        // C3: op_id baked into JSON blob (idempotency key for muninn_remember).
         expect(result.muninnInstruction).toContain(
-            'op_id: "project-preferences:'
+            '"op_id":"project-preferences:'
+        )
+        // The instruction must not interpolate raw free-form preference values
+        // outside the JSON blob — verify the directive line is present.
+        expect(result.muninnInstruction).toContain(
+            'do NOT interpolate the raw string'
         )
     })
 
@@ -201,5 +207,23 @@ describe('projectPreferences:update', () => {
         const result = await call({ action: 'update' })
         expect(result.success).toBe(false)
         expect(result.message).toContain('payload is required')
+    })
+
+    test('schemaVersion in payload is ignored (sealed to schema literal)', async () => {
+        // REVIEW-1.md MUST-FIX-4: caller-supplied schemaVersion must NOT
+        // overwrite the locked z.literal(1). Migrations belong in a future
+        // dedicated migrate() helper, not in mergePreferences.
+        mockLoad.mockReturnValue(DEFAULT_PREFERENCES)
+        mockReadLucaState.mockReturnValue({ preferencesSeeded: true } as any)
+        const result = await call({
+            action: 'update',
+            payload: {
+                schemaVersion: 2,
+                commits: { convention: 'none' },
+            },
+        })
+        expect(result.success).toBe(true)
+        expect(result.preferences.schemaVersion).toBe(1)
+        expect(result.preferences.commits.convention).toBe('none')
     })
 })

--- a/packages/luca-mastracode/src/__tests__/project-preferences.test.ts
+++ b/packages/luca-mastracode/src/__tests__/project-preferences.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for projectPreferences tool.
+ *
+ * Covers:
+ * - consult / consult-section happy path
+ * - C1 loop-safe: preferencesSeeded === true + missing file → defaults (not null)
+ * - fallback:true returns DEFAULT_PREFERENCES when not seeded
+ * - seed validates payload through Zod and writes both file + state flag
+ * - update merges section-by-section without losing existing fields
+ * - update preserves preferencesSeeded (does not toggle off)
+ */
+import { describe, test, expect, beforeEach, spyOn } from 'bun:test'
+
+import * as lucaStore from '../state/luca-store.js'
+import * as prefsState from '../state/project-preferences.js'
+import { DEFAULT_PREFERENCES } from '../state/project-preferences.js'
+import { projectPreferencesTool } from '../tools/project-preferences.js'
+
+const mockReadLucaState = spyOn(lucaStore, 'readLucaState')
+const mockWriteLucaState = spyOn(lucaStore, 'writeLucaState')
+const mockLoad = spyOn(prefsState, 'loadProjectPreferences')
+const mockWrite = spyOn(prefsState, 'writeProjectPreferences')
+
+beforeEach(() => {
+    mockReadLucaState.mockReset().mockReturnValue({} as any)
+    mockWriteLucaState
+        .mockReset()
+        .mockImplementation((updates: any) => updates)
+    mockLoad.mockReset()
+    mockWrite.mockReset().mockImplementation(() => undefined)
+})
+
+async function call(input: Record<string, unknown>): Promise<any> {
+    return projectPreferencesTool.execute!(input as any, {} as any)
+}
+
+describe('projectPreferences:consult', () => {
+    test('returns preferences when file present', async () => {
+        mockLoad.mockReturnValue(DEFAULT_PREFERENCES)
+        mockReadLucaState.mockReturnValue({ preferencesSeeded: true } as any)
+        const result = await call({ action: 'consult' })
+        expect(result.success).toBe(true)
+        expect(result.preferences).toEqual(DEFAULT_PREFERENCES)
+    })
+
+    test('back-fills preferencesSeeded flag when file present but flag missing', async () => {
+        mockLoad.mockReturnValue(DEFAULT_PREFERENCES)
+        mockReadLucaState.mockReturnValue({} as any)
+        const result = await call({ action: 'consult' })
+        expect(result.success).toBe(true)
+        expect(mockWriteLucaState).toHaveBeenCalledWith({
+            preferencesSeeded: true,
+        })
+    })
+
+    test('C1 LOOP-SAFE: seeded flag true + missing file → returns defaults, not null', async () => {
+        mockLoad.mockReturnValue(null)
+        mockReadLucaState.mockReturnValue({ preferencesSeeded: true } as any)
+        const result = await call({ action: 'consult' })
+        expect(result.success).toBe(true)
+        expect(result.preferences).toEqual(DEFAULT_PREFERENCES)
+    })
+
+    test('not seeded + no file + fallback:false → preferences:null (sentinel signal)', async () => {
+        mockLoad.mockReturnValue(null)
+        mockReadLucaState.mockReturnValue({} as any)
+        const result = await call({ action: 'consult', fallback: false })
+        expect(result.success).toBe(true)
+        expect(result.preferences).toBeNull()
+    })
+
+    test('not seeded + no file + fallback:true → DEFAULT_PREFERENCES (C2)', async () => {
+        mockLoad.mockReturnValue(null)
+        mockReadLucaState.mockReturnValue({} as any)
+        const result = await call({ action: 'consult', fallback: true })
+        expect(result.success).toBe(true)
+        expect(result.preferences).toEqual(DEFAULT_PREFERENCES)
+    })
+})
+
+describe('projectPreferences:consult-section', () => {
+    test('returns the requested section when file present', async () => {
+        mockLoad.mockReturnValue(DEFAULT_PREFERENCES)
+        mockReadLucaState.mockReturnValue({ preferencesSeeded: true } as any)
+        const result = await call({
+            action: 'consult-section',
+            section: 'branching',
+        })
+        expect(result.success).toBe(true)
+        expect(result.section).toEqual(DEFAULT_PREFERENCES.branching)
+    })
+
+    test('rejects unknown section name', async () => {
+        const result = await call({
+            action: 'consult-section',
+            section: 'nope',
+        })
+        expect(result.success).toBe(false)
+        expect(result.message).toContain('Unknown section')
+    })
+
+    test('C1 LOOP-SAFE: seeded + missing file → returns default section', async () => {
+        mockLoad.mockReturnValue(null)
+        mockReadLucaState.mockReturnValue({ preferencesSeeded: true } as any)
+        const result = await call({
+            action: 'consult-section',
+            section: 'commits',
+        })
+        expect(result.success).toBe(true)
+        expect(result.section).toEqual(DEFAULT_PREFERENCES.commits)
+    })
+
+    test('fallback:true returns default section when not seeded', async () => {
+        mockLoad.mockReturnValue(null)
+        mockReadLucaState.mockReturnValue({} as any)
+        const result = await call({
+            action: 'consult-section',
+            section: 'pr',
+            fallback: true,
+        })
+        expect(result.success).toBe(true)
+        expect(result.section).toEqual(DEFAULT_PREFERENCES.pr)
+    })
+})
+
+describe('projectPreferences:seed', () => {
+    test('writes preferences and sets preferencesSeeded flag', async () => {
+        const result = await call({
+            action: 'seed',
+            payload: {},
+        })
+        expect(result.success).toBe(true)
+        expect(mockWrite).toHaveBeenCalledTimes(1)
+        expect(mockWriteLucaState).toHaveBeenCalledWith({
+            preferencesSeeded: true,
+        })
+        expect(result.muninnInstruction).toContain(
+            'mcp__muninn__muninn_remember'
+        )
+        expect(result.muninnInstruction).toContain(
+            'op_id: "project-preferences:'
+        )
+    })
+
+    test('rejects payload missing entirely', async () => {
+        const result = await call({ action: 'seed' })
+        expect(result.success).toBe(false)
+        expect(result.message).toContain('payload is required')
+    })
+
+    test('rejects malformed payload via Zod', async () => {
+        const result = await call({
+            action: 'seed',
+            payload: { release: { tool: 'NOT_A_VALID_TOOL' } },
+        })
+        expect(result.success).toBe(false)
+        expect(result.message).toContain('Invalid preferences payload')
+    })
+})
+
+describe('projectPreferences:update', () => {
+    test('merges section without losing existing fields', async () => {
+        mockLoad.mockReturnValue({
+            ...DEFAULT_PREFERENCES,
+            branching: {
+                ...DEFAULT_PREFERENCES.branching,
+                defaultBranch: 'develop',
+            },
+        })
+        mockReadLucaState.mockReturnValue({ preferencesSeeded: true } as any)
+        const result = await call({
+            action: 'update',
+            payload: { branching: { template: '{type}/{slug}' } },
+        })
+        expect(result.success).toBe(true)
+        expect(result.preferences.branching.defaultBranch).toBe('develop')
+        expect(result.preferences.branching.template).toBe('{type}/{slug}')
+    })
+
+    test('does not toggle off preferencesSeeded', async () => {
+        mockLoad.mockReturnValue(DEFAULT_PREFERENCES)
+        mockReadLucaState.mockReturnValue({ preferencesSeeded: true } as any)
+        await call({
+            action: 'update',
+            payload: { commits: { convention: 'none' } },
+        })
+        // update must NOT call writeLucaState({preferencesSeeded:false}).
+        const wroteFalse = mockWriteLucaState.mock.calls.some((c: any) =>
+            JSON.stringify(c).includes('"preferencesSeeded":false')
+        )
+        expect(wroteFalse).toBe(false)
+    })
+
+    test('rejects array payload', async () => {
+        const result = await call({ action: 'update', payload: [] })
+        expect(result.success).toBe(false)
+        expect(result.message).toContain('object')
+    })
+
+    test('rejects missing payload', async () => {
+        const result = await call({ action: 'update' })
+        expect(result.success).toBe(false)
+        expect(result.message).toContain('payload is required')
+    })
+})

--- a/packages/luca-mastracode/src/index.ts
+++ b/packages/luca-mastracode/src/index.ts
@@ -29,6 +29,16 @@ export {
     resolvePackModelForMode,
 } from './integration/mastracode-config.js'
 export { loadAlwaysApplyRules, parseRuleFrontmatter } from './rules-loader.js'
+export { sanitizeVaultName, resolveProjectVault } from './state/vault.js'
+export {
+    ProjectPreferencesSchema,
+    SectionName,
+    DEFAULT_PREFERENCES,
+    PREFERENCES_PATH,
+    loadProjectPreferences,
+    writeProjectPreferences,
+} from './state/project-preferences.js'
+export type { ProjectPreferences } from './state/project-preferences.js'
 export {
     ANSI_ESCAPE_RE,
     clipToVisibleWidth,

--- a/packages/luca-mastracode/src/instructions/triage.md
+++ b/packages/luca-mastracode/src/instructions/triage.md
@@ -77,15 +77,15 @@ If results found, factor prior complexity levels and learnings into classificati
 Check whether this repo has seeded project preferences (branching, commits, PR, release, tracker conventions):
 
 ```
-projectPreferences(action: "consult", fallback: false)
+result = projectPreferences(action: "consult", fallback: false)
 ```
 
-Then read `state.preferencesSeeded` from `workflowState(action: "read")`.
+Single-call decision tree:
 
-- If `result.preferences === null` AND `state.preferencesSeeded !== true` → invoke the `/luca-init` skill to seed preferences before continuing. After luca-init completes, proceed to Step 2.
-- Otherwise (preferences present, or `preferencesSeeded === true`) → proceed to Step 2.
+- If `result.preferences === null` → invoke the `/luca-init` skill to seed preferences before continuing. After luca-init completes (Approve, Edit-section, or Abort), proceed to Step 2.
+- Otherwise → proceed to Step 2.
 
-Rationale: only triage runs the sentinel. Downstream phases call `consult(fallback: true)` and never trigger init — this prevents wizard prompts from interrupting headless execution. Risk-coverage: C1 (preferencesSeeded flag prevents seed→consult→null infinite loop), C2 (`fallback: false` here is the only place null can surface).
+Rationale: only triage runs the sentinel. The `consult` action already encodes C1 internally — when `preferencesSeeded === true` and the file is missing it returns `DEFAULT_PREFERENCES` (not `null`), so a single tool call distinguishes "needs init" (`null`) from every other state. Downstream phases call `consult(fallback: true)` and never trigger init — this prevents wizard prompts from interrupting headless execution.
 
 ## Step 2: Classify Complexity
 

--- a/packages/luca-mastracode/src/instructions/triage.md
+++ b/packages/luca-mastracode/src/instructions/triage.md
@@ -72,6 +72,21 @@ mcp__muninn__muninn_recall(vault: "<repo_vault>", context: "<parsed intent summa
 
 If results found, factor prior complexity levels and learnings into classification. If MuninnDB unavailable, skip — never delay triage.
 
+## Step 1.6: Project Preferences Sentinel
+
+Check whether this repo has seeded project preferences (branching, commits, PR, release, tracker conventions):
+
+```
+projectPreferences(action: "consult", fallback: false)
+```
+
+Then read `state.preferencesSeeded` from `workflowState(action: "read")`.
+
+- If `result.preferences === null` AND `state.preferencesSeeded !== true` → invoke the `/luca-init` skill to seed preferences before continuing. After luca-init completes, proceed to Step 2.
+- Otherwise (preferences present, or `preferencesSeeded === true`) → proceed to Step 2.
+
+Rationale: only triage runs the sentinel. Downstream phases call `consult(fallback: true)` and never trigger init — this prevents wizard prompts from interrupting headless execution. Risk-coverage: C1 (preferencesSeeded flag prevents seed→consult→null infinite loop), C2 (`fallback: false` here is the only place null can surface).
+
 ## Step 2: Classify Complexity
 
 Use the `classifyComplexity` tool with the parsed intent:

--- a/packages/luca-mastracode/src/state/luca-store.ts
+++ b/packages/luca-mastracode/src/state/luca-store.ts
@@ -109,6 +109,16 @@ export interface LucaWorkflowState {
     // --- Budget enforcement (advisory) ---
     budgetExceeded?: boolean
 
+    // --- Project preferences (set by projectPreferences tool / luca-init skill) ---
+    /**
+     * Loop-safety flag for the triage Step 1.6 sentinel. Set to `true` once
+     * preferences have been seeded (via `projectPreferences(action: "seed")`)
+     * or back-filled by `consult` when the file is found. Sentinel re-checks
+     * this flag before invoking /luca-init to prevent seed → consult → null
+     * infinite loops. See C1 in PLAN.md and project-preferences.test.ts.
+     */
+    preferencesSeeded?: boolean
+
     // Allow arbitrary extension
     [key: string]: unknown
 }

--- a/packages/luca-mastracode/src/state/project-preferences.ts
+++ b/packages/luca-mastracode/src/state/project-preferences.ts
@@ -1,9 +1,17 @@
 /**
  * Project preferences schema.
  *
- * SECURITY NOTE: Content of this file is trusted (repo-local).
- * Written verbatim into MuninnDB summaries by the luca-init skill.
- * Do not include user-supplied untrusted strings without sanitization.
+ * SECURITY NOTE: Content of this file is repo-local but is DERIVED FROM GIT
+ * OUTPUT during luca-init probe (branch names, commit messages, PR titles).
+ * In repos cloned from external sources, those strings are UNTRUSTED.
+ *
+ * The schema enforces a character allowlist on every free-form field that
+ * flows into the `muninnInstruction` string consumed by the LLM agent (see
+ * tools/project-preferences.ts buildMuninnInstruction). Do not relax these
+ * regexes / max-lengths without a security review — they are the blast-radius
+ * cap on prompt-injection from a malicious git history.
+ *
+ * See REVIEW-1.md MUST-FIX-2/3 for the original finding.
  */
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -16,28 +24,37 @@ import { planningRoot } from '../util/phase-paths.js'
 export const SectionName = z.enum(['branching', 'commits', 'pr', 'release', 'tracker'])
 export type SectionName = z.infer<typeof SectionName>
 
+/**
+ * Character allowlist for free-form preference strings that flow into the
+ * `muninnInstruction` text consumed by the LLM agent. Permits letters,
+ * digits, whitespace, and the structural punctuation needed for branch /
+ * commit / PR title templates. Excludes quote chars, backticks, control
+ * chars, and shell metacharacters.
+ */
+const SAFE_FREEFORM = z.string().max(64).regex(/^[\w\s{}/,.():\-]*$/)
+
 const BranchingSection = z
     .object({
-        types: z
-            .array(z.string())
-            .default(['feat', 'fix', 'refactor', 'chore', 'docs', 'test', 'style']),
-        template: z.string().default('{type}/{issue}-{slug}'),
-        defaultBranch: z.string().default('main'),
-        guardedBranches: z.array(z.string()).default(['main']),
+        types: z.array(SAFE_FREEFORM).default([
+            'feat', 'fix', 'refactor', 'chore', 'docs', 'test', 'style',
+        ]),
+        template: SAFE_FREEFORM.default('{type}/{issue}-{slug}'),
+        defaultBranch: SAFE_FREEFORM.default('main'),
+        guardedBranches: z.array(SAFE_FREEFORM).default(['main']),
     })
     .prefault({})
 
 const CommitsSection = z
     .object({
         convention: z.enum(['conventional', 'none']).default('conventional'),
-        scopes: z.array(z.string()).default([]),
+        scopes: z.array(SAFE_FREEFORM).default([]),
     })
     .prefault({})
 
 const PrSection = z
     .object({
-        titleFormat: z.string().default('{type}({scope}): {description}'),
-        baseBranch: z.string().default('main'),
+        titleFormat: SAFE_FREEFORM.default('{type}({scope}): {description}'),
+        baseBranch: SAFE_FREEFORM.default('main'),
     })
     .prefault({})
 
@@ -53,7 +70,7 @@ const ReleaseSection = z
 const TrackerSection = z
     .object({
         kind: z.enum(['github', 'linear', 'jira', 'none']).default('github'),
-        issuePrefix: z.string().default(''),
+        issuePrefix: SAFE_FREEFORM.default(''),
     })
     .prefault({})
 

--- a/packages/luca-mastracode/src/state/project-preferences.ts
+++ b/packages/luca-mastracode/src/state/project-preferences.ts
@@ -1,0 +1,97 @@
+/**
+ * Project preferences schema.
+ *
+ * SECURITY NOTE: Content of this file is trusted (repo-local).
+ * Written verbatim into MuninnDB summaries by the luca-init skill.
+ * Do not include user-supplied untrusted strings without sanitization.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { z } from 'zod'
+
+import { atomicWriteSync } from '../util/atomic-write.js'
+import { planningRoot } from '../util/phase-paths.js'
+
+export const SectionName = z.enum(['branching', 'commits', 'pr', 'release', 'tracker'])
+export type SectionName = z.infer<typeof SectionName>
+
+const BranchingSection = z
+    .object({
+        types: z
+            .array(z.string())
+            .default(['feat', 'fix', 'refactor', 'chore', 'docs', 'test', 'style']),
+        template: z.string().default('{type}/{issue}-{slug}'),
+        defaultBranch: z.string().default('main'),
+        guardedBranches: z.array(z.string()).default(['main']),
+    })
+    .prefault({})
+
+const CommitsSection = z
+    .object({
+        convention: z.enum(['conventional', 'none']).default('conventional'),
+        scopes: z.array(z.string()).default([]),
+    })
+    .prefault({})
+
+const PrSection = z
+    .object({
+        titleFormat: z.string().default('{type}({scope}): {description}'),
+        baseBranch: z.string().default('main'),
+    })
+    .prefault({})
+
+const ReleaseSection = z
+    .object({
+        tool: z.enum(['changesets', 'none', 'semantic-release']).default('none'),
+        versionBump: z
+            .record(z.string(), z.enum(['major', 'minor', 'patch']))
+            .default({ feat: 'minor', fix: 'patch', chore: 'patch', refactor: 'patch' }),
+    })
+    .prefault({})
+
+const TrackerSection = z
+    .object({
+        kind: z.enum(['github', 'linear', 'jira', 'none']).default('github'),
+        issuePrefix: z.string().default(''),
+    })
+    .prefault({})
+
+export const ProjectPreferencesSchema = z
+    .object({
+        schemaVersion: z.literal(1).default(1),
+        branching: BranchingSection,
+        commits: CommitsSection,
+        pr: PrSection,
+        release: ReleaseSection,
+        tracker: TrackerSection,
+    })
+    .prefault({})
+
+export type ProjectPreferences = z.infer<typeof ProjectPreferencesSchema>
+
+/** Hardcoded defaults matching today's behavior. Returned by consult() when fallback:true and no prefs file. */
+export const DEFAULT_PREFERENCES: ProjectPreferences = ProjectPreferencesSchema.parse({})
+
+/** `.planning/preferences.json` — repo-local cache of project preferences. */
+export function PREFERENCES_PATH(): string {
+    return join(planningRoot(), 'preferences.json')
+}
+
+/** Load preferences from .planning/preferences.json. Returns null if file missing/invalid. */
+export function loadProjectPreferences(): ProjectPreferences | null {
+    const p = PREFERENCES_PATH()
+    if (!existsSync(p)) return null
+    try {
+        const raw = JSON.parse(readFileSync(p, 'utf-8'))
+        return ProjectPreferencesSchema.parse(raw)
+    } catch {
+        return null
+    }
+}
+
+/** Write preferences to .planning/preferences.json (atomic). */
+export function writeProjectPreferences(prefs: ProjectPreferences): void {
+    const p = PREFERENCES_PATH()
+    atomicWriteSync(p, JSON.stringify(prefs, null, 2) + '\n')
+}

--- a/packages/luca-mastracode/src/state/vault.ts
+++ b/packages/luca-mastracode/src/state/vault.ts
@@ -1,11 +1,11 @@
 /**
  * Vault helpers — project-scoped MuninnDB vault resolution.
  *
- * `sanitizeVaultName` mirrors the regex from
- * `packages/luca-framework/src/utils/vault-setup.ts:108-114` (lowercase,
- * `[^a-z0-9-]` → `-`, collapse runs, trim ends). The framework re-exports
- * this function so existing consumers continue to import it from
- * `@alecsibilia/luca-framework`.
+ * `sanitizeVaultName` is an alias for `slugifySegment` from
+ * `util/phase-paths.ts` (lowercase, `[^a-z0-9-]` → `-`, collapse runs, trim
+ * ends). Single source of truth in `phase-paths.ts`; this module re-exports
+ * under the vault-specific name. The framework re-exports `sanitizeVaultName`
+ * so existing consumers continue to import it from `@alecsibilia/luca-framework`.
  *
  * `resolveProjectVault` reads `.planning/config.json` via `CONFIG_PATH()` and
  * extracts `muninn.vault`, applying `sanitizeVaultName` and falling back to
@@ -13,7 +13,7 @@
  */
 import { existsSync, readFileSync } from 'node:fs'
 
-import { CONFIG_PATH } from '../util/phase-paths.js'
+import { CONFIG_PATH, slugifySegment } from '../util/phase-paths.js'
 
 /**
  * Sanitize a string into a valid vault name (lowercase kebab-case).
@@ -26,11 +26,7 @@ import { CONFIG_PATH } from '../util/phase-paths.js'
  * sanitizeVaultName("@scope/pkg")    // "scope-pkg"
  */
 export function sanitizeVaultName(name: string): string {
-    return name
-        .toLowerCase()
-        .replace(/[^a-z0-9-]/g, '-')
-        .replace(/-+/g, '-')
-        .replace(/^-|-$/g, '')
+    return slugifySegment(name)
 }
 
 /**

--- a/packages/luca-mastracode/src/state/vault.ts
+++ b/packages/luca-mastracode/src/state/vault.ts
@@ -1,0 +1,57 @@
+/**
+ * Vault helpers — project-scoped MuninnDB vault resolution.
+ *
+ * `sanitizeVaultName` mirrors the regex from
+ * `packages/luca-framework/src/utils/vault-setup.ts:108-114` (lowercase,
+ * `[^a-z0-9-]` → `-`, collapse runs, trim ends). The framework re-exports
+ * this function so existing consumers continue to import it from
+ * `@alecsibilia/luca-framework`.
+ *
+ * `resolveProjectVault` reads `.planning/config.json` via `CONFIG_PATH()` and
+ * extracts `muninn.vault`, applying `sanitizeVaultName` and falling back to
+ * `"default"` when the file is missing, malformed, or the key is unset.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+
+import { CONFIG_PATH } from '../util/phase-paths.js'
+
+/**
+ * Sanitize a string into a valid vault name (lowercase kebab-case).
+ *
+ * Converts to lowercase, replaces non-alphanumeric characters with dashes,
+ * collapses consecutive dashes, and trims leading/trailing dashes.
+ *
+ * @example
+ * sanitizeVaultName("My Cool App!")  // "my-cool-app"
+ * sanitizeVaultName("@scope/pkg")    // "scope-pkg"
+ */
+export function sanitizeVaultName(name: string): string {
+    return name
+        .toLowerCase()
+        .replace(/[^a-z0-9-]/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '')
+}
+
+/**
+ * Resolve the project-scoped MuninnDB vault name.
+ *
+ * Reads `.planning/config.json`, extracts `muninn.vault`, sanitizes it via
+ * `sanitizeVaultName`, and returns the result. Falls back to `"default"` when
+ * the file is missing, unreadable, malformed, or the key is unset/empty.
+ */
+export function resolveProjectVault(): string {
+    const p = CONFIG_PATH()
+    if (!existsSync(p)) return 'default'
+    try {
+        const raw = JSON.parse(readFileSync(p, 'utf-8')) as {
+            muninn?: { vault?: unknown }
+        }
+        const vault = raw?.muninn?.vault
+        if (typeof vault !== 'string' || vault.trim() === '') return 'default'
+        const sanitized = sanitizeVaultName(vault)
+        return sanitized.length > 0 ? sanitized : 'default'
+    } catch {
+        return 'default'
+    }
+}

--- a/packages/luca-mastracode/src/tools/index.ts
+++ b/packages/luca-mastracode/src/tools/index.ts
@@ -15,6 +15,7 @@ export { claimVerifierTool } from './claim-verifier.js'
 export { prReviewTool } from './pr-review.js'
 export { runRulesTool } from './run-rules.js'
 export { ensureFeatureBranchTool } from './ensure-feature-branch.js'
+export { projectPreferencesTool } from './project-preferences.js'
 
 // Permission system
 export { createScopedTool } from './create-scoped-tool.js'

--- a/packages/luca-mastracode/src/tools/project-preferences.ts
+++ b/packages/luca-mastracode/src/tools/project-preferences.ts
@@ -1,0 +1,232 @@
+/**
+ * Project preferences tool — consult, seed, and update project conventions.
+ *
+ * Stores conventions (branching, commits, PR, release, tracker) in
+ * `.planning/preferences.json` and tracks the seeded state in
+ * `.planning/luca-state.json` (`preferencesSeeded`).
+ *
+ * The luca-init skill calls `seed` once; downstream modes call `consult` /
+ * `consult-section` to read the cached conventions. `update` patches sections
+ * in place. There is intentionally no `invalidate` action — preferences are
+ * the source of truth for the duration of the project.
+ */
+import { createTool } from '@mastra/core/tools'
+import { z } from 'zod'
+
+import {
+    DEFAULT_PREFERENCES,
+    loadProjectPreferences,
+    ProjectPreferencesSchema,
+    SectionName,
+    writeProjectPreferences,
+    type ProjectPreferences,
+} from '../state/project-preferences.js'
+import { readLucaState, writeLucaState } from '../state/luca-store.js'
+import { resolveProjectVault } from '../state/vault.js'
+
+type SectionKey = z.infer<typeof SectionName>
+const SECTION_KEYS = SectionName.options
+
+function buildMuninnInstruction(prefs: ProjectPreferences): string {
+    const vault = resolveProjectVault()
+    const content = JSON.stringify(prefs)
+    const summary =
+        `Project preferences (schema v${prefs.schemaVersion}): ` +
+        `branching=${prefs.branching.template} on default ${prefs.branching.defaultBranch}; ` +
+        `commits=${prefs.commits.convention}; ` +
+        `release=${prefs.release.tool}; ` +
+        `tracker=${prefs.tracker.kind}.`
+    return (
+        `After seeding, agent must call mcp__muninn__muninn_remember(` +
+        `vault: "${vault}", ` +
+        `op_id: "project-preferences:${vault}", ` +
+        `type: "project_preferences", ` +
+        `entities: [{name: "${vault}", type: "project"}], ` +
+        `tags: ["preferences","project-config","luca","convention"], ` +
+        `content: ${content}, ` +
+        `summary: "${summary}") to register in MuninnDB.`
+    )
+}
+
+/**
+ * Deep-merge a partial payload into existing preferences (top-level
+ * section-by-section shallow merge). Unknown sections are ignored at this
+ * stage; the merged object is then validated through the Zod schema.
+ */
+function mergePreferences(
+    existing: ProjectPreferences,
+    payload: Record<string, unknown>
+): Record<string, unknown> {
+    const merged: Record<string, unknown> = {
+        schemaVersion: existing.schemaVersion,
+    }
+    for (const key of SECTION_KEYS) {
+        const existingSection = existing[key] as Record<string, unknown>
+        const payloadSection = (payload[key] as Record<string, unknown> | undefined) ?? {}
+        merged[key] = { ...existingSection, ...payloadSection }
+    }
+    if (typeof payload.schemaVersion === 'number') {
+        merged.schemaVersion = payload.schemaVersion
+    }
+    return merged
+}
+
+export const projectPreferencesTool = createTool({
+    id: 'project-preferences',
+    description:
+        'Consult, seed, and update project preferences (branching, commits, PR, release, tracker conventions) ' +
+        'cached in .planning/preferences.json. ' +
+        "Use 'consult' to read the whole document, 'consult-section' to read a single section, " +
+        "'seed' to write the initial document (called once by the luca-init skill), " +
+        "and 'update' to patch sections in place. " +
+        "Pass fallback:true to consult/consult-section to receive hardcoded defaults when no preferences file exists.",
+    inputSchema: z.object({
+        action: z
+            .enum(['consult', 'consult-section', 'seed', 'update'])
+            .describe('Operation to perform on project preferences'),
+        section: z
+            .string()
+            .optional()
+            .describe(
+                "Section name for 'consult-section' (one of: branching, commits, pr, release, tracker)"
+            ),
+        fallback: z
+            .boolean()
+            .optional()
+            .describe(
+                "When true, return DEFAULT_PREFERENCES if no preferences file exists. Used by 'consult' and 'consult-section'."
+            ),
+        payload: z
+            .unknown()
+            .optional()
+            .describe(
+                "Preferences payload for 'seed' (full document) or 'update' (partial; merged section-by-section)."
+            ),
+    }),
+    outputSchema: z.object({
+        success: z.boolean(),
+        preferences: z.unknown().optional(),
+        section: z.unknown().optional(),
+        message: z.string().optional(),
+        muninnInstruction: z.string().optional(),
+    }),
+    execute: async (inputData) => {
+        const { action, section, fallback, payload } = inputData as {
+            action: 'consult' | 'consult-section' | 'seed' | 'update'
+            section?: string
+            fallback?: boolean
+            payload?: unknown
+        }
+
+        switch (action) {
+            case 'consult': {
+                const state = readLucaState()
+                const seeded = state.preferencesSeeded === true
+                const prefs = loadProjectPreferences()
+                if (prefs !== null) {
+                    if (!seeded) writeLucaState({ preferencesSeeded: true })
+                    return { success: true, preferences: prefs }
+                }
+                // prefs === null
+                if (seeded) {
+                    // C1 LOOP-SAFE: previously seeded but file missing/invalid —
+                    // return defaults so callers don't loop on a missing file.
+                    return { success: true, preferences: DEFAULT_PREFERENCES }
+                }
+                if (fallback === true) {
+                    return { success: true, preferences: DEFAULT_PREFERENCES }
+                }
+                return { success: true, preferences: null }
+            }
+
+            case 'consult-section': {
+                if (!section || !SECTION_KEYS.includes(section as SectionKey)) {
+                    return {
+                        success: false,
+                        message: `Unknown section "${section}". Must be one of: branching, commits, pr, release, tracker.`,
+                    }
+                }
+                const key = section as SectionKey
+                const state = readLucaState()
+                const seeded = state.preferencesSeeded === true
+                const prefs = loadProjectPreferences()
+                if (prefs !== null) {
+                    if (!seeded) writeLucaState({ preferencesSeeded: true })
+                    return { success: true, section: prefs[key] }
+                }
+                if (seeded) {
+                    return { success: true, section: DEFAULT_PREFERENCES[key] }
+                }
+                if (fallback === true) {
+                    return { success: true, section: DEFAULT_PREFERENCES[key] }
+                }
+                return { success: true, section: null }
+            }
+
+            case 'seed': {
+                if (payload === undefined || payload === null) {
+                    return {
+                        success: false,
+                        message: 'payload is required for seed',
+                    }
+                }
+                let parsed: ProjectPreferences
+                try {
+                    parsed = ProjectPreferencesSchema.parse(payload)
+                } catch (err) {
+                    const msg = err instanceof Error ? err.message : String(err)
+                    return {
+                        success: false,
+                        message: `Invalid preferences payload: ${msg}`,
+                    }
+                }
+                writeProjectPreferences(parsed)
+                writeLucaState({ preferencesSeeded: true })
+                return {
+                    success: true,
+                    preferences: parsed,
+                    muninnInstruction: buildMuninnInstruction(parsed),
+                }
+            }
+
+            case 'update': {
+                if (payload === undefined || payload === null) {
+                    return {
+                        success: false,
+                        message: 'payload is required for update',
+                    }
+                }
+                if (typeof payload !== 'object' || Array.isArray(payload)) {
+                    return {
+                        success: false,
+                        message: 'payload must be an object',
+                    }
+                }
+                const existing = loadProjectPreferences() ?? DEFAULT_PREFERENCES
+                const merged = mergePreferences(
+                    existing,
+                    payload as Record<string, unknown>
+                )
+                let parsed: ProjectPreferences
+                try {
+                    parsed = ProjectPreferencesSchema.parse(merged)
+                } catch (err) {
+                    const msg = err instanceof Error ? err.message : String(err)
+                    return {
+                        success: false,
+                        message: `Invalid preferences payload: ${msg}`,
+                    }
+                }
+                writeProjectPreferences(parsed)
+                // preserve preferencesSeeded — do not toggle on update
+                return { success: true, preferences: parsed }
+            }
+
+            default:
+                return {
+                    success: false,
+                    message: `Unknown action: ${String(action)}`,
+                }
+        }
+    },
+})

--- a/packages/luca-mastracode/src/tools/project-preferences.ts
+++ b/packages/luca-mastracode/src/tools/project-preferences.ts
@@ -24,27 +24,60 @@ import {
 import { readLucaState, writeLucaState } from '../state/luca-store.js'
 import { resolveProjectVault } from '../state/vault.js'
 
-type SectionKey = z.infer<typeof SectionName>
-const SECTION_KEYS = SectionName.options
+/**
+ * Resolve the effective preferences for read actions (consult, consult-section).
+ *
+ * Encapsulates the C1 / C2 decision tree:
+ * - file present → return parsed prefs; back-fill `preferencesSeeded:true` if
+ *   the flag wasn't already set.
+ * - file missing AND `preferencesSeeded === true` (loop-safe C1) → return
+ *   `DEFAULT_PREFERENCES`. Prevents seed → consult → null infinite loops when
+ *   the on-disk file is removed or unparseable after a successful seed.
+ * - file missing AND not seeded AND `fallback:true` (C2) → return defaults.
+ * - file missing AND not seeded AND `fallback:false` → return `null` (signal
+ *   to triage Step 1.6 sentinel that init is needed).
+ */
+function resolvePrefs(fallback?: boolean): ProjectPreferences | null {
+    const seeded = readLucaState().preferencesSeeded === true
+    const prefs = loadProjectPreferences()
+    if (prefs !== null) {
+        if (!seeded) writeLucaState({ preferencesSeeded: true })
+        return prefs
+    }
+    return seeded || fallback === true ? DEFAULT_PREFERENCES : null
+}
 
+/**
+ * Build the deterministic agent instruction that the luca-init skill executes
+ * after `seed`. Emits a SINGLE JSON-stringified blob argument so the agent
+ * `JSON.parse`s it instead of pattern-matching an interpolated pseudo-call.
+ * This eliminates the prompt-injection vector documented in REVIEW-1.md
+ * MUST-FIX-2/3 — no free-form preference field is ever interpolated into the
+ * instruction string. The Zod allowlist on `state/project-preferences.ts`
+ * provides defense in depth at the schema layer.
+ */
 function buildMuninnInstruction(prefs: ProjectPreferences): string {
     const vault = resolveProjectVault()
-    const content = JSON.stringify(prefs)
     const summary =
         `Project preferences (schema v${prefs.schemaVersion}): ` +
-        `branching=${prefs.branching.template} on default ${prefs.branching.defaultBranch}; ` +
+        `branching template+default; ` +
         `commits=${prefs.commits.convention}; ` +
         `release=${prefs.release.tool}; ` +
         `tracker=${prefs.tracker.kind}.`
+    const blob = {
+        vault,
+        op_id: `project-preferences:${vault}`,
+        type: 'project_preferences',
+        entities: [{ name: vault, type: 'project' }],
+        tags: ['preferences', 'project-config', 'luca', 'convention'],
+        content: JSON.stringify(prefs),
+        summary,
+    }
     return (
-        `After seeding, agent must call mcp__muninn__muninn_remember(` +
-        `vault: "${vault}", ` +
-        `op_id: "project-preferences:${vault}", ` +
-        `type: "project_preferences", ` +
-        `entities: [{name: "${vault}", type: "project"}], ` +
-        `tags: ["preferences","project-config","luca","convention"], ` +
-        `content: ${content}, ` +
-        `summary: "${summary}") to register in MuninnDB.`
+        `After seeding, agent must call mcp__muninn__muninn_remember with the ` +
+        `arguments encoded in this JSON blob (use JSON.parse to extract them, ` +
+        `do NOT interpolate the raw string into other tool calls): ` +
+        JSON.stringify(blob)
     )
 }
 
@@ -57,16 +90,17 @@ function mergePreferences(
     existing: ProjectPreferences,
     payload: Record<string, unknown>
 ): Record<string, unknown> {
+    // schemaVersion is sealed to the Zod literal — caller-supplied values are
+    // intentionally ignored here. Migrations belong in a dedicated migrate()
+    // helper gated on the stored value, NOT in mergePreferences. See
+    // REVIEW-1.md MUST-FIX-4.
     const merged: Record<string, unknown> = {
         schemaVersion: existing.schemaVersion,
     }
-    for (const key of SECTION_KEYS) {
+    for (const key of SectionName.options) {
         const existingSection = existing[key] as Record<string, unknown>
         const payloadSection = (payload[key] as Record<string, unknown> | undefined) ?? {}
         merged[key] = { ...existingSection, ...payloadSection }
-    }
-    if (typeof payload.schemaVersion === 'number') {
-        merged.schemaVersion = payload.schemaVersion
     }
     return merged
 }
@@ -105,8 +139,15 @@ export const projectPreferencesTool = createTool({
     }),
     outputSchema: z.object({
         success: z.boolean(),
-        preferences: z.unknown().optional(),
-        section: z.unknown().optional(),
+        // Typed contract: full document (consult) or null when init needed.
+        preferences: ProjectPreferencesSchema.nullable().optional(),
+        // section is the value of one keyed section; runtime-validated as a
+        // record (specific section types are erased here because the keys are
+        // dynamic and Mastra's tool generic does not support union outputs
+        // cleanly — callers should narrow via the `section` input).
+        section: z
+            .union([z.record(z.string(), z.unknown()), z.null()])
+            .optional(),
         message: z.string().optional(),
         muninnInstruction: z.string().optional(),
     }),
@@ -120,47 +161,25 @@ export const projectPreferencesTool = createTool({
 
         switch (action) {
             case 'consult': {
-                const state = readLucaState()
-                const seeded = state.preferencesSeeded === true
-                const prefs = loadProjectPreferences()
-                if (prefs !== null) {
-                    if (!seeded) writeLucaState({ preferencesSeeded: true })
-                    return { success: true, preferences: prefs }
-                }
-                // prefs === null
-                if (seeded) {
-                    // C1 LOOP-SAFE: previously seeded but file missing/invalid —
-                    // return defaults so callers don't loop on a missing file.
-                    return { success: true, preferences: DEFAULT_PREFERENCES }
-                }
-                if (fallback === true) {
-                    return { success: true, preferences: DEFAULT_PREFERENCES }
-                }
-                return { success: true, preferences: null }
+                return { success: true, preferences: resolvePrefs(fallback) }
             }
 
             case 'consult-section': {
-                if (!section || !SECTION_KEYS.includes(section as SectionKey)) {
+                if (
+                    !section ||
+                    !SectionName.options.includes(section as SectionName)
+                ) {
                     return {
                         success: false,
                         message: `Unknown section "${section}". Must be one of: branching, commits, pr, release, tracker.`,
                     }
                 }
-                const key = section as SectionKey
-                const state = readLucaState()
-                const seeded = state.preferencesSeeded === true
-                const prefs = loadProjectPreferences()
-                if (prefs !== null) {
-                    if (!seeded) writeLucaState({ preferencesSeeded: true })
-                    return { success: true, section: prefs[key] }
+                const key = section as SectionName
+                const prefs = resolvePrefs(fallback)
+                return {
+                    success: true,
+                    section: prefs ? (prefs[key] as Record<string, unknown>) : null,
                 }
-                if (seeded) {
-                    return { success: true, section: DEFAULT_PREFERENCES[key] }
-                }
-                if (fallback === true) {
-                    return { success: true, section: DEFAULT_PREFERENCES[key] }
-                }
-                return { success: true, section: null }
             }
 
             case 'seed': {

--- a/packages/luca-mastracode/src/tools/tool-manifest.ts
+++ b/packages/luca-mastracode/src/tools/tool-manifest.ts
@@ -29,6 +29,7 @@ import { manageRoadmapTool } from './manage-roadmap.js'
 import { manageTodosTool } from './manage-todos.js'
 import { pipelineLockTool } from './pipeline-lock.js'
 import { prReviewTool } from './pr-review.js'
+import { projectPreferencesTool } from './project-preferences.js'
 import { repoCleanupTool } from './repo-cleanup.js'
 import { runChecksTool } from './run-checks.js'
 import { runPostmortemTool } from './run-postmortem.js'
@@ -228,6 +229,24 @@ const TOOL_MANIFEST: Record<string, ToolManifestEntry> = {
             [MODES.finalize]: ['status'],
             // Build/fast keep full access for ad-hoc workflows + the
             // gh-prepare skill that retroactively moves commits to a branch.
+            build: '*',
+            fast: '*',
+        },
+    },
+    project_preferences: {
+        tool: projectPreferencesTool,
+        record_key: 'projectPreferences',
+        modes: {
+            // Triage runs the sentinel and may seed/update via luca-init.
+            [MODES.triage]: ['consult', 'consult-section', 'seed', 'update'],
+            // Read-only consumers across the rest of the pipeline.
+            [MODES.research]: ['consult', 'consult-section'],
+            [MODES.architect]: ['consult', 'consult-section'],
+            [MODES.execute]: ['consult', 'consult-section'],
+            [MODES.review]: ['consult', 'consult-section'],
+            [MODES.finalize]: ['consult', 'consult-section'],
+            [MODES.discuss]: ['consult', 'consult-section'],
+            // Stock modes get full access for ad-hoc reads/writes.
             build: '*',
             fast: '*',
         },


### PR DESCRIPTION
feat(mastracode): v11.7.0 #26 project preferences foundation

Closes #26

## Summary

Add project preferences foundation: Mastra tool + skill + sentinel + Zod schema for managing project conventions (branching, commits, PR, release, tracker). Tool manages local cache; skill handles MuninnDB I/O via mcp__muninn__muninn_remember. Sentinel at triage Step 1.6 invokes /luca-init when preferences not yet seeded.

## What This Enables

- Phase B (branching policy refactor) can consume consult-section('branching') instead of hardcoded BRANCH_TYPES
- Phase C (PR/release/commit conventions) can consume consult-section('pr') / consult-section('release') / consult-section('commits')
- Users can customize conventions per-repo via /luca-init wizard + MuninnDB registration

## Changes by Phase

### Architecture
- New projectPreferences Mastra tool with consult, consult-section, seed, update
- New luca-init skill (repo-probing wizard; detects conventions from git history)
- Sentinel in triage Step 1.6 (invokes skill if preferences not seeded)
- ProjectPreferencesSchema (Zod) with optional sections: branching, commits, pr, release, tracker
- resolveProjectVault() + sanitizeVaultName() helpers (mastracode shared, framework re-exports)

### Implementation
- Tool manages local cache + preferencesSeeded state flag
- All MuninnDB I/O happens in skill/instruction prose (tools have no MCP)
- Schema enforces Zod allowlist on free-form fields (mitigates prompt-injection from cloned repos)
- Three design constraints (C1 seeded flag, C2 fallback, C3 op_id) prevent infinite loops and concurrency hazards

### Testing
- All tests pass (luca-mastracode)
- project-preferences test cases cover all action branches + sentinel-loop C1 guard
- tsc clean across both packages

## Known Limitations

- User-generated cache; not in source control by default
- Phase B/C work will consume this tool; currently the tool is wired but unused (backward-compat; not breaking)
- invalidate action deferred until session cache lands

## Verification

- ✓ All 9 PLAN.md tasks completed (100% task ratio)
- ✓ 5/5 verification waves pass (aggregate)
- ✓ 2 non-critical postmortem warnings (expected)
- ✓ rule gate clean

## Links

- Postmortem: .planning/phases/20260507-1011-build-project-preferences-foundation-projectpre/POSTMORTEM.md
- Review 2 (CLEAN): .planning/phases/20260507-1011-build-project-preferences-foundation-projectpre/REVIEW-2.md
- Commits: 5443aad92 (iteration 1 MUST-FIX), 236db7c8a (wave 3), 6f3c8c268 (wave 2), 9a271f49e (wave 1)
