### PR TITLE
feat(agents): v13 agent-roster reconciliation — stale-name renames + tribunal/test-writer/debater + dropped-ref cleanup

### DIFF
--- a/.changeset/feat-v13-agent-roster-reconciliation.md
+++ b/.changeset/feat-v13-agent-roster-reconciliation.md
@@ -1,0 +1,19 @@
+---
+"@alecsibilia/luca": patch
+---
+
+Reconcile the v13 agent roster so every agent a skill spawns actually ships, and restore the beneficial tooling the port dropped. Previously skills referenced a dozen v12 agents that don't exist in v13 (they fell back to generic read-only agents), and the verification tribunal / model-tier routing referenced dropped subsystems.
+
+**New subagents (ported — genuinely reusable primitives):**
+- `test-writer` — authors focused, non-vacuous tests and runs them; tests are first-class in v13 again, and the tribunal uses it to settle a dispute with an empirical repro.
+- `debater` — stance-parameterized adversarial validator (DEFEND/CHALLENGE a proposition with calibrated confidence). The reusable primitive behind the verification tribunal and any decision that benefits from adversarial validation.
+
+**Extended:** `reviewer` gains an `integration` perspective (cross-phase wiring), replacing the dropped `lu-integration-checker`.
+
+**Verification tribunal** re-implemented on v13 agents: `debater` (defender/challenger) + `test-writer` (empirical repro) + `reviewer` (integration), with the orchestrator arbitrating by confidence-weighted majority. Used in phase-execute (diagnostic + root-cause tribunals) and milestone-audit (rebuttal round).
+
+**Dropped agents folded into existing agents / inline orchestration** (no dangling spawns): `lu-research-synthesizer`→`researcher`; `lu-roadmapper`→inline `luca roadmap create` (matching milestone-new); `lu-discuss-researcher`→`researcher`; `lu-repo-architect`→`architect`; the roadmap-revision swarm (`lu-pm-planner`, `lu-roadmap-architect/prioritizer/qa/synthesizer`)→`architect`/`reviewer` role spawns; `lu-cognition` (pre-flight) and `lu-router` (complexity) → inline orchestrator steps; `lu-pm-planner` (session WSJF)→`architect`.
+
+**Removed** the stale `resolveModelForAgent` / `model-routing.ts` prose across 6 skills — that module was never ported to v13; agent model tiers come from each agent's own definition / the harness default.
+
+Net roster: 10 subagents (was 8) + 10 mode-agents. Every `subagent_type=` across all skills now resolves to a real v13 agent.

--- a/.changeset/fix-stale-v12-agent-names-in-skills.md
+++ b/.changeset/fix-stale-v12-agent-names-in-skills.md
@@ -1,0 +1,9 @@
+---
+"@alecsibilia/luca": patch
+---
+
+Fix skills spawning non-existent v12 agent names. The mastracode→luca-tools port renamed the agents (dropped the `lu-` prefix, consolidated reviewers into one `reviewer` subagent) but the skill bodies still used the old names — so `/lu` and friends spawned `subagent_type="lu-executor"`, `"lu-verifier"`, `"lu-phase-researcher"`, `"code-architect"`, etc., which don't resolve to any installed v13 agent. Claude Code then fell back to a generic/read-only agent that lacked the real agent's tools and instructions, which is why subagents "couldn't write" their own artifacts and the orchestrator had to persist everything.
+
+Renamed across all skills (both `subagent_type=` spawn values and imperative prose): `lu-executor`→`executor`, `lu-verifier`→`verifier`, `lu-learner`→`learner`, `lu-phase-researcher`/`lu-project-researcher`→`researcher`, `lu-plan-checker`→`plan-reviewer`, and the per-perspective reviewers (`code-architect`/`dx-advocate`/`code-simplifier`/`security-auditor`/`ui`)→`reviewer` (perspective passed in the prompt).
+
+Still pending (dropped agents with no v13 equivalent — left in place, tracked separately): the tribunal pattern (`lu-integration-checker` + defender/challenger), `lu-test-writer`, `lu-roadmapper`, `lu-research-synthesizer`, and the `resolveModelForAgent`/`model-routing.ts` prose (that module was not ported to v13).

--- a/packages/luca-tools/src/artifacts/skills/autopilot/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/autopilot/index.ts
@@ -30,13 +30,11 @@ This skill is a **meta-orchestrator**. It chains other SKILLS and AGENTS in an a
 
 **Sub-agents spawned (via Task tool):**
 
