### PR TITLE
fix: move private luca-core to devDependencies (unbreaks install)

### DIFF
--- a/.changeset/fix-luca-core-private-dep-resolution.md
+++ b/.changeset/fix-luca-core-private-dep-resolution.md
@@ -1,0 +1,9 @@
+---
+"@alecsibilia/luca-framework": patch
+---
+
+Fix `bun add -g @alecsibilia/luca-framework` failing with `error: GET .../@alecsibilia%2fluca-core - 404`.
+
+`@alecsibilia/luca-core` is a private, workspace-only package that ships bundled inside the framework tarball — inlined into `dist/index.mjs` and copied to `dist/node_modules/` for the bundled mastracode harness. It was incorrectly listed under `dependencies`, so on publish its `workspace:*` spec was rewritten to a concrete `0.1.0` and a consumer's package manager tried to resolve it from the npm registry, where it does not exist. It is now a `devDependency`, matching how the other private internal package (`@alecsibilia/luca-mastracode`) is already handled — consumers do not install devDependencies, and the bundled copies are self-contained.
+
+`validate-tarball-deps.ts` now also fails the publish if any private workspace package leaks into the packed `dependencies`, so this regression cannot recur silently.

--- a/packages/luca-framework/package.json
+++ b/packages/luca-framework/package.json
@@ -6,7 +6,6 @@
     "luca": "./bin/luca.js"
   },
   "dependencies": {
-    "@alecsibilia/luca-core": "workspace:*",
     "@clack/prompts": "^1.0.0",
     "@mastra/core": "catalog:",
     "@mastra/libsql": "catalog:",
@@ -22,6 +21,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@alecsibilia/luca-core": "workspace:*",
     "@alecsibilia/luca-mastracode": "workspace:*",
     "@types/semver": "^7.5.8",
     "@types/shell-quote": "^1.7.5",

--- a/packages/luca-framework/scripts/validate-tarball-deps.ts
+++ b/packages/luca-framework/scripts/validate-tarball-deps.ts
@@ -1,26 +1,33 @@
 #!/usr/bin/env bun
 /**
- * Validate that the packed tarball pins every Mastra-family dependency
- * to an exact version (no caret, no tilde, no range, no `*`).
+ * Validate the packed luca-framework tarball before `npm publish`.
  *
- * Why: `mastracode` releases its harness alongside specific exact pins
- * of `@mastra/core` and friends. Publishing with caret ranges lets npm
- * silently swap in a newer `@mastra/core` at user install time, which
- * has produced runtime breakage like
- *     `Error: Exhausted all fallback models. Last error: Unsupported role: signal`
- * when `mastracode@0.19` (built against `@mastra/core@1.34`) ended up
- * paired with a stale older core that does not recognise the `signal`
- * message role. Pinning eliminates this drift class entirely.
+ * Two checks; either failing exits 1.
  *
- * This runs in the publish job, after `bun pm pack`, before
- * `npm publish`. Exit 1 if any Mastra dep in the packed
- * `package.json` is non-exact.
+ * Check 1 — no private workspace package in `dependencies`.
+ *   Private `@alecsibilia/*` packages (luca-core, luca-mastracode) are
+ *   bundled into the tarball and never published to the registry. If one
+ *   is listed under `dependencies`, the publish tooling rewrites its
+ *   `workspace:*` spec to a concrete version and a consumer's package
+ *   manager tries — and fails with a 404 — to resolve it from npm. Such
+ *   packages belong in `devDependencies`, which consumers do not install.
+ *
+ * Check 2 — every Mastra-family dependency is exact-pinned (no ^, ~,
+ *   range, or `*`). `mastracode` releases its harness alongside specific
+ *   exact pins of `@mastra/core` and friends. Caret ranges let npm
+ *   silently swap in a newer `@mastra/core` at install time, which has
+ *   produced runtime breakage like
+ *       `Error: Exhausted all fallback models. Last error: Unsupported role: signal`
+ *   when `mastracode@0.19` (built against `@mastra/core@1.34`) ended up
+ *   paired with a stale older core. Pinning eliminates that drift class.
+ *
+ * This runs in the publish job, after `bun pm pack`, before `npm publish`.
  *
  * Usage: bun run scripts/validate-tarball-deps.ts [path/to/tarball.tgz]
  *        (defaults to packages/luca-framework/.pack/*.tgz)
  */
 import { spawnSync } from 'node:child_process'
-import { existsSync, readdirSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 const PINNED_PREFIXES = ['mastracode', '@mastra/']
@@ -30,6 +37,37 @@ const isMastraFamilyDep = (name: string): boolean =>
     PINNED_PREFIXES.some(
         (p) => name === p.replace(/\/$/, '') || name.startsWith(p)
     )
+
+/**
+ * Names of every workspace package marked `private: true`. These are
+ * bundled into publishable tarballs and never published standalone, so
+ * they must never appear in a published package's `dependencies`.
+ *
+ * Derived from the workspace itself so a newly added private package is
+ * covered automatically — and a package that later drops `private` is
+ * automatically allowed.
+ */
+function collectPrivateWorkspacePackages(packagesDir: string): Set<string> {
+    const names = new Set<string>()
+    if (!existsSync(packagesDir)) return names
+    for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue
+        const manifest = resolve(packagesDir, entry.name, 'package.json')
+        if (!existsSync(manifest)) continue
+        try {
+            const p = JSON.parse(readFileSync(manifest, 'utf-8')) as {
+                name?: string
+                private?: boolean
+            }
+            if (p.private === true && typeof p.name === 'string') {
+                names.add(p.name)
+            }
+        } catch {
+            // Unreadable/malformed manifest — skip it.
+        }
+    }
+    return names
+}
 
 const pkgDir = resolve(import.meta.dir, '..')
 const tarballArg = process.argv[2]
@@ -94,10 +132,29 @@ try {
 }
 const deps: Record<string, string> = pkg.dependencies ?? {}
 
-console.log(
-    `[validate-tarball-deps] Inspecting ${tarball}\n` +
-        `  Mastra deps must be exact-pinned (no ^, no ~, no ranges).`
-)
+console.log(`[validate-tarball-deps] Inspecting ${tarball}`)
+
+// --- Check 1: no private workspace package leaked into `dependencies` ---
+const privatePkgs = collectPrivateWorkspacePackages(resolve(pkgDir, '..'))
+const privateLeaks = Object.keys(deps).filter((name) => privatePkgs.has(name))
+if (privateLeaks.length > 0) {
+    console.error(
+        `\n[validate-tarball-deps] FAIL: ${privateLeaks.length} private ` +
+            `workspace package(s) leaked into the published \`dependencies\`:`
+    )
+    for (const name of privateLeaks) {
+        console.error(
+            `  - ${name}: "${deps[name]}" — private packages are bundled into ` +
+                `the tarball, not published to npm. Move it to devDependencies ` +
+                `(consumers do not install devDependencies).`
+        )
+    }
+    process.exit(1)
+}
+console.log(`  ✔ no private workspace package in dependencies`)
+
+// --- Check 2: every Mastra-family dep is exact-pinned ---
+console.log(`  Mastra deps must be exact-pinned (no ^, no ~, no ranges).`)
 
 const violations: { name: string; spec: string }[] = []
 for (const [name, spec] of Object.entries(deps)) {


### PR DESCRIPTION
## Summary

Fixes `bun add -g @alecsibilia/luca-framework@alpha` (and any registry install) failing with:

```
error: GET https://registry.npmjs.org/@alecsibilia%2fluca-core - 404
error: @alecsibilia/luca-core@0.1.0 failed to resolve
```

`@alecsibilia/luca-core` is a private, workspace-only package that ships **bundled** inside the framework tarball — inlined into `dist/index.mjs` and copied to `dist/node_modules/` for the bundled mastracode harness. It was listed under `dependencies`, so on publish its `workspace:*` spec was rewritten to a concrete `0.1.0` and consumers' package managers tried to resolve it from the npm registry, where it does not exist.

The other private internal package, `@alecsibilia/luca-mastracode`, was already a `devDependency` and installs fine. `luca-core` now gets the identical treatment.

Shipped broken in `12.0.0-alpha.13`; this changeset produces `12.0.0-alpha.14`.

## Changes

- **`packages/luca-framework/package.json`** — move `@alecsibilia/luca-core` from `dependencies` to `devDependencies` (mirrors `@alecsibilia/luca-mastracode`). Consumers don't install devDependencies; the bundled copies make the tarball self-contained.
- **`scripts/validate-tarball-deps.ts`** — new publish-time check: fails if any `private: true` workspace package leaks into the packed `dependencies`. Derived from the workspace itself, so new private packages are covered automatically.
- **changeset** — `patch` for `@alecsibilia/luca-framework`.

## Test plan

- [x] `bunx --bun tsc --noEmit` passes for `luca-framework`
- [x] Verified the new validator detects all three private packages (`luca-core`, `luca-mastracode`, `luca-studio`) and not the public `luca-framework`
- [ ] CI publish dry-run / `validate-tarball-deps` passes on the packed tarball
- [ ] After release: `bun add -g @alecsibilia/luca-framework@alpha` resolves `12.0.0-alpha.14` cleanly

## Follow-up (not in this PR)

Consider `npm deprecate '@alecsibilia/luca-framework@12.0.0-alpha.13' 'broken install — use >=12.0.0-alpha.14'` so anyone pinning the exact broken version gets a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)