### PR TITLE
fix(mcp): stop prompting for a per-vault MuninnDB API key

### DIFF
--- a/.changeset/fix-init-decouple-vault-key.md
+++ b/.changeset/fix-init-decouple-vault-key.md
@@ -11,8 +11,11 @@ single registered `muninn` MCP server therefore covers all current and future
 vaults. The wizard previously prompted for a key on every `luca vault:init`
 (and `luca init`, which delegates to it), implying each vault needs its own —
 and `writeApiKeyToEnv` wrote the same key value under three names
-(`MUNINN_DB_<VAULT>_API_KEY`, `MUNINN_DB_DEFAULT_API_KEY`, `MUNINN_DB_API_KEY`),
-none of which anything reads.
+(`MUNINN_DB_<VAULT>_API_KEY`, `MUNINN_DB_DEFAULT_API_KEY`, `MUNINN_DB_API_KEY`).
+Writing all three was redundant: consumers that look up a per-vault/default key
+(e.g. luca-studio's `muninn-config`) already fall back to the generic
+`MUNINN_DB_API_KEY`, and the instance-level key is valid for every vault — so a
+single generic var suffices.
 
 Changes:
 
@@ -25,6 +28,7 @@ Changes:
 - **Reword the prompt** to say the key is a one-time, instance-level credential
   for registering the MCP server — not a per-vault secret.
 - **Simplify `writeApiKeyToEnv`** to write a single `MUNINN_DB_API_KEY` (the
-  per-vault aliasing was dead — same value under multiple names, never read).
+  per-vault aliasing was redundant — same value under multiple names, and
+  consumers fall back to the generic key).
   `VaultConfig.apiKey` is now optional, and `vault:init` only writes `.env`
   when a key was actually captured.

--- a/.changeset/fix-init-decouple-vault-key.md
+++ b/.changeset/fix-init-decouple-vault-key.md
@@ -1,0 +1,30 @@
+---
+"@alecsibilia/luca": patch
+---
+
+Stop prompting for a MuninnDB API key per vault during vault setup.
+
+The MuninnDB API key is **instance-level**, not per-vault: one MuninnDB
+instance issues one key that reaches every vault, because the vault is a
+per-tool-call parameter (`muninn_recall(vault, …)`), not an auth boundary. A
+single registered `muninn` MCP server therefore covers all current and future
+vaults. The wizard previously prompted for a key on every `luca vault:init`
+(and `luca init`, which delegates to it), implying each vault needs its own —
+and `writeApiKeyToEnv` wrote the same key value under three names
+(`MUNINN_DB_<VAULT>_API_KEY`, `MUNINN_DB_DEFAULT_API_KEY`, `MUNINN_DB_API_KEY`),
+none of which anything reads.
+
+Changes:
+
+- **Decouple the vault name from the API key.** `runVaultWizard` always
+  records the vault name; it only asks for an API key when **no `muninn` MCP
+  server is registered yet** (detected via the shared `isMuninnRegistered`
+  helper, extracted from the `muninn-mcp` doctor check). When one is already
+  registered, it records the vault name and skips the key entirely. When the
+  key is left blank it still records the vault name (previously aborted).
+- **Reword the prompt** to say the key is a one-time, instance-level credential
+  for registering the MCP server — not a per-vault secret.
+- **Simplify `writeApiKeyToEnv`** to write a single `MUNINN_DB_API_KEY` (the
+  per-vault aliasing was dead — same value under multiple names, never read).
+  `VaultConfig.apiKey` is now optional, and `vault:init` only writes `.env`
+  when a key was actually captured.