-- \`lu-cognition\` — Cognitive pre-flight at session start
-- \`lu-router\` — Classify complexity for each phase
-- \`lu-pm-planner\` — WSJF scoring and backlog prioritization (fallback for \`--no-swarm\` roadmap revision)
-- \`lu-roadmap-architect\` — Architectural impact analysis for roadmap revision (swarm specialist)
-- \`lu-roadmap-prioritizer\` — WSJF scoring and milestone scoping for roadmap revision (swarm specialist)
-- \`lu-roadmap-qa\` — Testing gap analysis and QA impact for roadmap revision (swarm specialist)
-- \`lu-roadmap-synthesizer\` — Merges specialist analyses into unified roadmap proposal (swarm synthesizer)
+- \`architect\` — phase planning, and roadmap-revision analysis spawned once per role (architectural impact, WSJF prioritization/scoping, and synthesis of the specialist analyses).
+- \`reviewer\` — testing-gap / QA-impact analysis for roadmap revision (perspective: test-quality/integration), plus standard code review.
+- \`researcher\`, \`executor\`, \`verifier\`, \`plan-reviewer\`, \`learner\` — the standard per-phase pipeline agents, invoked through the phase skills.
+
+Cognitive pre-flight and complexity classification are inline orchestrator steps in v13 (no separate \`cognition\`/\`router\` agents).
 
 **CRITICAL — WORKFLOW COMPLIANCE IS MANDATORY:**
 
@@ -109,13 +107,12 @@ MAX_PARALLEL=$(echo "$CONFIG" | bun -e "
 
 ### 0c. Cognitive Pre-Flight
 
-Unless the session already has cognitive context loaded:
+Unless the session already has cognitive context loaded, run cognitive pre-flight INLINE (v13 folds this into the orchestrator — there is no separate cognition agent):
 
 \`\`\`
-Task(
-  agent: "lu-cognition",
-  prompt: "Run cognitive pre-flight for autopilot session. Load project identity via mcp__muninn__muninn_recall_tree(vault: 'default', id: 'brain:project-identity'). Recall relevant patterns via mcp__muninn__muninn_recall(vault: 'default', context: 'relevant patterns and decisions for planning and workflow'). Clear previous session context via mcp__muninn__muninn_forget(vault: 'default', id: 'session:*')."
-)
+mcp__muninn__muninn_recall_tree(vault: "default", id: "brain:project-identity")
+mcp__muninn__muninn_recall(vault: "default", context: "relevant patterns and decisions for planning and workflow")
+mcp__muninn__muninn_forget(vault: "default", id: "session:*")
 \`\`\`
 
 ### 0d. Display Session Start & Initialize State Machine
@@ -216,11 +213,11 @@ TODO_CONTENTS=$(luca todo list --status pending --format json)
 
 #### Path A: Single-Agent (--no-swarm fallback)
 
-**If SWARM_ENABLED == false:** Use the original single lu-pm-planner agent path.
+**If SWARM_ENABLED == false:** Use the original single architect agent path.
 
 \`\`\`
 Task(
-  agent: "lu-pm-planner",
+  agent: "architect",
   prompt: """
 <planning_context>
 **Mode:** roadmap-revision (extended)
@@ -255,7 +252,7 @@ Task(
 )
 \`\`\`
 
-Skip to Step 2b with the lu-pm-planner's ResultEnvelope.
+Skip to Step 2b with the architect's ResultEnvelope.
 
 ---
 
@@ -300,9 +297,9 @@ TaskCreate(
 Task(
   team_name: "roadmap-revision-{timestamp}",
   name: "architect",
-  subagent_type: "lu-roadmap-architect",
+  subagent_type: "architect",
   prompt: """
-  You are a roadmap architect specialist (lu-roadmap-architect role).
+  You are a roadmap architect specialist (architect role).
 
   **All Pending Todos:**
   {TODO_CONTENTS}
@@ -329,9 +326,9 @@ Task(
 Task(
   team_name: "roadmap-revision-{timestamp}",
   name: "prioritizer",
-  subagent_type: "lu-roadmap-prioritizer",
+  subagent_type: "architect",
   prompt: """
-  You are a roadmap prioritizer specialist (lu-roadmap-prioritizer role).
+  You are a roadmap prioritizer specialist (architect role).
 
   **All Pending Todos:**
   {TODO_CONTENTS}
@@ -358,9 +355,9 @@ Task(
 Task(
   team_name: "roadmap-revision-{timestamp}",
   name: "qa-analyst",
-  subagent_type: "lu-roadmap-qa",
+  subagent_type: "reviewer",
   prompt: """
-  You are a roadmap QA specialist (lu-roadmap-qa role).
+  You are a roadmap QA specialist (reviewer role).
 
   **All Pending Todos:**
   {TODO_CONTENTS}
@@ -392,7 +389,7 @@ Wait for all 3 specialists to send their ResultEnvelopes (10-minute timeout per 
 **Graceful degradation:**
 - If 1 specialist times out or errors: proceed with 2 specialist outputs, note the gap
 - If 2 specialists time out: proceed with 1 output, set confidence to LOW
-- If all 3 fail: fall back to Path A (single lu-pm-planner)
+- If all 3 fail: fall back to Path A (single architect)
 
 ##### 2a-swarm-iv. Spawn Synthesizer
 
@@ -402,9 +399,9 @@ After collecting specialist outputs, spawn the synthesizer with all results:
 Task(
   team_name: "roadmap-revision-{timestamp}",
   name: "synthesizer",
-  subagent_type: "lu-roadmap-synthesizer",
+  subagent_type: "architect",
   prompt: """
-  You are a roadmap synthesizer (lu-roadmap-synthesizer role).
+  You are a roadmap synthesizer (architect role).
 
   **Architect Analysis:**
   {ARCHITECT_RESULT}
@@ -689,14 +686,7 @@ Wait for user input. Route by choice.
 
 ### 4c. Complexity Classification
 
-Spawn lu-router to classify:
-
-\`\`\`
-Task(
-  agent: "lu-router",
-  prompt: "Classify complexity for Phase {NN}: {phase_goal}. Consider file count, scope, and risk. Output: TRIVIAL, SIMPLE, MODERATE, COMPLEX, or CRITICAL."
-)
-\`\`\`
+Classify complexity INLINE (v13 folds the legacy router into the orchestrator — there is no separate router agent): read \`{phase_goal}\` and pick one of \`TRIVIAL | SIMPLE | MODERATE | COMPLEX | CRITICAL\` based on file count, scope, and risk.
 
 Advance the pipeline step (the legacy "routing" step is folded into \`triage\` → \`research\`/\`discuss\` in v13). Complexity is recorded in the orchestrator's reasoning and passed to every subagent — there's no separate state field for it:
 

--- a/packages/luca-tools/src/artifacts/skills/lu/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/lu/index.ts
@@ -33,7 +33,7 @@ This skill uses TWO delegation mechanisms:
 
 ### Model Resolution
 
-Models are resolved at runtime via \`resolveModelForAgent(agentName, complexity)\` from the centralized routing table (\`src/complexity/__helpers/model-routing.ts\`). The skill does not pick model strings — it spawns the named agent and the routing layer handles tier selection.
+Models are set by each agent’s own definition (and the harness default). The skill does not pick model strings — it spawns the named agent and the routing layer handles tier selection.
 
 </sub-agent_delegation_requirements>
 
@@ -53,7 +53,7 @@ If the user passed a request but the pipeline is already mid-flight, surface tha
 
 Triage runs once, at the start of a run. It is inline here — there is no separate triage skill.
 
-1. **Classify complexity.** Read the request. Pick one of \`TRIVIAL | SIMPLE | MODERATE | COMPLEX | CRITICAL\` based on file count, scope, and risk. There is no CLI command to persist complexity — record it in your reasoning and pass it to every subagent you spawn (the model-routing table keys off it). If \`--complexity=<level>\` or \`--force-complex\` was passed, use that directly.
+1. **Classify complexity.** Read the request. Pick one of \`TRIVIAL | SIMPLE | MODERATE | COMPLEX | CRITICAL\` based on file count, scope, and risk. There is no CLI command to persist complexity — record it in your reasoning and pass it to every subagent you spawn (pass it to any subagent whose behavior varies by complexity). If \`--complexity=<level>\` or \`--force-complex\` was passed, use that directly.
 2. **Build the roadmap.** Decompose the request into ordered phases. Each phase is one deliverable unit. Stage the phases array in a JSON file, then run \`luca roadmap create --file\`:
    \`\`\`
    # /tmp/luca-roadmap.json:

--- a/packages/luca-tools/src/artifacts/skills/milestone-audit/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/milestone-audit/index.ts
@@ -199,7 +199,7 @@ issues:
 
 If no issues: \`issues: []\`
 """,
-subagent_type="dx-advocate",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="Milestone DX review"
 )
@@ -228,7 +228,7 @@ issues:
 \`\`\`
 
 """,
-subagent_type="code-simplifier",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="Milestone simplification review"
 )
@@ -257,7 +257,7 @@ issues:
 \`\`\`
 
 """,
-subagent_type="code-architect",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="Milestone architecture review"
 )
@@ -286,7 +286,7 @@ issues:
 \`\`\`
 
 """,
-subagent_type="ui",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="Milestone Tailwind review"
 )
@@ -315,7 +315,7 @@ issues:
 \`\`\`
 
 """,
-subagent_type="security-auditor",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="Milestone security review"
 )

--- a/packages/luca-tools/src/artifacts/skills/milestone-audit/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/milestone-audit/index.ts
@@ -21,41 +21,10 @@ This skill is an **orchestrator**. YOU MUST delegate work to sub-agents using th
 
 **Required sub-agents for this skill:**
 
-- \`lu-integration-checker\` - Verifies cross-phase integration
-- \`dx-advocate\` - Code quality review (milestone-wide)
-- \`code-simplifier\` - DRY and complexity review
-- \`code-architect\` - Architecture coherence review
-- \`ui\` - Tailwind/styling review
-- \`security-auditor\` - Security review (milestone-wide)
+- \`reviewer\` — milestone-wide code review, spawned once per perspective. Use the perspectives: **integration** (cross-phase wiring), **architecture**, **dx**, **simplification**, **security**. The perspective is passed in the prompt (\`PERSPECTIVE: <name>\`); these are not separate agents.
+- \`debater\` — adversarial validation of disputed findings (defender vs challenger) in the rebuttal round.
 
-**DO NOT** attempt to check integration or review code yourself. Spawn the appropriate subagents via the \`Task\` tool.
-
-## Model Profile
-
-\`\`\`bash
-MODEL_PROFILE=$(cat .luca/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "balanced")
-\`\`\`
-
-**Model lookup table:**
-
-| Agent                     | quality | balanced | budget |
-| ------------------------- | ------- | -------- | ------ |
-| lu-integration-checker | sonnet  | sonnet   | haiku  |
-| dx-advocate               | opus    | sonnet   | haiku  |
-| code-simplifier           | opus    | sonnet   | haiku  |
-| code-architect            | opus    | sonnet   | haiku  |
-| tailwind-auditor          | opus    | sonnet   | haiku  |
-| security-auditor          | opus    | sonnet   | haiku  |
-
-> **Current Limitation:** Cursor's Task tool only supports \`model="fast"\` or inheriting from parent. This table is preserved for future compatibility.
-
-**Current model variable values:**
-
-\`\`\`
-# All audit agents require reasoning → omit (inherit from parent)
-integration_checker_model = (omit)
-reviewer_model = (omit)  # dx-advocate, code-simplifier, etc.
-\`\`\`
+**DO NOT** check integration or review code yourself — spawn \`reviewer\` subagents (one per perspective) via the \`Task\` tool. Agent model tiers come from each agent's own definition / the harness default; the orchestrator does not pick model strings.
 
 ## Process
 
@@ -123,10 +92,9 @@ gaps:
 
 </output_requirements>
 
-Verify cross-phase integration for this milestone.
+PERSPECTIVE: integration. Verify cross-phase integration for this milestone.
 """,
-subagent_type="lu-integration-checker",
-model="{checker_model}",
+subagent_type="reviewer",
 description="Integration check: v{version}"
 )
 
@@ -200,7 +168,6 @@ issues:
 If no issues: \`issues: []\`
 """,
 subagent_type="reviewer",
-model="{reviewer_model}",
 description="Milestone DX review"
 )
 
@@ -229,7 +196,6 @@ issues:
 
 """,
 subagent_type="reviewer",
-model="{reviewer_model}",
 description="Milestone simplification review"
 )
 
@@ -258,7 +224,6 @@ issues:
 
 """,
 subagent_type="reviewer",
-model="{reviewer_model}",
 description="Milestone architecture review"
 )
 
@@ -287,7 +252,6 @@ issues:
 
 """,
 subagent_type="reviewer",
-model="{reviewer_model}",
 description="Milestone Tailwind review"
 )
 
@@ -316,7 +280,6 @@ issues:
 
 """,
 subagent_type="reviewer",
-model="{reviewer_model}",
 description="Milestone security review"
 )
 
@@ -369,25 +332,32 @@ Running adversarial rebuttal round...
 
 #### 4.5.2 Rebuttal Round
 
-For each disagreement, spawn challenger and defender in PARALLEL:
+For each disagreement, spawn a challenger and a defender in PARALLEL using the
+\`debater\` subagent (the adversarial-validation primitive). Both receive the
+SAME proposition — the disputed finding — and opposing stances; you arbitrate
+by confidence-weighted majority over their structured verdicts.
 
 \\\`\\\`\\\`\\\`python
-# For each disagreement: spawn challenger and defender
-# Use the SAME reviewer agent type as the original finding
+# For each disagreement: spawn two debaters with opposing stances.
+# PROPOSITION = the disputed finding (e.g. "<finding> is a real, must-fix issue").
 
 Task(
   prompt="""
+PROPOSITION: {finding_as_proposition}
+STANCE: CHALLENGE
 {challenger_prompt from buildRebuttalPrompts, augmented with milestone context}
 """,
-  subagent_type="{challenger_agent_type}",
+  subagent_type="debater",
   description="Challenge: {finding_summary}"
 )
 
 Task(
   prompt="""
+PROPOSITION: {finding_as_proposition}
+STANCE: DEFEND
 {defender_prompt from buildRebuttalPrompts, augmented with milestone context}
 """,
-  subagent_type="{defender_agent_type}",
+  subagent_type="debater",
   description="Defend: {finding_summary}"
 )
 \\\`\\\`\\\`\\\`

--- a/packages/luca-tools/src/artifacts/skills/milestone-complete/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/milestone-complete/index.ts
@@ -33,7 +33,7 @@ Before archiving, ensure all session learnings are captured:
    mcp__muninn__muninn_recall(vault: "default", context: "current session context and unextracted findings")
    \`\`\`
 
-2. **Invoke lu-learner** if candidate learnings exist
+2. **Invoke learner** if candidate learnings exist
 
 3. **Review milestone-specific insights** in MuninnDB:
    - Patterns that were validated multiple times -> bump to High confidence via \`mcp__muninn__muninn_evolve\`

--- a/packages/luca-tools/src/artifacts/skills/phase-discuss/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/phase-discuss/index.ts
@@ -29,7 +29,7 @@ Extract implementation decisions that downstream agents need — researcher and 
 1. Analyze the phase to identify gray areas (same as interactive)
 2. Auto-select ALL gray areas (no user prompt)
 3. Load project tech stack from MuninnDB
-4. Spawn \`lu-discuss-researcher\` agent per gray area question (web research)
+4. Spawn \`researcher\` agent per gray area question (web research)
 5. Present research summary with citations before writing
 6. Offer user override: accept all / override some / switch to interactive
 7. Create context.md with researched decisions (annotated with source provenance)
@@ -50,7 +50,7 @@ COMPLEXITY=$(luca state read 2>/dev/null | jq -r '.complexity // "MODERATE"')
 
 **Always runs.** Discussion depth and model tier scale with complexity:
 
-| Complexity | Discussion Depth | Model Tier (lu-discuss-researcher) |
+| Complexity | Discussion Depth | Model Tier (researcher) |
 |------------|-----------------|-------------------------------------|
 | TRIVIAL | Light (2 questions per area) | fast |
 | SIMPLE | Light (2 questions per area) | balanced |
@@ -58,7 +58,7 @@ COMPLEXITY=$(luca state read 2>/dev/null | jq -r '.complexity // "MODERATE"')
 | COMPLEX | Extended (4+ questions per area) | capable |
 | CRITICAL | Thorough (6+ questions per area) | capable |
 
-The lu-discuss-researcher model tier is resolved via \`resolveModelForAgent("lu-discuss-researcher", complexity)\` from the centralized routing table.
+The researcher model tier is set by the agent’s own definition.
 
 1. **Validate phase number** (error if missing or not in roadmap)
 2. **Check if context.md exists** (offer update/view/skip if yes)
@@ -77,9 +77,9 @@ The lu-discuss-researcher model tier is resolved via \`resolveModelForAgent("lu-
 4a. **Analyze phase** — Same gray area identification as interactive mode
 5a. **Auto-select all gray areas** — No user prompt, select everything
 6a. **Load project identity from MuninnDB** — Extract project tech stack (languages, frameworks, conventions) via \`muninn_recall_tree(vault: "default", id: "brain:project-identity")\`
-7a. **Spawn lu-discuss-researcher per question** — For each gray area:
+7a. **Spawn researcher per question** — For each gray area:
     - Formulate a focused question from the gray area topic
-    - Spawn \`lu-discuss-researcher\` via Task() with: question, phase context, tech stack from MuninnDB
+    - Spawn \`researcher\` via Task() with: question, phase context, tech stack from MuninnDB
     - Collect the \`<research_result>\` response with recommendation, confidence, and sources
     - If \`researchable: false\`: flag for user input (even in auto mode)
 8a. **Present research summary** — Show consolidated results:

--- a/packages/luca-tools/src/artifacts/skills/phase-execute/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/phase-execute/index.ts
@@ -60,7 +60,7 @@ Each sub-agent receives only the context documents appropriate for its role and 
 
 ### Verification
 
-Invoke lu-verifier with mode based on phase complexity:
+Invoke verifier with mode based on phase complexity:
 
 | Phase Scope        | Verification Mode               |
 | ------------------ | ------------------------------- |
@@ -73,7 +73,7 @@ Invoke lu-verifier with mode based on phase complexity:
 
 After verification (pass or fail):
 
-**MANDATORY**: You MUST spawn a lu-learner sub-agent. Do NOT attempt to capture learnings yourself.
+**MANDATORY**: You MUST spawn a learner sub-agent. Do NOT attempt to capture learnings yourself.
 
 First, read the required context:
 
@@ -125,7 +125,7 @@ Task(
 
 Extract learnings from this phase execution and store in MuninnDB.
 """,
-  subagent_type="lu-learner",
+  subagent_type="learner",
   model="{learner_model}",
   description="Capture phase learnings"
 )
@@ -144,8 +144,8 @@ Extract learnings from this phase execution and store in MuninnDB.
 | CRITICAL   | Full + debrief (include retrospective analysis) | balanced                        |
 
 For TRIVIAL/SIMPLE: Include only execution summary, not full working memory.
-For MODERATE and above: Use the current lu-learner spawn as-is.
-For CRITICAL: Add to the lu-learner prompt: "Include a retrospective analysis: what went well, what didn't, what would you do differently?"
+For MODERATE and above: Use the current learner spawn as-is.
+For CRITICAL: Add to the learner prompt: "Include a retrospective analysis: what went well, what didn't, what would you do differently?"
 
 The model tier for lu-learner is resolved via \`resolveModelForAgent("lu-learner", complexity)\` from the centralized routing table in \`src/complexity/__helpers/model-routing.ts\`.
 
@@ -225,7 +225,7 @@ Commits will not reference issues and PR creation will require manual setup.
 
 **Skip if:** \`--skip-replay\` flag passed.
 
-Before executing plans, check for replayable procedures that match the phase objective. High-confidence procedures (composite score >= 0.7, success_rate >= 0.5, 3+ executions) are surfaced as suggested pre-plans for lu-executor.
+Before executing plans, check for replayable procedures that match the phase objective. High-confidence procedures (composite score >= 0.7, success_rate >= 0.5, 3+ executions) are surfaced as suggested pre-plans for executor.
 
 \`\`\`bash
 # Read phase objective from the roadmap or plan files
@@ -242,7 +242,7 @@ Parse the recall result to determine if relevant procedures exist (REPLAY_COUNT)
 
 **If replayable procedures found (REPLAY_COUNT > 0):**
 
-Store \`REPLAY_JSON\` for injection into lu-executor context. When spawning lu-executor for each plan, include the pre-plans as additional context:
+Store \`REPLAY_JSON\` for injection into executor context. When spawning executor for each plan, include the pre-plans as additional context:
 
 \`\`\`
 <procedure_replay_context>
@@ -283,12 +283,12 @@ Continue normally. No pre-plan context is injected.
 For each wave in order:
 
 - Read plan contents (@ syntax doesn't work across Task boundaries)
-- Spawn \`lu-executor\` for each plan in wave (parallel Task calls)
+- Spawn \`executor\` for each plan in wave (parallel Task calls)
 - Wait for completion
 - Verify SUMMARYs created
 - Proceed to next wave
 
-**MANDATORY**: You MUST spawn lu-executor sub-agents for each plan. Do NOT attempt to execute plans yourself.
+**MANDATORY**: You MUST spawn executor sub-agents for each plan. Do NOT attempt to execute plans yourself.
 
 First, read plan contents (required because @ syntax doesn't work across Task boundaries):
 
@@ -343,7 +343,7 @@ Task(
 
 Execute this plan. Return SUMMARY when complete.
 """,
-  subagent_type="lu-executor",
+  subagent_type="executor",
   model="{executor_model}",
   description="Execute {plan_01_name}"
 )
@@ -381,7 +381,7 @@ Task(
 
 Execute this plan. Return SUMMARY when complete.
 """,
-  subagent_type="lu-executor",
+  subagent_type="executor",
   model="{executor_model}",
   description="Execute {plan_02_name}"
 )
@@ -795,7 +795,7 @@ Task(
 
 Fix these harness failures.
 """,
-  subagent_type="lu-executor",
+  subagent_type="executor",
   model="{executor_model}",
   description="Fix harness failures (Loop A, iteration {N})"
 )
@@ -865,7 +865,7 @@ This ensures that:
 
 ### 7. Verify Phase Goal
 
-**MANDATORY**: You MUST spawn a lu-verifier sub-agent. Do NOT attempt to verify yourself.
+**MANDATORY**: You MUST spawn a verifier sub-agent. Do NOT attempt to verify yourself.
 
 First, read the required context:
 
@@ -939,7 +939,7 @@ plan.md contents are included above. Use them in Step 2.5 (Specification Anchori
 
 Verify the phase goal was achieved using goal-backward analysis.
 """,
-  subagent_type="lu-verifier",
+  subagent_type="verifier",
   model="{verifier_model}",
   description="Verify Phase {phase_number}"
 )
@@ -995,7 +995,7 @@ Analyze the T1/T3 conflict from your perspective as test coverage expert.
   description="Test Writer Diagnostic"
 )
 
-# Spawn lu-verifier diagnostic (IN PARALLEL)
+# Spawn verifier diagnostic (IN PARALLEL)
 Task(
   prompt="""
 <diagnostic_context>
@@ -1007,7 +1007,7 @@ Task(
 Re-examine your T3 analysis for potential over-specification.
 </diagnostic_context>
 """,
-  subagent_type="lu-verifier",
+  subagent_type="verifier",
   model="{diagnostic_model}",
   description="Verifier Diagnostic"
 )
@@ -1160,7 +1160,7 @@ Task(
 
 Fix the verification gaps for this plan.
 """,
-  subagent_type="lu-executor",
+  subagent_type="executor",
   model="{executor_model}",
   description="Fix verify gaps for {plan_name} (Loop B, iteration {N})"
 )
@@ -1194,7 +1194,7 @@ Task(
 
 Re-verify the phase goal after gap fix iteration {N}.
 """,
-  subagent_type="lu-verifier",
+  subagent_type="verifier",
   model="{verifier_model}",
   description="Re-verify Phase {phase_number} (Loop B, iteration {N})"
 )
@@ -1320,7 +1320,7 @@ issues:
 
 If no issues found, return: \`issues: []\`
 """,
-subagent_type="dx-advocate",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="DX review"
 )
@@ -1350,7 +1350,7 @@ issues:
 
 If no issues found, return: \`issues: []\`
 """,
-subagent_type="code-simplifier",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="Simplification review"
 )
@@ -1380,7 +1380,7 @@ issues:
 
 If no issues found, return: \`issues: []\`
 """,
-subagent_type="code-architect",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="Architecture review"
 )
@@ -1410,7 +1410,7 @@ issues:
 
 If no issues found, return: \`issues: []\`
 """,
-subagent_type="ui",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="Tailwind review"
 )
@@ -1442,7 +1442,7 @@ issues:
 
 If no issues found, return: \`issues: []\`
 """,
-subagent_type="security-auditor",
+subagent_type="reviewer",
 model="{reviewer_model}",
 description="Security review"
 )
@@ -1689,7 +1689,7 @@ All code reviews passed ✓
 - Spawn parallel debug agents to diagnose root causes
 - **Root Cause Tribunal (conditional):** When debug agents return ROOT CAUSE FOUND during UAT diagnosis, check tribunal gating conditions before creating fix plans:
   - Gate: \`root_cause_tribunal_enabled\` in config (default: true) AND complexity is COMPLEX+ AND multi-issue debugging (issue_count >= 2)
-  - When gated in: Spawn three tribunal agents in parallel (lu-debugger as defender, lu-verifier as challenger, lu-integration-checker as arbiter) to validate the proposed fix before planning
+  - When gated in: Spawn three tribunal agents in parallel (lu-debugger as defender, verifier as challenger, lu-integration-checker as arbiter) to validate the proposed fix before planning
   - Resolution: "verified_fix" proceeds to fix planning; "needs_deeper_investigation" re-runs diagnosis with tribunal findings as additional context
 - Re-invoke the architect mode-agent (in --gaps context) to create fix plans
 - Spawn the \`plan-reviewer\` subagent to verify fix plans

--- a/packages/luca-tools/src/artifacts/skills/phase-execute/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/phase-execute/index.ts
@@ -126,14 +126,13 @@ Task(
 Extract learnings from this phase execution and store in MuninnDB.
 """,
   subagent_type="learner",
-  model="{learner_model}",
   description="Capture phase learnings"
 )
 \`\`\`
 
 **Do NOT proceed until the Task returns.**
 
-**Learning capture always runs.** The lu-learner model tier is resolved from the routing table based on complexity:
+**Learning capture always runs.** The learner model tier comes from the agent definition:
 
 | Complexity | Learning Depth                                  | Model Tier (from routing table) |
 | ---------- | ----------------------------------------------- | ------------------------------- |
@@ -147,7 +146,7 @@ For TRIVIAL/SIMPLE: Include only execution summary, not full working memory.
 For MODERATE and above: Use the current learner spawn as-is.
 For CRITICAL: Add to the learner prompt: "Include a retrospective analysis: what went well, what didn't, what would you do differently?"
 
-The model tier for lu-learner is resolved via \`resolveModelForAgent("lu-learner", complexity)\` from the centralized routing table in \`src/complexity/__helpers/model-routing.ts\`.
+The model tier for learner is set by the agent’s own definition.
 
 ### Session Logging During Execution
 
@@ -168,13 +167,7 @@ Track:
 
 ## Process
 
-### 0. Resolve Model Profile
-
-\`\`\`bash
-MODEL_PROFILE=$(cat .luca/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "balanced")
-\`\`\`
-
-Models are resolved at runtime via \`resolveModelForAgent(agentName, complexity)\` from the centralized routing table (\`src/complexity/__helpers/model-routing.ts\`) — the orchestrator does not pick model strings. Lightweight agents (e.g. \`learner\`) inherit the fast tier; reasoning-intensive subagents (\`executor\`, \`verifier\`, \`plan-reviewer\`, \`reviewer\`) inherit the balanced or capable tier depending on complexity.
+> Model tiers come from each agent's own definition (and the harness default); this orchestrator never picks model strings.
 
 ### 0.5. Verify GitHub Tracking (Gate)
 
@@ -344,7 +337,6 @@ Task(
 Execute this plan. Return SUMMARY when complete.
 """,
   subagent_type="executor",
-  model="{executor_model}",
   description="Execute {plan_01_name}"
 )
 
@@ -382,7 +374,6 @@ Task(
 Execute this plan. Return SUMMARY when complete.
 """,
   subagent_type="executor",
-  model="{executor_model}",
   description="Execute {plan_02_name}"
 )
 \`\`\`
@@ -472,9 +463,9 @@ When sub-agents return, attempt to parse their output as a result envelope:
   "summary": "Brief description of what was accomplished",
   "artifacts": [{ "path": "file.ts", "action": "created" }],
   "issues": [
-    { "severity": "medium", "message": "...", "source_agent": "lu-executor" }
+    { "severity": "medium", "message": "...", "source_agent": "executor" }
   ],
-  "metadata": { "agent_name": "lu-executor", "context_tier": "T2" }
+  "metadata": { "agent_name": "executor", "context_tier": "T2" }
 }
 \`\`\`
 
@@ -796,7 +787,6 @@ Task(
 Fix these harness failures.
 """,
   subagent_type="executor",
-  model="{executor_model}",
   description="Fix harness failures (Loop A, iteration {N})"
 )
 \`\`\`
@@ -940,7 +930,6 @@ plan.md contents are included above. Use them in Step 2.5 (Specification Anchori
 Verify the phase goal was achieved using goal-backward analysis.
 """,
   subagent_type="verifier",
-  model="{verifier_model}",
   description="Verify Phase {phase_number}"
 )
 \`\`\`
@@ -978,7 +967,7 @@ VT_ENABLED=$(echo "$CONFIG" | bun -e "
 3. **Spawn three diagnostic agents in PARALLEL**:
 
 \`\`\`python
-# Spawn lu-test-writer diagnostic
+# Spawn test-writer diagnostic
 Task(
   prompt="""
 <diagnostic_context>
@@ -987,11 +976,10 @@ Task(
 **Phase:** {phase_number}
 **VERIFICATION.md:** {verification_content}
 
-Analyze the T1/T3 conflict from your perspective as test coverage expert.
+Settle the T1/T3 conflict empirically: write a focused, non-vacuous test that exercises the disputed behavior and report whether it passes, with the exact runner output.
 </diagnostic_context>
 """,
-  subagent_type="lu-test-writer",
-  model="{diagnostic_model}",
+  subagent_type="test-writer",
   description="Test Writer Diagnostic"
 )
 
@@ -1008,11 +996,10 @@ Re-examine your T3 analysis for potential over-specification.
 </diagnostic_context>
 """,
   subagent_type="verifier",
-  model="{diagnostic_model}",
   description="Verifier Diagnostic"
 )
 
-# Spawn lu-integration-checker diagnostic (IN PARALLEL)
+# Spawn the integration reviewer diagnostic (IN PARALLEL)
 Task(
   prompt="""
 <diagnostic_context>
@@ -1021,11 +1008,10 @@ Task(
 **Phase:** {phase_number}
 **VERIFICATION.md:** {verification_content}
 
-Analyze cross-component wiring for integration gaps.
+PERSPECTIVE: integration. Analyze cross-component/cross-phase wiring for integration gaps and report findings using the integration perspective.
 </diagnostic_context>
 """,
-  subagent_type="lu-integration-checker",
-  model="{diagnostic_model}",
+  subagent_type="reviewer",
   description="Integration Diagnostic"
 )
 \`\`\`
@@ -1161,7 +1147,6 @@ Task(
 Fix the verification gaps for this plan.
 """,
   subagent_type="executor",
-  model="{executor_model}",
   description="Fix verify gaps for {plan_name} (Loop B, iteration {N})"
 )
 \`\`\`
@@ -1195,7 +1180,6 @@ Task(
 Re-verify the phase goal after gap fix iteration {N}.
 """,
   subagent_type="verifier",
-  model="{verifier_model}",
   description="Re-verify Phase {phase_number} (Loop B, iteration {N})"
 )
 \`\`\`
@@ -1233,7 +1217,7 @@ If outcome is anything else: Display remaining gaps and offer \`/phase-plan {X} 
 
 **Skip if:** \`--skip-review\` flag passed OR \`workflow.code_review: false\` in config.
 
-**Always runs** (model tier resolved from routing table per complexity). Each reviewer agent resolves its model tier via \`resolveModelForAgent(agentName, complexity)\`.
+**Always runs** (model tier comes from the agent definition). Each reviewer agent inherits its model tier from its agent definition.
 
 Get changed files for this phase:
 
@@ -1321,7 +1305,6 @@ issues:
 If no issues found, return: \`issues: []\`
 """,
 subagent_type="reviewer",
-model="{reviewer_model}",
 description="DX review"
 )
 
@@ -1351,7 +1334,6 @@ issues:
 If no issues found, return: \`issues: []\`
 """,
 subagent_type="reviewer",
-model="{reviewer_model}",
 description="Simplification review"
 )
 
@@ -1381,7 +1363,6 @@ issues:
 If no issues found, return: \`issues: []\`
 """,
 subagent_type="reviewer",
-model="{reviewer_model}",
 description="Architecture review"
 )
 
@@ -1411,7 +1392,6 @@ issues:
 If no issues found, return: \`issues: []\`
 """,
 subagent_type="reviewer",
-model="{reviewer_model}",
 description="Tailwind review"
 )
 
@@ -1443,7 +1423,6 @@ issues:
 If no issues found, return: \`issues: []\`
 """,
 subagent_type="reviewer",
-model="{reviewer_model}",
 description="Security review"
 )
 
@@ -1689,7 +1668,7 @@ All code reviews passed ✓
 - Spawn parallel debug agents to diagnose root causes
 - **Root Cause Tribunal (conditional):** When debug agents return ROOT CAUSE FOUND during UAT diagnosis, check tribunal gating conditions before creating fix plans:
   - Gate: \`root_cause_tribunal_enabled\` in config (default: true) AND complexity is COMPLEX+ AND multi-issue debugging (issue_count >= 2)
-  - When gated in: Spawn three tribunal agents in parallel (lu-debugger as defender, verifier as challenger, lu-integration-checker as arbiter) to validate the proposed fix before planning
+  - When gated in: spawn two \`debater\` subagents in parallel over the proposed root-cause fix — one STANCE=DEFEND, one STANCE=CHALLENGE — and optionally a \`test-writer\` to settle it with an empirical repro. You arbitrate by confidence-weighted majority over their verdicts
   - Resolution: "verified_fix" proceeds to fix planning; "needs_deeper_investigation" re-runs diagnosis with tribunal findings as additional context
 - Re-invoke the architect mode-agent (in --gaps context) to create fix plans
 - Spawn the \`plan-reviewer\` subagent to verify fix plans

--- a/packages/luca-tools/src/artifacts/skills/phase-plan/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/phase-plan/index.ts
@@ -168,7 +168,7 @@ The researcher model tier is resolved via \`resolveModelForAgent("lu-phase-resea
 WORKFLOW_RESEARCH=$(cat .luca/config.json 2>/dev/null | grep -o '"research"[[:space:]]*:[[:space:]]*[^,}]*' | grep -o 'true|false' || echo "true")
 \`\`\`
 
-**MANDATORY**: If research is needed, you MUST spawn a lu-phase-researcher sub-agent. Do NOT attempt to research yourself.
+**MANDATORY**: If research is needed, you MUST spawn a researcher sub-agent. Do NOT attempt to research yourself.
 
 First, read the required context:
 
@@ -219,7 +219,7 @@ Task(
 
 Research how to implement this phase. Analyze the codebase, identify patterns, and document findings.
 """,
-  subagent_type="lu-phase-researcher",
+  subagent_type="researcher",
   model="{researcher_model}",
   description="Research Phase {phase_number}"
 )
@@ -316,7 +316,7 @@ Task(
 - **CHECKPOINT REACHED:** Present to user, get response
 - **PLANNING INCONCLUSIVE:** Offer options to add context, retry, or manual
 
-### 10. Spawn lu-plan-checker Agent
+### 10. Spawn plan-reviewer Agent
 
 Display:
 
@@ -386,7 +386,7 @@ Task(
 
 Verify these plans will achieve the phase goal when executed.
 """,
-  subagent_type="lu-plan-checker",
+  subagent_type="plan-reviewer",
   model="{checker_model}",
   description="Verify Phase {phase_number} plans"
 )
@@ -445,7 +445,7 @@ If issues found and iteration_count < planVerificationIterations:
 - [ ] Research completed (unless --skip-research or --gaps or exists)
 - [ ] architect mode-agent invoked with planning context (researcher + plan-reviewer subagents spawned as required)
 - [ ] Plans created
-- [ ] lu-plan-checker spawned (unless --skip-verify)
+- [ ] plan-reviewer spawned (unless --skip-verify)
 - [ ] Verification passed OR user override
 - [ ] User knows next steps (execute or review)
 

--- a/packages/luca-tools/src/artifacts/skills/phase-plan/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/phase-plan/index.ts
@@ -87,7 +87,7 @@ Before planning begins, run cognitive pre-flight:
 
 ## Process
 
-### 1. Validate Environment and Resolve Model Profile
+### 1. Validate Environment
 
 \`\`\`bash
 ls .luca/ 2>/dev/null
@@ -95,7 +95,7 @@ ls .luca/ 2>/dev/null
 
 If not found: Error - user should run \`/project-new\` first.
 
-Models are resolved at runtime via \`resolveModelForAgent(agentName, complexity)\` from the centralized routing table (\`src/complexity/__helpers/model-routing.ts\`) — the orchestrator does not pick model strings. The \`researcher\`, \`architect\` (mode-agent), and \`plan-reviewer\` subagents all inherit the appropriate tier based on the active complexity level.
+> Model tiers come from each agent's own definition (and the harness default); this orchestrator never picks model strings.
 
 ### 2. Parse and Normalize Arguments
 
@@ -144,7 +144,7 @@ fi
 
 **If \`--skip-research\` flag:** Skip to step 6.
 
-**Always runs** (model tier for lu-phase-researcher resolved from routing table per complexity). The \`--skip-research\` flag still allows skipping entirely.
+**Always runs** (model tier for researcher comes from the agent definition). The \`--skip-research\` flag still allows skipping entirely.
 
 | Complexity | Research | Model Tier (from routing table) |
 |------------|----------|---------------------------------|
@@ -160,7 +160,7 @@ Read complexity from the canonical workflow state:
 COMPLEXITY=$(luca state read 2>/dev/null | jq -r '.complexity // "MODERATE"')
 \`\`\`
 
-The researcher model tier is resolved via \`resolveModelForAgent("lu-phase-researcher", complexity)\`.
+The researcher model tier is set by the agent’s own definition.
 
 **Check config for research setting:**
 
@@ -220,7 +220,6 @@ Task(
 Research how to implement this phase. Analyze the codebase, identify patterns, and document findings.
 """,
   subagent_type="researcher",
-  model="{researcher_model}",
   description="Research Phase {phase_number}"
 )
 \`\`\`
@@ -326,7 +325,7 @@ Display:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 \`\`\`
 
-**Always runs** (iteration count scales with complexity, model tier for lu-plan-checker resolved from routing table).
+**Always runs** (iteration count scales with complexity).
 
 | Complexity | Plan Verification Iterations | Model Tier (from routing table) |
 |------------|-----------------------------|---------------------------------|
@@ -336,7 +335,7 @@ Display:
 | COMPLEX | 2 iterations | capable |
 | CRITICAL | 3 iterations | capable |
 
-The plan-checker model tier is resolved via \`resolveModelForAgent("lu-plan-checker", complexity)\`.
+The plan-checker model tier is set by the agent’s own definition.
 
 **MANDATORY**: You MUST spawn the \`plan-reviewer\` subagent. Do NOT attempt to verify plans yourself.
 
@@ -387,7 +386,6 @@ Task(
 Verify these plans will achieve the phase goal when executed.
 """,
   subagent_type="plan-reviewer",
-  model="{checker_model}",
   description="Verify Phase {phase_number} plans"
 )
 \`\`\`

--- a/packages/luca-tools/src/artifacts/skills/phase-research/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/phase-research/index.ts
@@ -39,7 +39,7 @@ Goes beyond "which library" to ecosystem knowledge:
 
 2. **Spawn researcher:**
 
-   - Use lu-phase-researcher agent
+   - Use researcher agent
    - Focus on ecosystem knowledge for the domain
 
 3. **Create research.md:**

--- a/packages/luca-tools/src/artifacts/skills/post-init-tour/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/post-init-tour/index.ts
@@ -32,7 +32,7 @@ Skills are user-invocable workflows triggered by /commands (e.g., /phase-plan, /
 
 ### Step 3: Agents -- Specialized AI Workers
 
-Agents are specialized sub-agents that handle focused tasks: lu-router classifies complexity, lu-executor runs code changes, lu-verifier validates results, and reviewers audit code quality. They are spawned automatically during workflow execution.
+Agents are specialized sub-agents that handle focused tasks: lu-router classifies complexity, executor runs code changes, verifier validates results, and reviewers audit code quality. They are spawned automatically during workflow execution.
 
 ### Step 4: Phases -- Structured Development
 

--- a/packages/luca-tools/src/artifacts/skills/post-init-tour/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/post-init-tour/index.ts
@@ -32,7 +32,7 @@ Skills are user-invocable workflows triggered by /commands (e.g., /phase-plan, /
 
 ### Step 3: Agents -- Specialized AI Workers
 
-Agents are specialized sub-agents that handle focused tasks: lu-router classifies complexity, executor runs code changes, verifier validates results, and reviewers audit code quality. They are spawned automatically during workflow execution.
+Agents are specialized sub-agents that handle focused tasks: the researcher gathers context, executor runs code changes, verifier validates results, and reviewers audit code quality. They are spawned automatically during workflow execution. (Complexity classification and cognitive pre-flight are handled inline by the orchestrator, not separate agents.)
 
 ### Step 4: Phases -- Structured Development
 

--- a/packages/luca-tools/src/artifacts/skills/project-new/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/project-new/index.ts
@@ -21,39 +21,9 @@ This skill is an **orchestrator**. YOU MUST delegate work to sub-agents using th
 
 **Required sub-agents for this skill:**
 
-- \`researcher\` - Domain research (4 parallel agents for Stack, Features, Architecture, Pitfalls)
-- \`lu-research-synthesizer\` - Synthesizes research outputs into SUMMARY.md
-- \`lu-roadmapper\` - Creates \`.luca/roadmap.md\` from requirements via \`luca roadmap create\`
+- \`researcher\` - Domain research (4 parallel agents for Stack, Features, Architecture, Pitfalls), and synthesis of those findings into \`.luca/research/SUMMARY.md\`.
 
-**DO NOT** attempt to research, synthesize, or create roadmaps yourself. Spawn the appropriate agents.
-
-
-### Model Resolution
-
-Resolve models before spawning agents:
-
-\`\`\`bash
-MODEL_PROFILE=$(cat .luca/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "balanced")
-\`\`\`
-
-| Agent                      | quality | balanced | budget |
-| -------------------------- | ------- | -------- | ------ |
-| researcher   | opus    | sonnet   | haiku  |
-| lu-research-synthesizer | opus    | sonnet   | haiku  |
-| lu-roadmapper           | opus    | opus     | sonnet |
-
-> **Current Limitation:** Cursor's Task tool only supports \`model="fast"\` or inheriting from parent. This table is preserved for future compatibility.
-
-**Current model variable values:**
-
-\`\`\`
-# Lightweight summarization → use "fast"
-synthesizer_model = "fast"
-
-# Reasoning-intensive agents → omit (inherit from parent)
-researcher_model = (omit)
-roadmapper_model = (omit)
-\`\`\`
+**DO NOT** do the domain research yourself — spawn \`researcher\` agents. Roadmap creation is an orchestrator step backed by the \`luca roadmap create\` write surface (Phase 8), not a subagent. Agent model tiers come from each agent's own definition / the harness default; the orchestrator does not pick model strings.
 
 ## Creates
 
@@ -290,7 +260,6 @@ Task(
 Research the optimal technology stack for this project.
 """,
   subagent_type="researcher",
-  model="{researcher_model}",
   description="Research Stack"
 )
 
@@ -321,7 +290,6 @@ Task(
 Research features and competitive landscape for this project.
 """,
   subagent_type="researcher",
-  model="{researcher_model}",
   description="Research Features"
 )
 
@@ -352,7 +320,6 @@ Task(
 Research architectural patterns and best practices for this project.
 """,
   subagent_type="researcher",
-  model="{researcher_model}",
   description="Research Architecture"
 )
 
@@ -383,7 +350,6 @@ Task(
 Research common pitfalls and risks for this project.
 """,
   subagent_type="researcher",
-  model="{researcher_model}",
   description="Research Pitfalls"
 )
 \`\`\`
@@ -420,8 +386,7 @@ Task(
 
 Synthesize all research outputs into a cohesive summary.
 """,
-  subagent_type="lu-research-synthesizer",
-  model="{synthesizer_model}",
+  subagent_type="researcher",
   description="Synthesize Research"
 )
 \`\`\`
@@ -435,7 +400,10 @@ Store the requirements as a MuninnDB tree under \`brain:project-requirements\` w
 
 ### Phase 8: Create Roadmap
 
-**MANDATORY**: You MUST spawn a lu-roadmapper sub-agent. Do NOT attempt to create the roadmap yourself.
+Build the roadmap yourself (you are the orchestrator) and persist it with the
+\`luca roadmap create\` CLI — the same inline pattern \`milestone-new\` uses. v13
+has no dedicated roadmapper subagent; roadmap synthesis is an orchestrator step
+backed by the deterministic \`luca roadmap create\` write surface.
 
 First, recall the required context from MuninnDB:
 
@@ -449,26 +417,8 @@ mcp__muninn__muninn_recall(vault: "<repo_vault>", context: "project-init researc
 CONFIG_CONTENT=$(cat .luca/config.json)
 \`\`\`
 
-Then spawn the roadmapper:
-
-\`\`\`python
-Task(
-  prompt="""
-<roadmap_context>
-
-**Project:**
-{project_content}
-
-**Requirements:**
-{requirements_content}
-
-**Research Summary:**
-{research_summary}
-
-**Config (for depth setting):**
-{config_content}
-
-</roadmap_context>
+Then synthesize the phase breakdown from the project identity, requirements, and
+research summary, and write it via the CLI:
 
 <depth_guidance>
 Based on config depth setting:
@@ -478,26 +428,18 @@ Based on config depth setting:
 </depth_guidance>
 
 <output_requirements>
-1. Create .luca/roadmap.md via \`luca roadmap create --file <payload.json>\` with:
+1. Create the roadmap via \`luca roadmap create --file <payload.json>\` with:
    - Phase structure with clear goals
    - Requirement mappings (REQ-XXX → Phase X)
    - Success criteria for each phase
    - Dependencies between phases
+   (\`luca roadmap create\` writes \`.luca/state.json\` and activates phase 1.)
 
-2. Initialize the workflow state via \`luca init\` (which creates \`.luca/state.json\`, \`config.json\`, and the canonical directory skeleton).
-
-3. The project requirements + traceability are already stored in MuninnDB (\`brain:project-requirements\` tree, Phase 7); the roadmap-creation step should reference those engrams for requirement → phase mapping. Per-phase requirement traceability surfaces via the per-phase \`audits/\` artifacts.
+2. Requirements + traceability are already stored in MuninnDB
+   (\`brain:project-requirements\` tree, Phase 7); reference those engrams for
+   requirement → phase mapping. Per-phase requirement traceability surfaces via
+   the per-phase \`audits/\` artifacts.
 </output_requirements>
-
-Create the project roadmap based on requirements and research.
-""",
-  subagent_type="lu-roadmapper",
-  model="{roadmapper_model}",
-  description="Create Roadmap"
-)
-\`\`\`
-
-**Do NOT proceed until the Task returns.**
 
 ### Phase 9: GitHub Issue & Branch
 

--- a/packages/luca-tools/src/artifacts/skills/project-new/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/project-new/index.ts
@@ -21,7 +21,7 @@ This skill is an **orchestrator**. YOU MUST delegate work to sub-agents using th
 
 **Required sub-agents for this skill:**
 
-- \`lu-project-researcher\` - Domain research (4 parallel agents for Stack, Features, Architecture, Pitfalls)
+- \`researcher\` - Domain research (4 parallel agents for Stack, Features, Architecture, Pitfalls)
 - \`lu-research-synthesizer\` - Synthesizes research outputs into SUMMARY.md
 - \`lu-roadmapper\` - Creates \`.luca/roadmap.md\` from requirements via \`luca roadmap create\`
 
@@ -38,7 +38,7 @@ MODEL_PROFILE=$(cat .luca/config.json 2>/dev/null | grep -o '"model_profile"[[:s
 
 | Agent                      | quality | balanced | budget |
 | -------------------------- | ------- | -------- | ------ |
-| lu-project-researcher   | opus    | sonnet   | haiku  |
+| researcher   | opus    | sonnet   | haiku  |
 | lu-research-synthesizer | opus    | sonnet   | haiku  |
 | lu-roadmapper           | opus    | opus     | sonnet |
 
@@ -289,7 +289,7 @@ Task(
 
 Research the optimal technology stack for this project.
 """,
-  subagent_type="lu-project-researcher",
+  subagent_type="researcher",
   model="{researcher_model}",
   description="Research Stack"
 )
@@ -320,7 +320,7 @@ Task(
 
 Research features and competitive landscape for this project.
 """,
-  subagent_type="lu-project-researcher",
+  subagent_type="researcher",
   model="{researcher_model}",
   description="Research Features"
 )
@@ -351,7 +351,7 @@ Task(
 
 Research architectural patterns and best practices for this project.
 """,
-  subagent_type="lu-project-researcher",
+  subagent_type="researcher",
   model="{researcher_model}",
   description="Research Architecture"
 )
@@ -382,7 +382,7 @@ Task(
 
 Research common pitfalls and risks for this project.
 """,
-  subagent_type="lu-project-researcher",
+  subagent_type="researcher",
   model="{researcher_model}",
   description="Research Pitfalls"
 )

--- a/packages/luca-tools/src/artifacts/skills/quick/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/quick/index.ts
@@ -149,7 +149,7 @@ Create a quick plan for this task.
 
 ### Step 6: Spawn Executor
 
-**MANDATORY**: You MUST spawn a lu-executor sub-agent. Do NOT attempt to execute yourself.
+**MANDATORY**: You MUST spawn a executor sub-agent. Do NOT attempt to execute yourself.
 
 First, read the plan:
 

--- a/packages/luca-tools/src/artifacts/skills/quick/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/quick/index.ts
@@ -35,13 +35,7 @@ This skill is an **orchestrator**. YOU MUST delegate work to subagents using the
 
 ## Process
 
-### Step 0: Resolve Model Profile
-
-\`\`\`bash
-MODEL_PROFILE=$(cat .luca/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "balanced")
-\`\`\`
-
-Models are resolved at runtime via \`resolveModelForAgent(agentName, complexity)\` from the centralized routing table — the orchestrator does not pick model strings.
+> Model tiers come from each agent's own definition (and the harness default); this orchestrator never picks model strings.
 
 ### Step 1: Pre-flight Validation
 

--- a/packages/luca-tools/src/artifacts/skills/repo-audit/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/repo-audit/index.ts
@@ -17,11 +17,11 @@ Run a repo structure health check to detect naming violations, orphaned files, i
 
 ## Sub-agent Delegation
 
-This skill delegates the analysis to the \`lu-repo-architect\` agent:
+This skill delegates the analysis to the \`architect\` agent:
 
 \`\`\`
 Task(
-  agent: "lu-repo-architect",
+  agent: "architect",
   prompt: "Run {mode} repo audit on this codebase. Report findings in structured format."
 )
 \`\`\`
@@ -51,13 +51,13 @@ bun run scripts/check-domain-boundaries.ts 2>&1
 bun run check:drift 2>&1
 \`\`\`
 
-### 3. Delegate to lu-repo-architect
+### 3. Delegate to architect
 
 Spawn the agent for deeper analysis based on the mode:
 
 \`\`\`
 Task(
-  agent: "lu-repo-architect",
+  agent: "architect",
   prompt: "Run {AUDIT_MODE} repo audit. The automated checks returned: {SCRIPT_RESULTS}. Now perform the additional checks for this mode and produce a structured health report."
 )
 \`\`\`
@@ -88,7 +88,7 @@ If \`--fix\` is passed and issues are auto-fixable (naming, empty dirs):
 ## Notes
 
 - This skill is invoked as \`/repo-audit\` or automatically at phase boundaries
-- The lu-repo-architect agent performs the actual analysis
+- The architect agent performs the actual analysis
 - Existing scripts (check-domain-boundaries, check-drift) handle the mechanical checks
 </main>
 `

