### PR TITLE
fix(skills): rename stale v12 agent names → v13 (fixes subagents that couldn't write)

### DIFF
--- a/.changeset/fix-stale-v12-agent-names-in-skills.md
+++ b/.changeset/fix-stale-v12-agent-names-in-skills.md
@@ -1,0 +1,9 @@
+---
+"@alecsibilia/luca": patch
+---
+
+Fix skills spawning non-existent v12 agent names. The mastracode→luca-tools port renamed the agents (dropped the `lu-` prefix, consolidated reviewers into one `reviewer` subagent) but the skill bodies still used the old names — so `/lu` and friends spawned `subagent_type="lu-executor"`, `"lu-verifier"`, `"lu-phase-researcher"`, `"code-architect"`, etc., which don't resolve to any installed v13 agent. Claude Code then fell back to a generic/read-only agent that lacked the real agent's tools and instructions, which is why subagents "couldn't write" their own artifacts and the orchestrator had to persist everything.
+
+Renamed across all skills (both `subagent_type=` spawn values and imperative prose): `lu-executor`→`executor`, `lu-verifier`→`verifier`, `lu-learner`→`learner`, `lu-phase-researcher`/`lu-project-researcher`→`researcher`, `lu-plan-checker`→`plan-reviewer`, and the per-perspective reviewers (`code-architect`/`dx-advocate`/`code-simplifier`/`security-auditor`/`ui`)→`reviewer` (perspective passed in the prompt).
+
+Still pending (dropped agents with no v13 equivalent — left in place, tracked separately): the tribunal pattern (`lu-integration-checker` + defender/challenger), `lu-test-writer`, `lu-roadmapper`, `lu-research-synthesizer`, and the `resolveModelForAgent`/`model-routing.ts` prose (that module was not ported to v13).

--- a/packages/luca-tools/src/artifacts/skills/milestone-audit/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/milestone-audit/index.ts
@@ -199,7 +199,7 @@ issues:
 
 If no issues: \`issues: []\`
 """,
-subagent_type="dx-advocate",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="Milestone DX review"
 )
@@ -228,7 +228,7 @@ issues:
 \`\`\`
 
 """,
-subagent_type="code-simplifier",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="Milestone simplification review"
 )
@@ -257,7 +257,7 @@ issues:
 \`\`\`
 
 """,
-subagent_type="code-architect",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="Milestone architecture review"
 )
@@ -286,7 +286,7 @@ issues:
 \`\`\`
 
 """,
-subagent_type="ui",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="Milestone Tailwind review"
 )
@@ -315,7 +315,7 @@ issues:
 \`\`\`
 
 """,
-subagent_type="security-auditor",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="Milestone security review"
 )

--- a/packages/luca-tools/src/artifacts/skills/milestone-complete/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/milestone-complete/index.ts
@@ -33,7 +33,7 @@ Before archiving, ensure all session learnings are captured:
    mcp__muninn__muninn_recall(vault: "default", context: "current session context and unextracted findings")
    \`\`\`
 
-2. **Invoke lu-learner** if candidate learnings exist
+2. **Invoke learner** if candidate learnings exist
 
 3. **Review milestone-specific insights** in MuninnDB:
    - Patterns that were validated multiple times -> bump to High confidence via \`mcp__muninn__muninn_evolve\`

--- a/packages/luca-tools/src/artifacts/skills/phase-execute/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/phase-execute/index.ts
@@ -60,7 +60,7 @@ Each sub-agent receives only the context documents appropriate for its role and 
 
 ### Verification
 
-Invoke lu-verifier with mode based on phase complexity:
+Invoke verifier with mode based on phase complexity:
 
 | Phase Scope        | Verification Mode               |
 | ------------------ | ------------------------------- |
@@ -73,7 +73,7 @@ Invoke lu-verifier with mode based on phase complexity:
 
 After verification (pass or fail):
 
-**MANDATORY**: You MUST spawn a lu-learner sub-agent. Do NOT attempt to capture learnings yourself.
+**MANDATORY**: You MUST spawn a learner sub-agent. Do NOT attempt to capture learnings yourself.
 
 First, read the required context:
 
@@ -125,7 +125,7 @@ Task(
 
 Extract learnings from this phase execution and store in MuninnDB.
 """,
-  subagent_type="lu-learner",
+  subagent_type="learner",
   model="{learner_model}",
   description="Capture phase learnings"
 )
@@ -144,8 +144,8 @@ Extract learnings from this phase execution and store in MuninnDB.
 | CRITICAL   | Full + debrief (include retrospective analysis) | balanced                        |
 
 For TRIVIAL/SIMPLE: Include only execution summary, not full working memory.
-For MODERATE and above: Use the current lu-learner spawn as-is.
-For CRITICAL: Add to the lu-learner prompt: "Include a retrospective analysis: what went well, what didn't, what would you do differently?"
+For MODERATE and above: Use the current learner spawn as-is.
+For CRITICAL: Add to the learner prompt: "Include a retrospective analysis: what went well, what didn't, what would you do differently?"
 
 The model tier for lu-learner is resolved via \`resolveModelForAgent("lu-learner", complexity)\` from the centralized routing table in \`src/complexity/__helpers/model-routing.ts\`.
 
@@ -225,7 +225,7 @@ Commits will not reference issues and PR creation will require manual setup.
 
 **Skip if:** \`--skip-replay\` flag passed.
 
-Before executing plans, check for replayable procedures that match the phase objective. High-confidence procedures (composite score >= 0.7, success_rate >= 0.5, 3+ executions) are surfaced as suggested pre-plans for lu-executor.
+Before executing plans, check for replayable procedures that match the phase objective. High-confidence procedures (composite score >= 0.7, success_rate >= 0.5, 3+ executions) are surfaced as suggested pre-plans for executor.
 
 \`\`\`bash
 # Read phase objective from the roadmap or plan files
@@ -242,7 +242,7 @@ Parse the recall result to determine if relevant procedures exist (REPLAY_COUNT)
 
 **If replayable procedures found (REPLAY_COUNT > 0):**
 
-Store \`REPLAY_JSON\` for injection into lu-executor context. When spawning lu-executor for each plan, include the pre-plans as additional context:
+Store \`REPLAY_JSON\` for injection into executor context. When spawning executor for each plan, include the pre-plans as additional context:
 
 \`\`\`
 <procedure_replay_context>
@@ -283,12 +283,12 @@ Continue normally. No pre-plan context is injected.
 For each wave in order:
 
 - Read plan contents (@ syntax doesn't work across Task boundaries)
-- Spawn \`lu-executor\` for each plan in wave (parallel Task calls)
+- Spawn \`executor\` for each plan in wave (parallel Task calls)
 - Wait for completion
 - Verify SUMMARYs created
 - Proceed to next wave
 
-**MANDATORY**: You MUST spawn lu-executor sub-agents for each plan. Do NOT attempt to execute plans yourself.
+**MANDATORY**: You MUST spawn executor sub-agents for each plan. Do NOT attempt to execute plans yourself.
 
 First, read plan contents (required because @ syntax doesn't work across Task boundaries):
 
@@ -343,7 +343,7 @@ Task(
 
 Execute this plan. Return SUMMARY when complete.
 """,
-  subagent_type="lu-executor",
+  subagent_type="executor",
   model="{executor_model}",
   description="Execute {plan_01_name}"
 )
@@ -381,7 +381,7 @@ Task(
 
 Execute this plan. Return SUMMARY when complete.
 """,
-  subagent_type="lu-executor",
+  subagent_type="executor",
   model="{executor_model}",
   description="Execute {plan_02_name}"
 )
@@ -795,7 +795,7 @@ Task(
 
 Fix these harness failures.
 """,
-  subagent_type="lu-executor",
+  subagent_type="executor",
   model="{executor_model}",
   description="Fix harness failures (Loop A, iteration {N})"
 )
@@ -865,7 +865,7 @@ This ensures that:
 
 ### 7. Verify Phase Goal
 
-**MANDATORY**: You MUST spawn a lu-verifier sub-agent. Do NOT attempt to verify yourself.
+**MANDATORY**: You MUST spawn a verifier sub-agent. Do NOT attempt to verify yourself.
 
 First, read the required context:
 
@@ -939,7 +939,7 @@ plan.md contents are included above. Use them in Step 2.5 (Specification Anchori
 
 Verify the phase goal was achieved using goal-backward analysis.
 """,
-  subagent_type="lu-verifier",
+  subagent_type="verifier",
   model="{verifier_model}",
   description="Verify Phase {phase_number}"
 )
@@ -995,7 +995,7 @@ Analyze the T1/T3 conflict from your perspective as test coverage expert.
   description="Test Writer Diagnostic"
 )
 
-# Spawn lu-verifier diagnostic (IN PARALLEL)
+# Spawn verifier diagnostic (IN PARALLEL)
 Task(
   prompt="""
 <diagnostic_context>
@@ -1007,7 +1007,7 @@ Task(
 Re-examine your T3 analysis for potential over-specification.
 </diagnostic_context>
 """,
-  subagent_type="lu-verifier",
+  subagent_type="verifier",
   model="{diagnostic_model}",
   description="Verifier Diagnostic"
 )
@@ -1160,7 +1160,7 @@ Task(
 
 Fix the verification gaps for this plan.
 """,
-  subagent_type="lu-executor",
+  subagent_type="executor",
   model="{executor_model}",
   description="Fix verify gaps for {plan_name} (Loop B, iteration {N})"
 )
@@ -1194,7 +1194,7 @@ Task(
 
 Re-verify the phase goal after gap fix iteration {N}.
 """,
-  subagent_type="lu-verifier",
+  subagent_type="verifier",
   model="{verifier_model}",
   description="Re-verify Phase {phase_number} (Loop B, iteration {N})"
 )
@@ -1320,7 +1320,7 @@ issues:
 
 If no issues found, return: \`issues: []\`
 """,
-subagent_type="dx-advocate",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="DX review"
 )
@@ -1350,7 +1350,7 @@ issues:
 
 If no issues found, return: \`issues: []\`
 """,
-subagent_type="code-simplifier",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="Simplification review"
 )
@@ -1380,7 +1380,7 @@ issues:
 
 If no issues found, return: \`issues: []\`
 """,
-subagent_type="code-architect",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="Architecture review"
 )
@@ -1410,7 +1410,7 @@ issues:
 
 If no issues found, return: \`issues: []\`
 """,
-subagent_type="ui",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="Tailwind review"
 )
@@ -1442,7 +1442,7 @@ issues:
 
 If no issues found, return: \`issues: []\`
 """,
-subagent_type="security-auditor",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="Security review"
 )
@@ -1689,7 +1689,7 @@ All code reviews passed ✓
 - Spawn parallel debug agents to diagnose root causes
 - **Root Cause Tribunal (conditional):** When debug agents return ROOT CAUSE FOUND during UAT diagnosis, check tribunal gating conditions before creating fix plans:
   - Gate: \`root_cause_tribunal_enabled\` in config (default: true) AND complexity is COMPLEX+ AND multi-issue debugging (issue_count >= 2)
-  - When gated in: Spawn three tribunal agents in parallel (lu-debugger as defender, lu-verifier as challenger, lu-integration-checker as arbiter) to validate the proposed fix before planning
+  - When gated in: Spawn three tribunal agents in parallel (lu-debugger as defender, verifier as challenger, lu-integration-checker as arbiter) to validate the proposed fix before planning
   - Resolution: "verified_fix" proceeds to fix planning; "needs_deeper_investigation" re-runs diagnosis with tribunal findings as additional context
 - Re-invoke the architect mode-agent (in --gaps context) to create fix plans
 - Spawn the \`plan-reviewer\` subagent to verify fix plans

--- a/packages/luca-tools/src/artifacts/skills/phase-plan/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/phase-plan/index.ts
@@ -168,7 +168,7 @@ The researcher model tier is resolved via \`resolveModelForAgent("lu-phase-resea
 WORKFLOW_RESEARCH=$(cat .luca/config.json 2>/dev/null | grep -o '"research"[[:space:]]*:[[:space:]]*[^,}]*' | grep -o 'true|false' || echo "true")
 \`\`\`
 
-**MANDATORY**: If research is needed, you MUST spawn a lu-phase-researcher sub-agent. Do NOT attempt to research yourself.
+**MANDATORY**: If research is needed, you MUST spawn a researcher sub-agent. Do NOT attempt to research yourself.
 
 First, read the required context:
 
@@ -219,7 +219,7 @@ Task(
 
 Research how to implement this phase. Analyze the codebase, identify patterns, and document findings.
 """,
-  subagent_type="lu-phase-researcher",
+  subagent_type="researcher",
   model="{researcher_model}",
   description="Research Phase {phase_number}"
 )
@@ -316,7 +316,7 @@ Task(
 - **CHECKPOINT REACHED:** Present to user, get response
 - **PLANNING INCONCLUSIVE:** Offer options to add context, retry, or manual
 
-### 10. Spawn lu-plan-checker Agent
+### 10. Spawn plan-reviewer Agent
 
 Display:
 
@@ -386,7 +386,7 @@ Task(
 
 Verify these plans will achieve the phase goal when executed.
 """,
-  subagent_type="lu-plan-checker",
+  subagent_type="plan-reviewer",
   model="{checker_model}",
   description="Verify Phase {phase_number} plans"
 )
@@ -445,7 +445,7 @@ If issues found and iteration_count < planVerificationIterations:
 - [ ] Research completed (unless --skip-research or --gaps or exists)
 - [ ] architect mode-agent invoked with planning context (researcher + plan-reviewer subagents spawned as required)
 - [ ] Plans created
-- [ ] lu-plan-checker spawned (unless --skip-verify)
+- [ ] plan-reviewer spawned (unless --skip-verify)
 - [ ] Verification passed OR user override
 - [ ] User knows next steps (execute or review)
 

--- a/packages/luca-tools/src/artifacts/skills/phase-research/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/phase-research/index.ts
@@ -39,7 +39,7 @@ Goes beyond "which library" to ecosystem knowledge:
 
 2. **Spawn researcher:**
 
-   - Use lu-phase-researcher agent
+   - Use researcher agent
    - Focus on ecosystem knowledge for the domain
 
 3. **Create research.md:**

--- a/packages/luca-tools/src/artifacts/skills/post-init-tour/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/post-init-tour/index.ts
@@ -32,7 +32,7 @@ Skills are user-invocable workflows triggered by /commands (e.g., /phase-plan, /
 
 ### Step 3: Agents -- Specialized AI Workers
 
-Agents are specialized sub-agents that handle focused tasks: lu-router classifies complexity, lu-executor runs code changes, lu-verifier validates results, and reviewers audit code quality. They are spawned automatically during workflow execution.
+Agents are specialized sub-agents that handle focused tasks: lu-router classifies complexity, executor runs code changes, verifier validates results, and reviewers audit code quality. They are spawned automatically during workflow execution.
 
 ### Step 4: Phases -- Structured Development
 

--- a/packages/luca-tools/src/artifacts/skills/project-new/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/project-new/index.ts
@@ -21,7 +21,7 @@ This skill is an **orchestrator**. YOU MUST delegate work to sub-agents using th
 
 **Required sub-agents for this skill:**
 
-- \`lu-project-researcher\` - Domain research (4 parallel agents for Stack, Features, Architecture, Pitfalls)
+- \`researcher\` - Domain research (4 parallel agents for Stack, Features, Architecture, Pitfalls)
 - \`lu-research-synthesizer\` - Synthesizes research outputs into SUMMARY.md
 - \`lu-roadmapper\` - Creates \`.luca/roadmap.md\` from requirements via \`luca roadmap create\`
 
@@ -38,7 +38,7 @@ MODEL_PROFILE=$(cat .luca/config.json 2>/dev/null | grep -o '"model_profile"[[:s
 
 | Agent                      | quality | balanced | budget |
 | -------------------------- | ------- | -------- | ------ |
-| lu-project-researcher   | opus    | sonnet   | haiku  |
+| researcher   | opus    | sonnet   | haiku  |
 | lu-research-synthesizer | opus    | sonnet   | haiku  |
 | lu-roadmapper           | opus    | opus     | sonnet |
 
@@ -289,7 +289,7 @@ Task(
 
 Research the optimal technology stack for this project.
 """,
-  subagent_type="lu-project-researcher",
+  subagent_type="researcher",
   model="{researcher_model}",
   description="Research Stack"
 )
@@ -320,7 +320,7 @@ Task(
 
 Research features and competitive landscape for this project.
 """,
-  subagent_type="lu-project-researcher",
+  subagent_type="researcher",
   model="{researcher_model}",
   description="Research Features"
 )
@@ -351,7 +351,7 @@ Task(
 
 Research architectural patterns and best practices for this project.
 """,
-  subagent_type="lu-project-researcher",
+  subagent_type="researcher",
   model="{researcher_model}",
   description="Research Architecture"
 )
@@ -382,7 +382,7 @@ Task(
 
 Research common pitfalls and risks for this project.
 """,
-  subagent_type="lu-project-researcher",
+  subagent_type="researcher",
   model="{researcher_model}",
   description="Research Pitfalls"
 )

--- a/packages/luca-tools/src/artifacts/skills/quick/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/quick/index.ts
@@ -149,7 +149,7 @@ Create a quick plan for this task.
 
 ### Step 6: Spawn Executor
 
-**MANDATORY**: You MUST spawn a lu-executor sub-agent. Do NOT attempt to execute yourself.
+**MANDATORY**: You MUST spawn a executor sub-agent. Do NOT attempt to execute yourself.
 
 First, read the plan:
 

--- a/packages/luca-tools/src/artifacts/skills/workflow-save/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/workflow-save/index.ts
@@ -101,7 +101,7 @@ Entities create the relational graph between memories. Use these types consisten
 | \`phase\` | \`phase-{NN}\` | \`phase-06\`, \`phase-03\` |
 | \`plan\` | plan filename | \`PLAN-06-01.md\` |
 | \`branch\` | full branch name | \`53--v3-data-integrity\` |
-| \`agent\` | agent name | \`lu-executor\`, \`lu-verifier\` |
+| \`agent\` | agent name | \`executor\`, \`verifier\` |
 | \`commit\` | short hash | \`a0acf99c\` |
 | \`project\` | project name | \`luca-framework\` |
 | \`error\` | fingerprint hash | \`err-5f3a\` |
@@ -231,8 +231,8 @@ After Phase 06 completes, the skill produces these memories:
 3. **commit**: "a0acf99c — docs(05-01,05-02): verify Phase 5 agentic reliability todos"
 4. **commit**: "506bbba6 — fix(03-01): add eventType/timestamp indexes to observer_events"
 5. **convergence**: "Phase 06 converged in 1 iteration. Error count: 0, delta: 0, status: improved."
-6. **agent_invocation**: "lu-executor: 3 invocations, 3 success, avg 42s, model: sonnet"
-7. **agent_invocation**: "lu-verifier: 1 invocation, 1 success, 18s, model: sonnet"
+6. **agent_invocation**: "executor: 3 invocations, 3 success, avg 42s, model: sonnet"
+7. **agent_invocation**: "verifier: 1 invocation, 1 success, 18s, model: sonnet"
 
 Then links:
 
@@ -246,7 +246,7 @@ Then links:
 At session pause, the skill produces:
 
 1. **session_end**: "Session sess-abc123 ended after 2h15m. Completed phases 05, 06. 4 commits. Paused: context window approaching limit."
-2. **scorecard_snapshot**: "Agent scorecard at session end: lu-executor 6/6 success avg 40s, lu-verifier 2/2 success avg 20s, lu-cognition 1/1 success avg 8s."
+2. **scorecard_snapshot**: "Agent scorecard at session end: executor 6/6 success avg 40s, verifier 2/2 success avg 20s, lu-cognition 1/1 success avg 8s."
 
 Links:
 


### PR DESCRIPTION
## Summary

A live `/lu` run surfaced that subagents "couldn't write their own artifacts" (the orchestrator had to persist research.md / context.md / plan.md). Root cause: the mastracode→luca-tools port **renamed/consolidated the agents** (dropped the `lu-` prefix; merged the per-perspective reviewers into one `reviewer` subagent) but the **skill bodies kept the v12 names**. So `/lu` and friends spawned `subagent_type="lu-executor"`, `"lu-verifier"`, `"lu-phase-researcher"`, `"code-architect"`, etc. — none of which resolve to an installed v13 agent. Claude Code fell back to a generic/read-only agent without the real agent's tools or instructions, hence the inability to write artifacts.

This was a **repo-wide audit** (per request) across all artifact types. Stale `subagent_type=` values were found only in skills; modes/subagents/commands were clean.

## Renamed (clear 1:1, both `subagent_type=` and imperative prose)
| v12 (stale) | → v13 |
|---|---|
| `lu-executor` | `executor` |
| `lu-verifier` | `verifier` |
| `lu-learner` | `learner` |
| `lu-phase-researcher`, `lu-project-researcher` | `researcher` |
| `lu-plan-checker` | `plan-reviewer` |
| `code-architect`/`dx-advocate`/`code-simplifier`/`security-auditor`/`ui` | `reviewer` (perspective in prompt) |

~24 spawn values + ~28 prose references across 9 skills. Routing/telemetry lines (`resolveModelForAgent`, example JSON) were deliberately preserved.

## Still pending — dropped agents with no v13 equivalent (tracked, NOT renamed)
These reference agents the restructure dropped; renaming won't fix them — each needs a map-to-closest / inline / remove decision:
- **Tribunal pattern** — `lu-integration-checker` + `{defender_agent_type}`/`{challenger_agent_type}` (phase-execute, milestone-audit)
- `lu-test-writer` (phase-execute)
- `lu-roadmapper`, `lu-research-synthesizer` (project-new)
- The **`resolveModelForAgent` / `model-routing.ts`** prose in 5 skills — that module was never ported to v13 (narrative only, not a runtime break).

## Verification
- tsc clean; umbrella rebuilds `skills:42`, no clear `lu-*` agent refs remain outside routing/telemetry lines.

Cuts `@alecsibilia/luca@13.0.0-alpha.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