--- a/packages/luca-cli/src/commands/vault-init.ts
+++ b/packages/luca-cli/src/commands/vault-init.ts
@@ -107,7 +107,13 @@ export const vaultInitCommand = defineCommand({
         if (vaultResult.apiKey) {
             await writeApiKeyToEnv(vaultResult.apiKey, envPath)
             p.log.success('API key written to .env')
+        }
 
+        // Protect `.env` in `.gitignore` whenever it exists — independent of
+        // whether we wrote a Muninn key this run. In the common no-key path
+        // (MCP server already registered) a project may still have a `.env`
+        // holding OTHER secrets, and it must not be left untracked-by-gitignore.
+        if (existsSync(envPath)) {
             await ensureEnvInGitignore(cwd)
             p.log.success('.env protected in .gitignore')
         }

--- a/packages/luca-cli/src/commands/vault-init.ts
+++ b/packages/luca-cli/src/commands/vault-init.ts
@@ -100,15 +100,17 @@ export const vaultInitCommand = defineCommand({
         await writeVaultConfig(vaultResult.vaultName, configPath)
         p.log.success('Vault name written to .luca/config.json')
 
-        await writeApiKeyToEnv(
-            vaultResult.apiKey,
-            envPath,
-            vaultResult.vaultName
-        )
-        p.log.success('API key written to .env')
+        // The API key is optional and instance-level: only write it when the
+        // wizard captured one (i.e. no MuninnDB MCP server was registered yet).
+        // A registered server already reaches this vault, so there's nothing to
+        // write to .env.
+        if (vaultResult.apiKey) {
+            await writeApiKeyToEnv(vaultResult.apiKey, envPath)
+            p.log.success('API key written to .env')
 
-        await ensureEnvInGitignore(cwd)
-        p.log.success('.env protected in .gitignore')
+            await ensureEnvInGitignore(cwd)
+            p.log.success('.env protected in .gitignore')
+        }
 
         const reachable = await verifyVaultConnection(vaultResult.vaultName)
         if (reachable) {

--- a/packages/luca-cli/src/utils/doctor/checks/muninn-mcp.ts
+++ b/packages/luca-cli/src/utils/doctor/checks/muninn-mcp.ts
@@ -18,10 +18,8 @@
  * wiring requires an API key this check cannot supply, so there is no
  * automatic `fix()`.
  */
-import { homedir } from 'node:os'
-import { join } from 'node:path'
-
 import type { CheckResult, DoctorCheck } from '../types'
+import { isMuninnRegistered } from '../../muninn-mcp-registration'
 
 const CHECK_NAME = 'MuninnDB MCP wiring'
 
@@ -31,53 +29,6 @@ const MCP_URL = 'http://127.0.0.1:8750/mcp'
 const ADD_COMMAND =
     'claude mcp add --transport sse muninn http://localhost:8750/mcp ' +
     '--header "Authorization: Bearer <your-muninn-api-key>"'
-
-/** Read + parse a JSON object file; null on missing/unreadable/malformed. */
-async function readJsonObject(
-    path: string
-): Promise<Record<string, unknown> | null> {
-    try {
-        const file = Bun.file(path)
-        if (!(await file.exists())) return null
-        const parsed = JSON.parse(await file.text()) as unknown
-        return parsed !== null && typeof parsed === 'object'
-            ? (parsed as Record<string, unknown>)
-            : null
-    } catch {
-        return null
-    }
-}
-
-/** True when an `mcpServers` map contains a `muninn` entry. */
-function hasMuninnEntry(mcpServers: unknown): boolean {
-    return (
-        mcpServers !== null &&
-        typeof mcpServers === 'object' &&
-        'muninn' in (mcpServers as Record<string, unknown>)
-    )
-}
-
-/** Scan the user + project config surfaces for a registered `muninn` server. */
-async function isMuninnRegistered(cwd: string): Promise<boolean> {
-    const projectMcp = await readJsonObject(join(cwd, '.mcp.json'))
-    if (hasMuninnEntry(projectMcp?.mcpServers)) return true
-
-    const userConfig = await readJsonObject(join(homedir(), '.claude.json'))
-    if (hasMuninnEntry(userConfig?.mcpServers)) return true
-
-    const projects = userConfig?.projects
-    if (projects !== null && typeof projects === 'object') {
-        const project = (projects as Record<string, unknown>)[cwd]
-        if (
-            project !== null &&
-            typeof project === 'object' &&
-            hasMuninnEntry((project as Record<string, unknown>).mcpServers)
-        ) {
-            return true
-        }
-    }
-    return false
-}
 
 /**
  * True only when `:8750/mcp` answers like the MuninnDB MCP endpoint: a 2xx,

--- a/packages/luca-cli/src/utils/muninn-mcp-registration.ts
+++ b/packages/luca-cli/src/utils/muninn-mcp-registration.ts
@@ -1,0 +1,61 @@
+/**
+ * Detect whether a `muninn` MCP server is registered with Claude Code.
+ *
+ * A registered MuninnDB MCP server authenticates with a single, INSTANCE-level
+ * API key and reaches EVERY vault — the vault is a per-tool-call parameter, not
+ * an auth boundary. So one registration covers all current and future vaults.
+ *
+ * This is the signal the vault wizard uses to decide whether an API key still
+ * needs capturing (if the server is already registered, it doesn't), and the
+ * signal the `muninn-mcp` doctor check uses for its "registered?" half. Shared
+ * here so the two stay in sync.
+ */
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+/** Read + parse a JSON object file; null on missing/unreadable/malformed. */
+async function readJsonObject(
+    path: string
+): Promise<Record<string, unknown> | null> {
+    try {
+        const file = Bun.file(path)
+        if (!(await file.exists())) return null
+        const parsed = JSON.parse(await file.text()) as unknown
+        return parsed !== null && typeof parsed === 'object'
+            ? (parsed as Record<string, unknown>)
+            : null
+    } catch {
+        return null
+    }
+}
+
+/** True when an `mcpServers` map contains a `muninn` entry. */
+function hasMuninnEntry(mcpServers: unknown): boolean {
+    return (
+        mcpServers !== null &&
+        typeof mcpServers === 'object' &&
+        'muninn' in (mcpServers as Record<string, unknown>)
+    )
+}
+
+/** Scan the user + project config surfaces for a registered `muninn` server. */
+export async function isMuninnRegistered(cwd: string): Promise<boolean> {
+    const projectMcp = await readJsonObject(join(cwd, '.mcp.json'))
+    if (hasMuninnEntry(projectMcp?.mcpServers)) return true
+
+    const userConfig = await readJsonObject(join(homedir(), '.claude.json'))
+    if (hasMuninnEntry(userConfig?.mcpServers)) return true
+
+    const projects = userConfig?.projects
+    if (projects !== null && typeof projects === 'object') {
+        const project = (projects as Record<string, unknown>)[cwd]
+        if (
+            project !== null &&
+            typeof project === 'object' &&
+            hasMuninnEntry((project as Record<string, unknown>).mcpServers)
+        ) {
+            return true
+        }
+    }
+    return false
+}

--- a/packages/luca-cli/src/utils/vault-setup.ts
+++ b/packages/luca-cli/src/utils/vault-setup.ts
@@ -300,9 +300,12 @@ export async function writeVaultConfig(
  *
  * The key is INSTANCE-level, not per-vault: one MuninnDB instance issues one
  * key that reaches every vault (the vault is a per-tool-call parameter). So
- * there is exactly one env var — earlier per-vault aliasing
- * (`MUNINN_DB_<VAULT>_API_KEY`, `MUNINN_DB_DEFAULT_API_KEY`) wrote the same
- * value under several names and was never read by anything. This value is a
+ * there is exactly one env var. Earlier per-vault aliasing
+ * (`MUNINN_DB_<VAULT>_API_KEY`, `MUNINN_DB_DEFAULT_API_KEY`) wrote the SAME
+ * value under several names, which was redundant: consumers that look up a
+ * per-vault/default key (e.g. luca-studio's `muninn-config`) already fall back
+ * to the generic `MUNINN_DB_API_KEY`, and the instance-level key is valid for
+ * every vault — so the single generic var is sufficient. This value is also a
  * convenience reference for the one-time `claude mcp add … --header
  * "Authorization: Bearer <key>"` registration.
  *

--- a/packages/luca-cli/src/utils/vault-setup.ts
+++ b/packages/luca-cli/src/utils/vault-setup.ts
@@ -34,6 +34,7 @@ import { join, basename } from 'pathe'
 import { z } from 'zod'
 
 import { checkMuninndbService } from './muninndb-health'
+import { isMuninnRegistered } from './muninn-mcp-registration'
 import { resolveMuninndbPort } from './muninndb-schemas'
 import { sanitizeJsonParse } from './sanitize'
 
@@ -53,8 +54,14 @@ import type { ProjectContext } from '../types'
 export const VaultConfigSchema = z.object({
     /** Sanitized vault name in lowercase kebab-case. */
     vaultName: z.string().min(1),
-    /** MuninnDB API key for authentication. */
-    apiKey: z.string().min(1),
+    /**
+     * MuninnDB API key. OPTIONAL — it is an instance-level credential needed
+     * only ONCE to register the MuninnDB MCP server, which then reaches every
+     * vault (the vault is a per-tool-call parameter). When a `muninn` MCP
+     * server is already registered, the wizard records just the vault name and
+     * leaves this unset.
+     */
+    apiKey: z.string().min(1).optional(),
 })
 
 /** Vault configuration inferred from the Zod schema. */
@@ -174,17 +181,33 @@ export async function runVaultWizard(
 
     const finalVaultName = sanitizeVaultName(String(vaultName))
 
-    // Step 2: API key guidance
+    // Step 2: API key — but ONLY if it's actually needed. The key is an
+    // instance-level credential used once to register the MuninnDB MCP server;
+    // a registered server already reaches EVERY vault (vault is a per-call
+    // parameter). So when one is registered, record just the vault name and
+    // skip the key entirely — there is no such thing as a per-vault key.
+    if (await isMuninnRegistered(cwd)) {
+        p.log.success(
+            'MuninnDB MCP server already registered — it reaches every vault, ' +
+                'so no API key is needed here.'
+        )
+        return { vaultName: finalVaultName }
+    }
+
     p.note(
         [
-            'To generate an API key, open the MuninnDB Web UI:',
+            'No MuninnDB MCP server is registered with Claude Code yet. The key',
+            'below is an INSTANCE-level credential, captured once to register',
+            'the server — that single registration then reaches every vault.',
+            '',
+            'Generate one in the MuninnDB Web UI:',
             '',
             `  ${muninndbWebUiUrl()}`,
             '',
-            'Navigate to Settings > API Keys and create a new key.',
-            'If MuninnDB is not running, you can set this up later.',
+            'Settings > API Keys > create a new key. You can also skip this and',
+            'register the server later (see `luca doctor`).',
         ].join('\n'),
-        'API Key'
+        'API Key (one-time)'
     )
 
     // Step 3: API key input
@@ -197,15 +220,18 @@ export async function runVaultWizard(
     const trimmedKey = String(apiKey ?? '').trim()
 
     if (trimmedKey.length === 0) {
+        // Still record the vault name — the key is optional and only used to
+        // register the MCP server, which can be done later.
         p.log.warn(
-            'No API key provided. You can set MUNINN_API_KEY in .env later.'
+            'No API key provided. Vault name recorded; register the MuninnDB ' +
+                'MCP server later (see `luca doctor`).'
         )
-        return null
+        return { vaultName: finalVaultName }
     }
 
     // Step 4: Confirmation
     const confirmed = await p.confirm({
-        message: `Set vault "${finalVaultName}" with the provided API key?`,
+        message: `Set vault "${finalVaultName}" and write the API key to .env?`,
         initialValue: true,
     })
 
@@ -270,51 +296,34 @@ export async function writeVaultConfig(
 }
 
 /**
- * Write MuninnDB API key(s) to a `.env` file using per-vault naming.
+ * Write the MuninnDB API key to a `.env` file as a single `MUNINN_DB_API_KEY`.
  *
- * Creates the `.env` file if it does not exist. Writes up to three env vars:
- * - `MUNINN_DB_<VAULT>_API_KEY` — per-vault key (when vaultName provided)
- * - `MUNINN_DB_DEFAULT_API_KEY` — default vault key (for cross-cutting access)
- * - `MUNINN_DB_API_KEY` — generic fallback (for runtime code that reads this)
+ * The key is INSTANCE-level, not per-vault: one MuninnDB instance issues one
+ * key that reaches every vault (the vault is a per-tool-call parameter). So
+ * there is exactly one env var — earlier per-vault aliasing
+ * (`MUNINN_DB_<VAULT>_API_KEY`, `MUNINN_DB_DEFAULT_API_KEY`) wrote the same
+ * value under several names and was never read by anything. This value is a
+ * convenience reference for the one-time `claude mcp add … --header
+ * "Authorization: Bearer <key>"` registration.
  *
- * If the file already contains a matching line, the existing value is replaced.
- * Otherwise the key is appended on a new line.
- *
- * After writing, the file permissions are set to `0600` (owner read/write
- * only) to prevent other users on the system from reading the API key.
+ * Creates the `.env` file if it does not exist; replaces an existing
+ * `MUNINN_DB_API_KEY=` line in place, otherwise appends it. After writing,
+ * permissions are set to `0600` (owner read/write only).
  *
  * @param apiKey - The MuninnDB API key value to write.
  * @param envPath - Absolute path to the `.env` file.
- * @param vaultName - Vault name for per-vault env var (e.g. "my-project").
  *
  * @example
  * ```typescript
- * await writeApiKeyToEnv("sk-abc123", "/path/to/.env", "my-project");
- * // .env now contains:
- * //   MUNINN_DB_MY_PROJECT_API_KEY=sk-abc123
- * //   MUNINN_DB_DEFAULT_API_KEY=sk-abc123
- * //   MUNINN_DB_API_KEY=sk-abc123
- * // File permissions: 0600 (owner read/write only)
+ * await writeApiKeyToEnv("sk-abc123", "/path/to/.env");
+ * // .env now contains: MUNINN_DB_API_KEY=sk-abc123  (perms 0600)
  * ```
  */
 export async function writeApiKeyToEnv(
     apiKey: string,
-    envPath: string,
-    vaultName?: string
+    envPath: string
 ): Promise<void> {
-    // MuninnDB expects per-vault env vars: MUNINN_DB_<VAULT>_API_KEY
-    // Also write the default vault key and generic fallback for runtime consumers
-    const vaultKey = vaultName
-        ? `MUNINN_DB_${vaultName.toUpperCase().replace(/[^A-Z0-9]/g, '_')}_API_KEY`
-        : 'MUNINN_DB_API_KEY'
-    const envLines = [
-        `${vaultKey}=${apiKey}`,
-        // Default vault key is always needed for cross-cutting memories
-        ...(vaultName && vaultName !== 'default'
-            ? [`MUNINN_DB_DEFAULT_API_KEY=${apiKey}`]
-            : []),
-        `MUNINN_DB_API_KEY=${apiKey}`,
-    ]
+    const envLines = [`MUNINN_DB_API_KEY=${apiKey}`]
 
     const file = Bun.file(envPath)
 


### PR DESCRIPTION
## Problem

`luca vault:init` (and `luca init`, which delegates to it) prompts for a MuninnDB API key on **every** vault setup, implying each vault needs its own key. It doesn't.

The MuninnDB API key is **instance-level**, not per-vault: one MuninnDB instance issues one key that reaches every vault, because the vault is a **per-tool-call parameter** (`muninn_recall(vault, …)`, `muninn_remember(vault, …)`), not an auth boundary. Verified live — one MCP connection queried two vaults with no re-auth:

```
muninn_status(vault=default)        -> 3080 memories
muninn_status(vault=luca-framework) ->  555 memories
```

Two corroborating tells in the old code:
- `writeApiKeyToEnv` wrote the **same key value** under three names (`MUNINN_DB_<VAULT>_API_KEY`, `MUNINN_DB_DEFAULT_API_KEY`, `MUNINN_DB_API_KEY`).
- Writing all three was **redundant**: consumers that look up a per-vault/default key (e.g. luca-studio `lib/muninn-config.ts`, `app/api/muninn/vaults/route.ts`) already **fall back** to the generic `MUNINN_DB_API_KEY`, and the instance-level key is valid for every vault. The real connection is the single `claude mcp add … --header "Authorization: Bearer <key>"` registration.

## Fix

Decouple the per-project thing (vault **name**) from the instance-level thing (the **key**):

- **`runVaultWizard`** always records the vault name. It only asks for a key when **no `muninn` MCP server is registered yet** — detected via a new shared `isMuninnRegistered` helper, extracted from the `muninn-mcp` doctor check so the two stay in sync. When a server is already registered, it records the vault name and skips the key entirely. A blank key still records the vault name (previously it aborted).
- **Prompt copy** reworded: the key is a one-time, instance-level credential for registering the MCP server, not a per-vault secret.
- **`writeApiKeyToEnv`** simplified to a single `MUNINN_DB_API_KEY` (the per-vault aliasing was dead code). `VaultConfig.apiKey` is now optional; `vault:init` writes `.env` only when a key was actually captured.

## Effect

On a machine where the `muninn` MCP server is already registered (the common case after first setup), `luca vault:init` now just records the vault name and moves on — no key prompt. Verified: `isMuninnRegistered()` returns `true` against this repo's environment, so the skip path triggers.

## Verification

- `bunx --bun tsc --noEmit` clean.
- Runtime-verified: `writeApiKeyToEnv` writes only `MUNINN_DB_API_KEY` (perms `0600`); `isMuninnRegistered` detects the registered server from `~/.claude.json` / `.mcp.json`.

## Deploy note

CLI rebuild needed for this to take effect (it's in the `luca` binary's `vault:init`/`init` flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