--- a/packages/luca-tools/src/artifacts/skills/session-plan/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/session-plan/index.ts
@@ -43,21 +43,21 @@ Plan the next AI coding session (or week) by analyzing pending todos, scoring th
    - Show count of pending todos by area
    - Note any items with dependencies
 
-### Step 2: Invoke PM Agent (lu-pm-planner)
+### Step 2: Invoke the planner (\`architect\`) for WSJF prioritization
 
-1. **Prepare context for PM agent:**
+1. **Prepare planning context:**
    - Package TodoMetadata[] as structured input
    - Include \`.luca/roadmap.md\` for priority context
    - Include dependency graph
    - Include any calibration entries for effort estimates (via MuninnDB: \`mcp__muninn__muninn_recall(vault: "default", context: "effort estimates and calibration data")\`)
 
-2. **Spawn lu-pm-planner sub-agent:**
-   - Agent infers WSJF inputs (BV, TC, RR) for each todo from context
-   - Agent maps complexity to effort points
-   - Agent computes WSJF scores and ranks items
-   - Agent applies Big Rock First + WSJF tail scheduling
-   - Agent assigns quality zones
-   - Agent returns ResultEnvelope containing SessionPlan
+2. **Spawn the \`architect\` mode-agent** (v13 does planning/prioritization work through the architect; the v12-era \`lu-pm-planner\` subagent was dropped), with a WSJF-prioritization brief instructing it to:
+   - Infer WSJF inputs (BV, TC, RR) for each todo from context
+   - Map complexity to effort points
+   - Compute WSJF scores and rank items
+   - Apply Big Rock First + WSJF tail scheduling
+   - Assign quality zones
+   - Return a ResultEnvelope containing the SessionPlan
 
 3. **Receive and validate result:**
    - Parse ResultEnvelope from agent output

--- a/packages/luca-tools/src/artifacts/skills/workflow-save/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/workflow-save/index.ts
@@ -101,7 +101,7 @@ Entities create the relational graph between memories. Use these types consisten
 | \`phase\` | \`phase-{NN}\` | \`phase-06\`, \`phase-03\` |
 | \`plan\` | plan filename | \`PLAN-06-01.md\` |
 | \`branch\` | full branch name | \`53--v3-data-integrity\` |
-| \`agent\` | agent name | \`lu-executor\`, \`lu-verifier\` |
+| \`agent\` | agent name | \`executor\`, \`verifier\` |
 | \`commit\` | short hash | \`a0acf99c\` |
 | \`project\` | project name | \`luca-framework\` |
 | \`error\` | fingerprint hash | \`err-5f3a\` |
@@ -231,8 +231,8 @@ After Phase 06 completes, the skill produces these memories:
 3. **commit**: "a0acf99c — docs(05-01,05-02): verify Phase 5 agentic reliability todos"
 4. **commit**: "506bbba6 — fix(03-01): add eventType/timestamp indexes to observer_events"
 5. **convergence**: "Phase 06 converged in 1 iteration. Error count: 0, delta: 0, status: improved."
-6. **agent_invocation**: "lu-executor: 3 invocations, 3 success, avg 42s, model: sonnet"
-7. **agent_invocation**: "lu-verifier: 1 invocation, 1 success, 18s, model: sonnet"
+6. **agent_invocation**: "executor: 3 invocations, 3 success, avg 42s, model: sonnet"
+7. **agent_invocation**: "verifier: 1 invocation, 1 success, 18s, model: sonnet"
 
 Then links:
 
@@ -246,7 +246,7 @@ Then links:
 At session pause, the skill produces:
 
 1. **session_end**: "Session sess-abc123 ended after 2h15m. Completed phases 05, 06. 4 commits. Paused: context window approaching limit."
-2. **scorecard_snapshot**: "Agent scorecard at session end: lu-executor 6/6 success avg 40s, lu-verifier 2/2 success avg 20s, lu-cognition 1/1 success avg 8s."
+2. **scorecard_snapshot**: "Agent scorecard at session end: executor 6/6 success avg 40s, verifier 2/2 success avg 20s, lu-cognition 1/1 success avg 8s."
 
 Links:
 

--- a/packages/luca-tools/src/artifacts/skills/workflow-save/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/workflow-save/index.ts
@@ -246,7 +246,7 @@ Then links:
 At session pause, the skill produces:
 
 1. **session_end**: "Session sess-abc123 ended after 2h15m. Completed phases 05, 06. 4 commits. Paused: context window approaching limit."
-2. **scorecard_snapshot**: "Agent scorecard at session end: executor 6/6 success avg 40s, verifier 2/2 success avg 20s, lu-cognition 1/1 success avg 8s."
+2. **scorecard_snapshot**: "Agent scorecard at session end: executor 6/6 success avg 40s, verifier 2/2 success avg 20s, researcher 1/1 success avg 8s."
 
 Links:
 

--- a/packages/luca-tools/src/artifacts/subagents/debater.ts
+++ b/packages/luca-tools/src/artifacts/subagents/debater.ts
@@ -1,0 +1,67 @@
+/**
+ * debater subagent — a stance-parameterized adversarial validator. Given a
+ * proposition and an assigned stance (DEFEND or CHALLENGE), it builds the
+ * strongest evidence-backed case for that stance, then returns a structured
+ * verdict the orchestrator can tally against the opposing debater.
+ *
+ * This is the reusable primitive behind the verification tribunal (defender
+ * vs challenger over "is this fix correct?") and, more generally, any point
+ * where a decision benefits from adversarial validation rather than a single
+ * agent's self-assessment (loop-termination, plan-prioritization, error
+ * classification, …). The orchestrator is the arbiter: it spawns opposing
+ * debaters in parallel and resolves by confidence-weighted majority.
+ *
+ * Read-only by design: a debater argues from evidence in the codebase/diff;
+ * it never mutates state. Empirical settlement (running a repro) is the
+ * test-writer's job — kept separate so the debate stays about reasoning.
+ */
+import { defineSubagent } from '../../define/index.ts'
+import { SUBAGENT_SHARED_PREFIX } from '../shared/index.ts'
+
+export const debaterSubagent = defineSubagent({
+    id: 'debater',
+    name: 'Adversarial Debater',
+    description:
+        'Argues one assigned side (DEFEND or CHALLENGE) of a proposition with evidence, then returns a structured verdict with confidence. Spawn opposing debaters in parallel for adversarial validation of a fix, decision, or claim; the orchestrator arbitrates by confidence-weighted majority.',
+    maxSteps: 20,
+    allowedTools: ['Read', 'Grep', 'Glob'],
+    guidance: {
+        selfVerify: true,
+        antiSycophancy: true,
+    },
+    telemetryHooks: ['subagent-end'],
+    pipelineInvocations: ['muninn-recall'],
+    instructions: `${SUBAGENT_SHARED_PREFIX}
+You are a Luca debater. You are assigned ONE side of a proposition and you argue it as rigorously and honestly as the evidence allows.
+
+## Inputs you will be given
+- **PROPOSITION** — the claim under dispute (e.g. "the fix in <diff> correctly resolves the failure and introduces no regression").
+- **STANCE** — exactly one of:
+  - **DEFEND** — make the strongest evidence-backed case that the proposition is TRUE.
+  - **CHALLENGE** — make the strongest evidence-backed case that the proposition is FALSE (find the break, the missed case, the regression).
+- Context: the diff/files/criteria in question.
+
+## How to argue
+1. Argue ONLY your assigned stance — the opposing debater covers the other side; the orchestrator weighs both.
+2. Ground every claim in specific evidence: \`file:line\`, a code path, a failing/expected behavior. Assertion without a citation carries no weight.
+3. Reason about real execution: trace the actual code path, inputs, edge cases, and cross-module effects — not surface plausibility.
+4. **Honesty over advocacy** (anti-sycophancy): if the evidence genuinely undercuts your assigned stance, say so in CONCESSION and lower your CONFIDENCE accordingly. A dishonest 0.9 is worse than an honest 0.4 — the arbiter relies on calibrated confidence.
+
+## Output Format
+\`\`\`
+STANCE: DEFEND | CHALLENGE
+POSITION: <one-sentence claim you are arguing>
+CONFIDENCE: <0.0–1.0 — calibrated likelihood your position is correct on the evidence>
+EVIDENCE:
+- <claim> — <file:line or code path / observed behavior>
+- ...
+STRONGEST_OPPOSING_POINT: <the best argument against your stance, stated fairly>
+CONCESSION: <what the evidence does NOT let you claim, or "none">
+\`\`\`
+
+## Constraints
+- Read-only: cite and reason, never edit. Empirical settlement (writing/running a repro test) is delegated to the test-writer, not you.
+- No hedging-as-both-sides: you were assigned a stance — commit to it, but keep CONFIDENCE calibrated.
+- Be concrete and falsifiable: every EVIDENCE line should be something the arbiter (or the opposing debater) could check.
+`,
+})

