### PR TITLE
feat(mastracode): v11.9.0-alpha.3 add mode.start/mode.end telemetry to switch-mode #40

### DIFF
--- a/.changeset/mode-transition-telemetry.md
+++ b/.changeset/mode-transition-telemetry.md
@@ -1,0 +1,5 @@
+---
+"@alecsibilia/luca-mastracode": patch
+---
+
+Add `mode.start` / `mode.end` telemetry records emitted from `switch-mode` in `workflow-state.ts`. Captures outer pipeline loop durations (triage, research, architect, execute, review, finalize) that were missing from the v1 telemetry foundation (PR #239). Extends `TelemetryRecord.kind` union, adds `currentModeStartedAt` to `LucaWorkflowState`.

--- a/packages/luca-mastracode/src/__tests__/workflow-state-actions.test.ts
+++ b/packages/luca-mastracode/src/__tests__/workflow-state-actions.test.ts
@@ -961,7 +961,10 @@ describe('switch-mode telemetry', () => {
         const modeCalls = mockAppendTelemetry.mock.calls.filter(
             (c) => c[0] === 'mode.end' || c[0] === 'mode.start'
         )
-        expect(modeCalls).toHaveLength(0)
+        expect(
+            modeCalls,
+            'switch failed but telemetry leaked — hook must be AFTER switchModeRef.current() resolves'
+        ).toHaveLength(0)
     })
 
     test('(f) reset-pipeline clears currentModeStartedAt → next mode.end has durationMs: null', async () => {

--- a/packages/luca-mastracode/src/__tests__/workflow-state-actions.test.ts
+++ b/packages/luca-mastracode/src/__tests__/workflow-state-actions.test.ts
@@ -846,3 +846,155 @@ describe('ROOT_WHITELIST_DIRS regression', () => {
         expect(ROOT_WHITELIST_DIRS.has('telemetry')).toBe(true)
     })
 })
+
+// ---------------------------------------------------------------------------
+// switch-mode telemetry
+// ---------------------------------------------------------------------------
+
+describe('switch-mode telemetry', () => {
+    test('(a) emits mode.end with populated durationMs for prior mode', async () => {
+        switchModeRef.current = async () => {}
+        const priorModeStartedAt = new Date(Date.now() - 100).toISOString()
+        mockReadLucaState.mockReturnValue({
+            pipelineStep: 'luca:1-triage',
+            currentModeStartedAt: priorModeStartedAt,
+            currentPhaseName: null,
+            currentPhaseSlug: null,
+            currentWave: null,
+        } as any)
+
+        const result = await callAction({
+            action: 'switch-mode',
+            targetMode: 'luca:2-research',
+        })
+
+        expect(result.success).toBe(true)
+        const modeEndCall = mockAppendTelemetry.mock.calls.find(
+            (c) => c[0] === 'mode.end'
+        )
+        expect(modeEndCall).toBeDefined()
+        const overrides = modeEndCall![2] as any
+        expect(typeof overrides?.durationMs).toBe('number')
+        expect(overrides?.durationMs).toBeGreaterThan(0)
+    })
+
+    test('(b) emits mode.start with durationMs: null for incoming mode', async () => {
+        switchModeRef.current = async () => {}
+        const priorModeStartedAt = new Date(Date.now() - 100).toISOString()
+        mockReadLucaState.mockReturnValue({
+            pipelineStep: 'luca:1-triage',
+            currentModeStartedAt: priorModeStartedAt,
+        } as any)
+
+        await callAction({
+            action: 'switch-mode',
+            targetMode: 'luca:2-research',
+        })
+
+        const modeStartCall = mockAppendTelemetry.mock.calls.find(
+            (c) => c[0] === 'mode.start'
+        )
+        expect(modeStartCall).toBeDefined()
+        const overrides = modeStartCall![2] as any
+        expect(overrides?.durationMs ?? null).toBeNull()
+        const meta = modeStartCall![1] as any
+        expect(meta?.to).toBe('luca:2-research')
+    })
+
+    test('(c) first switch (no prior currentModeStartedAt) emits mode.end with durationMs: null', async () => {
+        switchModeRef.current = async () => {}
+        mockReadLucaState.mockReturnValue({
+            pipelineStep: 'idle',
+            // no currentModeStartedAt
+        } as any)
+
+        const result = await callAction({
+            action: 'switch-mode',
+            targetMode: 'luca:1-triage',
+        })
+
+        expect(result.success).toBe(true)
+        const modeEndCall = mockAppendTelemetry.mock.calls.find(
+            (c) => c[0] === 'mode.end'
+        )
+        expect(modeEndCall).toBeDefined()
+        const overrides = modeEndCall![2] as any
+        expect(overrides?.durationMs).toBeNull()
+    })
+
+    test('(d) malformed currentModeStartedAt → durationMs: null (NaN guard)', async () => {
+        switchModeRef.current = async () => {}
+        mockReadLucaState.mockReturnValue({
+            pipelineStep: 'luca:1-triage',
+            currentModeStartedAt: 'not-a-valid-date',
+        } as any)
+
+        await callAction({
+            action: 'switch-mode',
+            targetMode: 'luca:2-research',
+        })
+
+        const modeEndCall = mockAppendTelemetry.mock.calls.find(
+            (c) => c[0] === 'mode.end'
+        )
+        expect(modeEndCall).toBeDefined()
+        const overrides = modeEndCall![2] as any
+        expect(overrides?.durationMs).toBeNull()
+    })
+
+    test('(e) failed switch (switchModeRef throws) → no telemetry emitted', async () => {
+        switchModeRef.current = async () => {
+            throw new Error('switch failed')
+        }
+        mockReadLucaState.mockReturnValue({
+            pipelineStep: 'luca:1-triage',
+            currentModeStartedAt: new Date().toISOString(),
+        } as any)
+
+        const result = await callAction({
+            action: 'switch-mode',
+            targetMode: 'luca:2-research',
+        })
+
+        expect(result.success).toBe(false)
+        // appendTelemetry must NOT have been called — switch failed before hook
+        const modeCalls = mockAppendTelemetry.mock.calls.filter(
+            (c) => c[0] === 'mode.end' || c[0] === 'mode.start'
+        )
+        expect(modeCalls).toHaveLength(0)
+    })
+
+    test('(f) reset-pipeline clears currentModeStartedAt → next mode.end has durationMs: null', async () => {
+        // First: perform a reset-pipeline to clear session state
+        await callAction({ action: 'reset-pipeline' })
+
+        // Verify writeLucaState was called with currentModeStartedAt: undefined
+        const resetCalls = mockWriteLucaState.mock.calls
+        const resetStateCall = resetCalls.find(
+            (c) => c[0] && 'currentModeStartedAt' in (c[0] as any)
+        )
+        expect(resetStateCall).toBeDefined()
+        expect((resetStateCall![0] as any).currentModeStartedAt).toBeUndefined()
+
+        // Simulate the state after reset: currentModeStartedAt is gone
+        mockWriteLucaState.mockClear()
+        mockAppendTelemetry.mockClear()
+        switchModeRef.current = async () => {}
+        mockReadLucaState.mockReturnValue({
+            pipelineStep: 'idle',
+            // currentModeStartedAt deliberately absent — simulates post-reset state
+        } as any)
+
+        await callAction({
+            action: 'switch-mode',
+            targetMode: 'luca:1-triage',
+        })
+
+        const modeEndCall = mockAppendTelemetry.mock.calls.find(
+            (c) => c[0] === 'mode.end'
+        )
+        expect(modeEndCall).toBeDefined()
+        const overrides = modeEndCall![2] as any
+        expect(overrides?.durationMs).toBeNull()
+    })
+})

--- a/packages/luca-mastracode/src/state/luca-store.ts
+++ b/packages/luca-mastracode/src/state/luca-store.ts
@@ -112,6 +112,10 @@ export interface LucaWorkflowState {
      * resolves so a failed switch never poisons this field. Consumed by
      * `switch-mode` telemetry to compute `mode.end` durationMs.
      * Cleared by `reset-pipeline` to prevent cross-run duration bleed.
+     *
+     * Treated as an opaque string by the consumer — `finiteOrNull` guards
+     * against malformed or legacy values (e.g. non-date strings left by
+     * a corrupted state file). Do not remove that guard as "defensive cruft".
      */
     currentModeStartedAt?: string
 

--- a/packages/luca-mastracode/src/state/luca-store.ts
+++ b/packages/luca-mastracode/src/state/luca-store.ts
@@ -106,6 +106,14 @@ export interface LucaWorkflowState {
     sessionId?: string
     startedAt?: string
     runId?: string
+    /**
+     * Timestamp (ISO 8601) when the current pipeline mode was entered via a
+     * successful `switch-mode` call. Written AFTER `switchModeRef.current()`
+     * resolves so a failed switch never poisons this field. Consumed by
+     * `switch-mode` telemetry to compute `mode.end` durationMs.
+     * Cleared by `reset-pipeline` to prevent cross-run duration bleed.
+     */
+    currentModeStartedAt?: string
 
     // --- Phase proof (set by start-phase, consumed by complete-phase) ---
     currentPhaseStartSnapshot?: PhaseSnapshotState

--- a/packages/luca-mastracode/src/state/telemetry.ts
+++ b/packages/luca-mastracode/src/state/telemetry.ts
@@ -4,7 +4,18 @@
  * Data layer: `.planning/telemetry/<runId>.jsonl` (machine-readable, append-only).
  *
  * Produced by `workflowState` action handlers (`start-phase`, `advance-wave`,
- * `complete-phase`) and consumed by a future aggregator skill (`/luca-telemetry-report`).
+ * `complete-phase`, `switch-mode`) and consumed by a future aggregator skill
+ * (`/luca-telemetry-report`).
+ *
+ * ## Two-tier event hierarchy
+ *
+ * **Pipeline modes** (outer loop) — one pair per `switch-mode` call:
+ * - `mode.start` / `mode.end` — captures duration of each pipeline mode
+ *   (triage, research, architect, execute, review, finalize).
+ *
+ * **PLAN.md phases** (inner loop, execute-only) — emitted by `start-phase`,
+ * `advance-wave`, `complete-phase`:
+ * - `phase.start` / `wave.start` / `wave.end` / `phase.end`
  *
  * ## Schema contract (v1 — LOCKED)
  *
@@ -69,6 +80,8 @@ export type TelemetryKind =
     | 'phase.end'
     | 'wave.start'
     | 'wave.end'
+    | 'mode.start'
+    | 'mode.end'
     | (string & {})
 
 export interface TelemetryRecord {

--- a/packages/luca-mastracode/src/tools/workflow-state.ts
+++ b/packages/luca-mastracode/src/tools/workflow-state.ts
@@ -582,7 +582,7 @@ export const workflowStateTool = createTool({
                                 | undefined
                         writeLucaState(stateUpdates)
                         appendLedger('mode-transition', {
-                            from: prevState.pipelineStep,
+                            from: priorMode,
                             to: targetMode,
                         })
                         await switchModeRef.current(targetMode)
@@ -591,9 +591,15 @@ export const workflowStateTool = createTool({
                         contextRefresherRef.current?.setMode(targetMode)
 
                         // Persist currentModeStartedAt AFTER successful switch.
-                        // Writing here (not in stateUpdates above) ensures a failed
-                        // switch never records a timestamp without a matching mode.start
-                        // telemetry record — keeping the durationMs invariant clean.
+                        // Intentional two-write design: the first write (pipelineStep/
+                        // nextMode above) runs BEFORE switchModeRef.current() so the new
+                        // mode reads correct state on entry. This second write runs AFTER
+                        // a successful switch — a failed switch (throw at line above) skips
+                        // this block entirely, ensuring currentModeStartedAt is never set
+                        // without a matching mode.start telemetry record.
+                        // Trade-off: a process crash between the two writes leaves pipelineStep
+                        // updated but currentModeStartedAt stale — the next mode.end will emit
+                        // durationMs: null (no prior timestamp), which is safe and recoverable.
                         const modeStartedAt = new Date().toISOString()
                         writeLucaState({ currentModeStartedAt: modeStartedAt })
 
@@ -606,6 +612,11 @@ export const workflowStateTool = createTool({
                                       new Date(priorModeStartedAt).getTime()
                               )
                             : null
+                        // `mode.end` overrides phase/slug/wave with pre-mutation
+                        // values because writeLucaState above only mutated
+                        // pipelineStep/nextMode/intent — complexity, oversight, runId
+                        // are NOT mutated by switch-mode and safely flow through
+                        // readLucaState() inside buildTelemetryRecord.
                         appendTelemetry(
                             'mode.end',
                             { from: priorMode },

--- a/packages/luca-mastracode/src/tools/workflow-state.ts
+++ b/packages/luca-mastracode/src/tools/workflow-state.ts
@@ -569,6 +569,17 @@ export const workflowStateTool = createTool({
                         if (userRequest) {
                             stateUpdates.intent = userRequest
                         }
+                        // Capture pre-mutation context for mode.end telemetry.
+                        // Must read BEFORE writeLucaState() — after mutation,
+                        // readLucaState() reflects new pipelineStep/phase/slug/wave.
+                        const priorMode = prevState.pipelineStep ?? null
+                        const priorPhase = prevState.currentPhaseName ?? null
+                        const priorSlug = prevState.currentPhaseSlug ?? null
+                        const priorWave = prevState.currentWave ?? null
+                        const priorModeStartedAt =
+                            prevState.currentModeStartedAt as
+                                | string
+                                | undefined
                         writeLucaState(stateUpdates)
                         appendLedger('mode-transition', {
                             from: prevState.pipelineStep,
@@ -578,6 +589,35 @@ export const workflowStateTool = createTool({
                         // Notify context refresher of mode change AFTER successful switch
                         // so it doesn't get stuck in the wrong mode if switch fails.
                         contextRefresherRef.current?.setMode(targetMode)
+
+                        // Persist currentModeStartedAt AFTER successful switch.
+                        // Writing here (not in stateUpdates above) ensures a failed
+                        // switch never records a timestamp without a matching mode.start
+                        // telemetry record — keeping the durationMs invariant clean.
+                        const modeStartedAt = new Date().toISOString()
+                        writeLucaState({ currentModeStartedAt: modeStartedAt })
+
+                        // Telemetry: outer pipeline loop durations.
+                        // appendTelemetry is fail-safe — never throws.
+                        // mode.end closes the outgoing mode; mode.start opens the new one.
+                        const modeDurationMs = priorModeStartedAt
+                            ? finiteOrNull(
+                                  Date.now() -
+                                      new Date(priorModeStartedAt).getTime()
+                              )
+                            : null
+                        appendTelemetry(
+                            'mode.end',
+                            { from: priorMode },
+                            {
+                                phase: priorPhase,
+                                slug: priorSlug,
+                                wave: priorWave,
+                                durationMs: modeDurationMs,
+                            }
+                        )
+                        appendTelemetry('mode.start', { to: targetMode })
+
                         return {
                             success: true,
                             message: `Switched to "${targetMode}" mode.`,
@@ -1132,6 +1172,10 @@ export const workflowStateTool = createTool({
                         // Session metadata
                         sessionId: undefined,
                         startedAt: undefined,
+                        // Mode-transition telemetry — clear so a new run's
+                        // first switch-mode emits mode.end with durationMs=null
+                        // instead of bleeding the prior run's mode duration.
+                        currentModeStartedAt: undefined,
                         assignedTodos: undefined,
                         phaseResults: undefined,
                         // Phase-diff snapshots (Step 2 of the postmortem plan)


### PR DESCRIPTION
# feat(mastracode): add mode.start/mode.end telemetry to switch-mode

## What
Emit `mode.start` and `mode.end` telemetry records from `switch-mode` to capture outer pipeline loop (triage → research → architect → execute → review → finalize) durations. Closes gap where PR #239 only logged execute-internal PLAN.md phases.

## Why
Telemetry was incomplete. PR #239 captured Wave-level durations (inner loop), but pipeline mode transitions (outer loop) were invisible. Now every mode entry/exit is logged with duration, enabling cross-mode bottleneck detection (e.g., "research takes 60% of total pipeline time").

## How

### Schema (telemetry.ts)
- Added `'mode.start'` and `'mode.end'` to `TelemetryKind` union
- Two-tier hierarchy JSDoc: pipeline modes (outer) vs PLAN.md phases (inner, execute-only)

### State (luca-store.ts)
- Added `currentModeStartedAt?: string` field in `LucaWorkflowState` under Session section
- JSDoc documents consumer (`switch-mode` telemetry), writer (AFTER successful `switch-mode`), reset path

### Hook (workflow-state.ts)
- Pre-mutation capture in `switch-mode`: `priorMode`, `priorPhase`, `priorSlug`, `priorWave`, `priorModeStartedAt`
- Post-switch telemetry (AFTER `await switchModeRef.current()` resolves):
  - `mode.end` with `meta.from`, phase/slug/wave overrides from pre-mutation state, `durationMs` via `finiteOrNull`
  - `mode.start` with `meta.to`, `durationMs: null`
- Two-write design: `currentModeStartedAt` written AFTER successful switch to prevent stale timestamps from failed switches
- `reset-pipeline` clears `currentModeStartedAt` to prevent cross-run bleed

### Tests (workflow-state-actions.test.ts)
6 new test cases:
- (a) `mode.end` populated durationMs from prior timestamp
- (b) `mode.start` null durationMs (opening event)
- (c) first switch (no prior timestamp) → `durationMs: null`
- (d) malformed timestamp → `finiteOrNull` guard → `durationMs: null`
- (e) failed switch → no telemetry emitted (hook is post-await)
- (f) reset clears field → no cross-run bleed

## Testing
- ✅ 324 tests pass (318 existing + 6 new)
- ✅ tsc clean (0 errors)
- ✅ 4-perspective code review: 0 MUST-FIX, 0 outstanding SHOULD-FIX
- ✅ Verification gate: all 8 blocking criteria MET
- ✅ Postmortem gate: PASS (1 benign warning)

## Changeset
`@alecsibilia/luca-mastracode`: patch

## Related
- Depends on: PR #239 (wave-duration-telemetry — foundation TelemetryRecord schema)
- Follow-up: `telemetry-re-enter-pipeline-mode-transition-parity` (separate todo — `re-enter-pipeline` needs same hook)

## Branches
- **Feature**: `feat/mode-start-end-telemetry-switch-mode` (6 commits)
- **Base**: main
- **Commits**:
  1. `eae4d5f2f` – add schema + state field
  2. `3fe064f78` – add `mode.start`/`mode.end` to union
  3. `724b8fb8f` – hook into switch-mode + reset-pipeline
  4. `002f86696` – 6 new tests
  5. `adf32ac09` – changeset
  6. `df08b17c6` – review polish (5 SHOULD-FIX applied)

---

**Closes**: #40 (telemetry-mode-transition-logging-pipeline-outer-loop-coverage)