--- a/packages/luca-tools/src/artifacts/subagents/index.ts
+++ b/packages/luca-tools/src/artifacts/subagents/index.ts
@@ -1,5 +1,5 @@
 /**
- * Subagents barrel — the 7 Task-tool-spawnable subagents authored as
+ * Subagents barrel — the Task-tool-spawnable subagents authored as
  * `defineSubagent` definitions in this package.
  *
  * Per plan §5.6, the v12-era `planner` and `fix` subagents are
@@ -8,6 +8,12 @@
  *     does the planning work directly).
  *   - `fix` was referenced in `execute.md` but never existed as a
  *     concrete subagent file in mastracode.
+ *
+ * `test-writer` and `debater` were RESTORED (v13 roster reconciliation):
+ *   - `test-writer` — tests are first-class in v13 again; authors focused,
+ *     non-vacuous tests and can settle a dispute with an empirical repro.
+ *   - `debater` — stance-parameterized adversarial validator; the reusable
+ *     primitive behind the verification tribunal (defender vs challenger).
  *
  * `shadow-scanner` is included; the partially-broken state called out
  * in plan §5.1 is addressed by retargeting `.planning/` → `.luca/` and
@@ -19,6 +25,7 @@
  */
 import type { Artifact } from '../../define/index.ts'
 
+import { debaterSubagent } from './debater.ts'
 import { discussionSubagent } from './discussion.ts'
 import { executorSubagent } from './executor.ts'
 import { learnerSubagent } from './learner.ts'
@@ -26,9 +33,11 @@ import { planReviewerSubagent } from './plan-reviewer.ts'
 import { researcherSubagent } from './researcher.ts'
 import { reviewerSubagent } from './reviewer.ts'
 import { shadowScannerSubagent } from './shadow-scanner.ts'
+import { testWriterSubagent } from './test-writer.ts'
 import { verifierSubagent } from './verifier.ts'
 
 export {
+    debaterSubagent,
     discussionSubagent,
     executorSubagent,
     learnerSubagent,
@@ -36,6 +45,7 @@ export {
     researcherSubagent,
     reviewerSubagent,
     shadowScannerSubagent,
+    testWriterSubagent,
     verifierSubagent,
 }
 
@@ -45,6 +55,7 @@ export {
  * by id keeps the output diff-friendly).
  */
 export const SUBAGENTS: readonly Artifact[] = [
+    debaterSubagent,
     discussionSubagent,
     executorSubagent,
     learnerSubagent,
@@ -52,5 +63,6 @@ export const SUBAGENTS: readonly Artifact[] = [
     researcherSubagent,
     reviewerSubagent,
     shadowScannerSubagent,
+    testWriterSubagent,
     verifierSubagent,
 ]

--- a/packages/luca-tools/src/artifacts/subagents/reviewer.ts
+++ b/packages/luca-tools/src/artifacts/subagents/reviewer.ts
@@ -26,7 +26,7 @@ export const reviewerSubagent = defineSubagent({
     id: 'reviewer',
     name: 'Code Reviewer',
     description:
-        'Reviews code changes from a specific perspective: architecture, DX, security, simplification, or test quality. Returns structured findings with severity consolidation.',
+        'Reviews code changes from a specific perspective: architecture, DX, security, simplification, test quality, or cross-phase integration. Returns structured findings with severity consolidation.',
     maxSteps: 20,
     allowedTools: ['Read', 'Grep', 'Glob'],
     guidance: {
@@ -36,7 +36,7 @@ export const reviewerSubagent = defineSubagent({
     telemetryHooks: ['subagent-end'],
     pipelineInvocations: ['muninn-recall'],
     instructions: `${SUBAGENT_SHARED_PREFIX}
-You are a Luca code reviewer. You review code changes from one of five perspectives.
+You are a Luca code reviewer. You review code changes from one of six perspectives.
 
 ## Review Perspectives
 You will be told which perspective to use:
@@ -73,6 +73,13 @@ You will be told which perspective to use:
 - Test-name-vs-assertion drift — test description claims X but body asserts Y
 - Coverage-by-existence — describe block exists but no real branch coverage
 
+### Integration (integration-checker)
+- Cross-phase contracts: a later phase's code matches the interfaces/shapes an earlier phase established (and vice-versa)
+- Wiring completeness: new modules are actually imported/registered/invoked, not just defined
+- Shared-state and config coherence across phases (no drift between producer and consumer)
+- End-to-end seam: data flows through the phase boundary it claims to (call it out with the concrete call path)
+- Use this perspective for milestone-wide audits and any review explicitly scoped to integration between phases.
+
 ## Severity Classification
 
 ### MUST-FIX
@@ -99,10 +106,10 @@ Informational observations. Use for:
 
 ## Output Format
 
-Write the review to \`.luca/phases/<currentPhaseSlug>/audits/<reviewer>.md\` (the reviewer slug is one of: \`code-architect\`, \`dx-advocate\`, \`security-auditor\`, \`code-simplifier\`, \`test-quality-reviewer\` — the orchestrator picks the slug based on your assigned perspective).
+Write the review to \`.luca/phases/<currentPhaseSlug>/audits/<reviewer>.md\` (the reviewer slug is one of: \`code-architect\`, \`dx-advocate\`, \`security-auditor\`, \`code-simplifier\`, \`test-quality-reviewer\`, \`integration-checker\` — the orchestrator picks the slug based on your assigned perspective).
 
 \`\`\`
-PERSPECTIVE: [architecture|dx|security|simplification|test-quality]
+PERSPECTIVE: [architecture|dx|security|simplification|test-quality|integration]
 VERDICT: APPROVE | REQUEST_CHANGES
 FINDINGS:
 - [MUST-FIX] {description}

--- a/packages/luca-tools/src/artifacts/subagents/test-writer.ts
+++ b/packages/luca-tools/src/artifacts/subagents/test-writer.ts
@@ -1,0 +1,64 @@
+/**
+ * test-writer subagent — authors focused, non-vacuous tests for a target
+ * behavior or change, runs them, and reports what they prove.
+ *
+ * Restored as a first-class v13 subagent: tests are part of the codebase
+ * again (co-located `*.test.ts`, a `test` script), and the verification
+ * tribunal needs an agent that can settle a correctness dispute with an
+ * EMPIRICAL repro test rather than argument. Distinct from the executor
+ * (which implements plan tasks) and the verifier (which checks acceptance
+ * criteria) — this agent's single job is to write a test that exercises a
+ * real production code path and fails for the right reason when the
+ * behavior is wrong.
+ */
+import { defineSubagent } from '../../define/index.ts'
+import { SUBAGENT_SHARED_PREFIX } from '../shared/index.ts'
+
+export const testWriterSubagent = defineSubagent({
+    id: 'test-writer',
+    name: 'Test Writer',
+    description:
+        'Authors focused, non-vacuous tests for a specified behavior or change, runs them, and reports the outcome. Use to add coverage for a code path or to settle a correctness dispute with an empirical repro test.',
+    maxSteps: 30,
+    allowedTools: ['Read', 'Grep', 'Glob', 'Edit', 'Write', 'Bash'],
+    guidance: {
+        selfVerify: true,
+    },
+    telemetryHooks: ['subagent-end'],
+    pipelineInvocations: ['muninn-recall'],
+    instructions: `${SUBAGENT_SHARED_PREFIX}
+You are a Luca test writer. You write ONE focused test (or a tight cluster) that exercises a real production code path for an assigned behavior, run it, and report what it proves.
+
+## Inputs you will be given
+- The target behavior/change to cover (file:line or description).
+- Why it matters (the requirement, the suspected bug, or the dispute to settle).
+- The project's test runner + conventions (read them from the repo — e.g. \`bun test\`, co-located \`*.test.ts\`, fixtures). Match the existing style exactly.
+
+## How to write the test
+1. **Read the production code first.** Identify the exact function/branch under test and its real inputs/outputs. Never test a mock of the thing you're trying to validate.
+2. **Make it fail for the right reason.** The test must exercise the production path so that, if the behavior were wrong, it would FAIL. Confirm this — if you can, briefly invert the expectation mentally (or temporarily) to ensure the assertion has teeth.
+3. **Anti-vacuous rules** (these are the failure modes you must avoid):
+   - No presence-only assertions (\`toBeDefined\`/\`toContain\` with no negative anchor).
+   - No vacuous mocks that let the test pass without running production code.
+   - Assert the actual value/behavior, with at least one negative/boundary case where it adds signal.
+4. **Keep it minimal and isolated** — one behavior, deterministic, no network/time flakiness, cleaned-up temp state.
+
+## Run it
+- Run the single test file scoped (e.g. \`bun test <path>\`), never the whole suite.
+- Capture the exact pass/fail output.
+
+## Output Format
+\`\`\`
+TARGET: <behavior under test>
+TEST FILE: <path> (created | extended)
+RESULT: PASS | FAIL
+WHAT IT PROVES: <one line — what is now guaranteed, and what a regression would trip>
+RUN OUTPUT: <the exact runner summary>
+\`\`\`
+
+## Constraints
+- Match the repo's existing test conventions — do not introduce a new framework or runner.
+- A FAIL result is a valid, useful outcome when settling a dispute — report it honestly with the failing assertion; do NOT weaken the test to make it pass.
+- Do not modify production code. If the only way to make a meaningful test pass is a production change, say so explicitly and stop — that is the executor's job, not yours.
+`,
+})


### PR DESCRIPTION
## Summary

Combined PR (supersedes #276) — the full v13 agent-roster fix in one reviewable change. A live `/lu` run surfaced that subagents "couldn't write their own artifacts": the mastracode→luca-tools port left skills spawning agents that don't exist in v13, which fell back to generic read-only agents. This PR makes **every spawned agent resolve to a real v13 agent**, restores the beneficial tooling the port dropped, and folds the rest into existing agents / inline orchestration.

Two commits:
1. **`fix(skills)` — stale-name renames** (was #276): the clear 1:1 renames of v12 agent names still used in skill `subagent_type=` values and imperative prose.
2. **`feat(agents)` — roster reconciliation**: new agents, the tribunal, and folding the remaining dropped agents.

### Renamed (clear 1:1 — both `subagent_type=` and prose)
`lu-executor`→`executor`, `lu-verifier`→`verifier`, `lu-learner`→`learner`, `lu-phase-researcher`/`lu-project-researcher`→`researcher`, `lu-plan-checker`→`plan-reviewer`, and the per-perspective reviewers (`code-architect`/`dx-advocate`/`code-simplifier`/`security-auditor`/`ui`)→`reviewer`.

### Ported — genuinely reusable primitives (roster 8 → 10 subagents)
- **`test-writer`** — authors focused, non-vacuous tests and runs them (tests are first-class in v13; also the empirical leg of the tribunal).
- **`debater`** — stance-parameterized adversarial validator (DEFEND/CHALLENGE with calibrated confidence); the reusable primitive behind the tribunal.

### Extended
- **`reviewer`** gains an **`integration`** perspective (replaces `lu-integration-checker`).

### Verification tribunal — re-implemented on v13 agents
`debater` (defender/challenger) + `test-writer` (empirical repro) + `reviewer` (integration), orchestrator arbitrates by confidence-weighted majority. In phase-execute (diagnostic + root-cause tribunals) and milestone-audit (rebuttal round).

### Stayed dropped — folded into existing agents / inline (no new single-use agents)
| Dropped | → |
|---|---|
| `lu-research-synthesizer`, `lu-discuss-researcher` | `researcher` |
| `lu-roadmapper` | inline `luca roadmap create` (matches milestone-new) |
| `lu-repo-architect` | `architect` |
| roadmap-revision swarm (`lu-pm-planner`, `lu-roadmap-architect/prioritizer/qa/synthesizer`) | `architect` / `reviewer` role spawns |
| `lu-cognition` (pre-flight), `lu-router` (complexity) | inline orchestrator steps |

### Removed
- Stale `resolveModelForAgent` / `model-routing.ts` prose across 6 skills — module never ported to v13; tiers come from each agent's definition / harness default.

## Verification
- `bunx --bun tsc --noEmit` clean.
- Umbrella rebuilds **subagents:10** (was 8), skills:42.
- Zero `lu-*` agent spawn references remain in the artifacts (only the legitimate `lu-review` skill/command name).

Two changesets included; cuts `@alecsibilia/luca@13.0.0-alpha.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
