### PR TITLE
fix(state): terminal finalize step + restore pipeline re-entry edges

### DIFF
--- a/packages/luca-cli/src/commands/write-surface/phase.ts
+++ b/packages/luca-cli/src/commands/write-surface/phase.ts
@@ -44,7 +44,7 @@ const advanceCommand = defineCommand({
             'Advance the active roadmap phase by one (currentPhase → ' +
             'currentPhase+1), marking the completed phase done and the next ' +
             'in-progress. Call at the phase boundary (learn step) when more ' +
-            'phases remain; the final phase routes to the milestone step.',
+            'phases remain; the final phase routes to the finalize step.',
     },
     async run() {
         await runWriteHandler('phase advance', lucaPhaseAdvanceTool, {})
@@ -58,7 +58,7 @@ const archiveCommand = defineCommand({
             'Archive all active phase directories (.luca/phases/<slug>/ → ' +
             '.luca/archive/<slug>/) at milestone close, so the next milestone ' +
             'starts from an empty phases/ dir. Idempotent; skips slugs already ' +
-            'archived. Allowed only in the milestone/complete steps.',
+            'archived. Allowed only in the finalize step.',
     },
     async run() {
         await runWriteHandler('phase archive', lucaPhaseArchiveTool, {})

--- a/packages/luca-cli/src/write-surface/handlers/luca-phase-advance.ts
+++ b/packages/luca-cli/src/write-surface/handlers/luca-phase-advance.ts
@@ -12,7 +12,7 @@ const inputSchema = z.object({})
  * multi-phase roadmap stalled at the phase-1→2 boundary (every phase-2 artifact
  * path resolved against the stale phase-1 slug, or none at all). The orchestrator
  * calls this at the phase boundary (the `learn` step) when more phases remain;
- * the final phase routes to the `milestone` step instead of advancing.
+ * the final phase routes to the `finalize` step instead of advancing.
  *
  * Restricted to the `learn` pipelineStep — the canonical end-of-phase moment in
  * the `/lu` loop, just before advancing the step to `plan` for the next phase.
@@ -41,7 +41,7 @@ export const lucaPhaseAdvanceTool: ToolDescriptor<z.infer<typeof inputSchema>> =
                     }
                     if (currentPhase >= totalPhases) {
                         throw new Error(
-                            `already at the final phase (${currentPhase}/${totalPhases}); there is no next phase. Advance to the milestone step instead.`
+                            `already at the final phase (${currentPhase}/${totalPhases}); there is no next phase. Advance to the finalize step instead.`
                         )
                     }
                     // Mark the leaving phase complete, the entering phase

--- a/packages/luca-cli/src/write-surface/handlers/luca-phase-archive.ts
+++ b/packages/luca-cli/src/write-surface/handlers/luca-phase-archive.ts
@@ -28,9 +28,9 @@ export const lucaPhaseArchiveTool: ToolDescriptor<z.infer<typeof inputSchema>> =
     {
         name: 'luca_phase_archive',
         description:
-            'Archive all active phase directories (.luca/phases/<slug>/ → .luca/archive/<slug>/) at milestone close, so the next milestone starts from an empty phases/ dir. Idempotent: a slug already present under archive/ is skipped, not overwritten. Allowed only in the milestone/complete steps.',
+            'Archive all active phase directories (.luca/phases/<slug>/ → .luca/archive/<slug>/) at milestone close, so the next milestone starts from an empty phases/ dir. Idempotent: a slug already present under archive/ is skipped, not overwritten. Allowed only in the finalize step.',
         inputSchema,
-        allowedPhases: ['milestone', 'complete'],
+        allowedPhases: ['finalize'],
         async handler(_args, ctx) {
             const phasesDir = join(ctx.cwd, '.luca', 'phases')
             if (!existsSync(phasesDir)) {

--- a/packages/luca-cli/src/write-surface/handlers/luca-state-advance.test.ts
+++ b/packages/luca-cli/src/write-surface/handlers/luca-state-advance.test.ts
@@ -37,7 +37,7 @@ describe('luca_state_advance', () => {
 
     test('rejects illegal jumps with isError', async () => {
         const result = await lucaStateAdvanceTool.handler(
-            { toStep: 'milestone' },
+            { toStep: 'execute' },
             { cwd }
         )
 

--- a/packages/luca-core/src/orchestration/context-refresher.ts
+++ b/packages/luca-core/src/orchestration/context-refresher.ts
@@ -241,10 +241,8 @@ const STEP_REMINDERS: Record<RefresherStep, string> = {
         '<luca-reminder>You are in review mode (read-only). Maximum 5 MUST-FIX items. MUST-FIX = correctness bugs, security, missing requirements ONLY.</luca-reminder>',
     learn:
         '<luca-reminder>You are in learn mode. Capture patterns/decisions/pitfalls in MuninnDB + learn.md. Be concrete. ≤200 lines.</luca-reminder>',
-    milestone:
-        '<luca-reminder>You are in milestone mode. Close the milestone: versioned roadmap + audit snapshot under .luca/milestones/.</luca-reminder>',
-    complete:
-        '<luca-reminder>You are in complete mode. Finalize metrics, surface the PR if appropriate, then advance to idle.</luca-reminder>',
+    finalize:
+        '<luca-reminder>You are in finalize mode. Gap audit + postmortem, close the milestone (versioned roadmap + audit snapshot under .luca/milestones/), surface the PR, then reset to idle.</luca-reminder>',
 }
 
 /**
@@ -439,8 +437,7 @@ const ALL_PIPELINE_STEPS_TABLE: Record<PipelineStep, true> = {
     verify: true,
     review: true,
     learn: true,
-    milestone: true,
-    complete: true,
+    finalize: true,
 }
 const ALL_PIPELINE_STEPS_SET = new Set<string>(
     Object.keys(ALL_PIPELINE_STEPS_TABLE),

--- a/packages/luca-core/src/orchestration/continuation-messages.ts
+++ b/packages/luca-core/src/orchestration/continuation-messages.ts
@@ -180,12 +180,10 @@ const STEP_TEMPLATES: Record<ContinuationStep, string> = {
         'execute; otherwise advance to learn.',
     learn:
         'Capture learnings as patterns/decisions/pitfalls in MuninnDB and as `learn.md`. ' +
-        'Then advance to milestone (to close the milestone) or back to plan (to start the next phase).',
-    milestone:
-        'Close the milestone. Produce the versioned roadmap + audit snapshot under `.luca/milestones/`. ' +
-        'Then advance to complete.',
-    complete:
-        'Wrap the session: finalize metrics, surface the PR if appropriate, and advance to idle.',
+        'Then advance to finalize (last phase done) or back to plan (to start the next phase).',
+    finalize:
+        'Finalize the run: gap audit + postmortem, close the milestone (versioned roadmap + audit ' +
+        'snapshot under `.luca/milestones/`), surface the PR, then reset to idle.',
 }
 
 /**
@@ -325,8 +323,7 @@ const ALL_PIPELINE_STEPS_TABLE: Record<PipelineStep, true> = {
     verify: true,
     review: true,
     learn: true,
-    milestone: true,
-    complete: true,
+    finalize: true,
 }
 const ALL_PIPELINE_STEPS_SET = new Set<string>(
     Object.keys(ALL_PIPELINE_STEPS_TABLE),

--- a/packages/luca-core/src/state/configs/coarse-phase-map.ts
+++ b/packages/luca-core/src/state/configs/coarse-phase-map.ts
@@ -22,6 +22,5 @@ export const PIPELINE_STEP_TO_COARSE_PHASE: Record<PipelineStep, CoarsePhase> =
         review: 'REVIEWING',
         learn: 'REVIEWING',
 
-        milestone: 'FINALIZING',
-        complete: 'FINALIZING',
+        finalize: 'FINALIZING',
     }

--- a/packages/luca-core/src/state/configs/pipeline-transitions.test.ts
+++ b/packages/luca-core/src/state/configs/pipeline-transitions.test.ts
@@ -13,9 +13,9 @@ describe('PIPELINE_TRANSITIONS', () => {
         }
     })
 
-    test('only "complete" can transition back to idle', () => {
+    test('only "finalize" can transition back to idle', () => {
         for (const [from, nexts] of Object.entries(PIPELINE_TRANSITIONS)) {
-            if (from === 'complete') {
+            if (from === 'finalize') {
                 expect(nexts).toContain('idle')
             } else {
                 expect(nexts).not.toContain('idle')
@@ -35,24 +35,27 @@ describe('PIPELINE_TRANSITIONS', () => {
         expect(isLegalTransition('checks', 'verify')).toBe(true)
         expect(isLegalTransition('verify', 'review')).toBe(true)
         expect(isLegalTransition('review', 'learn')).toBe(true)
-        expect(isLegalTransition('learn', 'milestone')).toBe(true)
-        expect(isLegalTransition('milestone', 'complete')).toBe(true)
-        expect(isLegalTransition('complete', 'idle')).toBe(true)
+        expect(isLegalTransition('learn', 'finalize')).toBe(true)
+        expect(isLegalTransition('finalize', 'idle')).toBe(true)
     })
 
     test('loop-back transitions for fix cycles', () => {
         expect(isLegalTransition('plan-review', 'plan')).toBe(true)
         expect(isLegalTransition('checks', 'execute')).toBe(true)
         expect(isLegalTransition('verify', 'checks')).toBe(true)
+        expect(isLegalTransition('review', 'execute')).toBe(true) // MUST-FIX / SHOULD-FIX iteration
         expect(isLegalTransition('learn', 'plan')).toBe(true) // next phase
+        expect(isLegalTransition('learn', 'finalize')).toBe(true) // last phase done
+        expect(isLegalTransition('finalize', 'execute')).toBe(true) // gap/postmortem re-entry
+        expect(isLegalTransition('finalize', 'review')).toBe(true) // gap re-entry
         expect(isLegalTransition('research', 'research')).toBe(true) // re-research
     })
 
     test('illegal jumps are rejected', () => {
         expect(isLegalTransition('idle', 'execute')).toBe(false)
         expect(isLegalTransition('plan', 'execute')).toBe(false) // must go via plan-review
-        expect(isLegalTransition('execute', 'milestone')).toBe(false)
-        expect(isLegalTransition('triage', 'complete')).toBe(false)
+        expect(isLegalTransition('execute', 'finalize')).toBe(false) // must run the full review path
+        expect(isLegalTransition('triage', 'finalize')).toBe(false)
         expect(isLegalTransition('idle', 'idle')).toBe(false)
     })
 })

--- a/packages/luca-core/src/state/configs/pipeline-transitions.ts
+++ b/packages/luca-core/src/state/configs/pipeline-transitions.ts
@@ -20,10 +20,9 @@ export const PIPELINE_TRANSITIONS: Record<PipelineStep, PipelineStep[]> = {
     execute: ['checks'],
     checks: ['verify', 'execute'], // fix loop back to execute
     verify: ['review', 'checks'], // fix loop back to checks
-    review: ['learn'],
-    learn: ['milestone', 'plan'], // next phase OR close milestone
-    milestone: ['complete'],
-    complete: ['idle'], // start a fresh session
+    review: ['learn', 'execute'], // fix loop back to execute for MUST-FIX / SHOULD-FIX iteration
+    learn: ['plan', 'finalize'], // plan=next phase; finalize=last phase done
+    finalize: ['idle', 'execute', 'review'], // idle=run complete; execute/review=gap & postmortem re-entry
 }
 
 export function isLegalTransition(

--- a/packages/luca-core/src/state/configs/step-artifacts.ts
+++ b/packages/luca-core/src/state/configs/step-artifacts.ts
@@ -50,8 +50,9 @@ export const STEP_ARTIFACTS: Record<PipelineStep, StepArtifact[]> = {
     verify: ['verify'],
     review: ['audits/*'],
     learn: ['learn'],
-    milestone: [],
-    complete: [],
+    // finalize writes the postmortem learn.md and records gap summaries in
+    // audit artifacts before re-entry; see finalize mode.
+    finalize: ['learn', 'audits/*'],
 }
 
 /**
@@ -97,10 +98,10 @@ export const WRITE_COMMAND_PHASES: Record<string, PipelineStep[]> = {
     'roadmap create': ['idle', 'triage'],
     'checks run': ['execute', 'checks'],
     // Phase lifecycle: advance at the phase boundary (learn); archive only
-    // at milestone close. (The tool descriptors carry matching allowedPhases,
+    // during finalize (milestone close). (The tool descriptors carry matching allowedPhases,
     // but the CLI self-check consults THIS table — runWriteHandler.)
     'phase advance': ['learn'],
-    'phase archive': ['milestone', 'complete'],
+    'phase archive': ['finalize'],
 
     // Phase-restricted freeform artifact writes
     'phase write-research': ['research'],

--- a/packages/luca-core/src/state/constants.ts
+++ b/packages/luca-core/src/state/constants.ts
@@ -1,4 +1,6 @@
-// Canonical pipelineStep values (14), trimmed from the original 22.
+// Canonical pipelineStep values (13). `finalize` is the terminal mode that
+// wraps the milestone (gap audit, postmortem, PR) and resets to `idle`;
+// "milestone" is a work-organization concept handled by skills, not a step.
 // Folded steps are mapped to canonical values via LEGACY_PIPELINE_STEP_MAP
 // for backwards-compat reading of pre-migration state.json files.
 export const PipelineStepValues = [
@@ -14,8 +16,7 @@ export const PipelineStepValues = [
     'verify',
     'review',
     'learn',
-    'milestone',
-    'complete',
+    'finalize',
 ] as const
 
 // Mapping from legacy pipelineStep values to their canonical replacements.
@@ -30,6 +31,8 @@ export const LEGACY_PIPELINE_STEP_MAP: Record<string, string> = {
     // Old audit sub-steps fold into review.
     'review-audit': 'review',
     'gap-audit': 'review',
-    // Old cleanup folds into milestone.
-    cleanup: 'milestone',
+    // Old milestone/complete/cleanup steps fold into the terminal finalize mode.
+    cleanup: 'finalize',
+    milestone: 'finalize',
+    complete: 'finalize',
 }

--- a/packages/luca-core/src/state/helpers/coarse-phase-of.test.ts
+++ b/packages/luca-core/src/state/helpers/coarse-phase-of.test.ts
@@ -20,8 +20,7 @@ describe('coarsePhaseOf', () => {
         ['verify', 'REVIEWING'],
         ['review', 'REVIEWING'],
         ['learn', 'REVIEWING'],
-        ['milestone', 'FINALIZING'],
-        ['complete', 'FINALIZING'],
+        ['finalize', 'FINALIZING'],
     ]
 
     for (const [step, expected] of cases) {
@@ -30,7 +29,7 @@ describe('coarsePhaseOf', () => {
         })
     }
 
-    test('all 14 canonical pipelineSteps are covered by the table above', () => {
-        expect(cases.length).toBe(14)
+    test('all 13 canonical pipelineSteps are covered by the table above', () => {
+        expect(cases.length).toBe(13)
     })
 })

--- a/packages/luca-core/src/state/schemas.test.ts
+++ b/packages/luca-core/src/state/schemas.test.ts
@@ -56,8 +56,7 @@ describe('PipelineStep', () => {
             'verify',
             'review',
             'learn',
-            'milestone',
-            'complete',
+            'finalize',
         ] as const
         for (const step of canonical) {
             expect(PipelineStep.parse(step)).toBe(step)
@@ -81,8 +80,10 @@ describe('PipelineStep', () => {
         expect(PipelineStep.parse('gap-audit')).toBe('review')
     })
 
-    test('maps legacy cleanup to milestone', () => {
-        expect(PipelineStep.parse('cleanup')).toBe('milestone')
+    test('maps legacy milestone/complete/cleanup to finalize', () => {
+        expect(PipelineStep.parse('cleanup')).toBe('finalize')
+        expect(PipelineStep.parse('milestone')).toBe('finalize')
+        expect(PipelineStep.parse('complete')).toBe('finalize')
     })
 
     test('rejects unknown pipelineStep values', () => {
@@ -152,7 +153,7 @@ describe('lucaStateSchema', () => {
 
     test('applies pipelineStep legacy mapping at the top level', () => {
         const parsed = lucaStateSchema.parse({ pipelineStep: 'cleanup' })
-        expect(parsed.pipelineStep).toBe('milestone')
+        expect(parsed.pipelineStep).toBe('finalize')
     })
 
     test('strict variant drops legacy fields by failing them', () => {

--- a/packages/luca-tools/src/artifacts/commands/lu.ts
+++ b/packages/luca-tools/src/artifacts/commands/lu.ts
@@ -10,7 +10,7 @@ import { defineCommand } from '../../define/command.ts'
 
 const BODY = `# /lu
 
-The unified entry point for the Luca pipeline. \`/lu <request>\` takes a development request and drives it through the full pipeline: triage → research → discuss → architect → plan → plan-review → execute → checks → verify → review → learn → milestone.
+The unified entry point for the Luca pipeline. \`/lu <request>\` takes a development request and drives it through the full pipeline: triage → research → discuss → architect → plan → plan-review → execute → checks → verify → review → learn → finalize.
 
 You are the **orchestrator**. You do not write code or planning artifacts directly — you read state, run each step (delegating to its skill or subagent), and advance the pipeline.
 
@@ -42,7 +42,7 @@ Triage runs once, at the start of a run. It is inline here — there is no separ
 
 ## Pipeline loop
 
-Repeat until \`pipelineStep\` is \`complete\`:
+Repeat until the \`finalize\` step resets the run (\`pipelineStep\` returns to \`idle\`):
 
 1. Run \`luca state read\` to get the current \`pipelineStep\`.
 2. Run the step using the table below.
@@ -59,8 +59,8 @@ Repeat until \`pipelineStep\` is \`complete\`:
 | \`checks\`      | Run \`luca checks run --file <commands.json>\` with the project's typecheck (and tests, if present). On failure, loop back to \`execute\`. |
 | \`verify\`      | Spawn \`verifier\` (Agent tool). On \`recommendation: fix\`, loop back to \`checks\`; on \`escalate\`, stop and surface to the user. |
 | \`review\`      | Spawn \`reviewer\` (Agent tool) — one per perspective, in parallel.     |
-| \`learn\`       | Spawn \`learner\` (Agent tool); it writes \`learn.md\` and returns a \`TO_PERSIST\` block. **You persist those learnings to MuninnDB** (subagents have no MCP access): for each \`TO_PERSIST\` entry call \`mcp__muninn__muninn_remember_batch\` routed to the entry's \`vault:\` (\`default\` for \`pattern:\`/\`pitfall:\`, the repo vault for \`convention:\`/\`decision:\`), deduping against existing memories. Then: more phases remain → run \`luca phase advance\`, then advance to \`plan\`; last phase → advance to \`milestone\`. |
-| \`milestone\`   | Invoke the \`/milestone-new\` skill to close out, or advance to \`complete\` if no milestone bookkeeping is needed. |
+| \`learn\`       | Spawn \`learner\` (Agent tool); it writes \`learn.md\` and returns a \`TO_PERSIST\` block. **You persist those learnings to MuninnDB** (subagents have no MCP access): for each \`TO_PERSIST\` entry call \`mcp__muninn__muninn_remember_batch\` routed to the entry's \`vault:\` (\`default\` for \`pattern:\`/\`pitfall:\`, the repo vault for \`convention:\`/\`decision:\`), deduping against existing memories. Then: more phases remain → run \`luca phase advance\`, then advance to \`plan\`; last phase → advance to \`finalize\`. |
+| \`finalize\`    | Spawn the \`finalize\` agent (Agent tool): gap detection, postmortem gate, PR creation, milestone close (invokes \`/milestone-complete\` for the versioned snapshot + phase archive). On a gap/postmortem block it re-enters via \`--to-step execute\`/\`review\`; on success it resets the run with \`--to-step idle\`. |
 
 ## Oversight
 

--- a/packages/luca-tools/src/artifacts/commands/milestone-new.ts
+++ b/packages/luca-tools/src/artifacts/commands/milestone-new.ts
@@ -24,7 +24,7 @@ Parse \`$ARGUMENTS\` for:
 
 Resolve \`<repo_vault>\` from \`.luca/config.json\` → \`muninn.vault\`, falling back to \`"default"\`.
 
-If the pipeline is mid-flight (\`pipelineStep\` is not \`idle\` or \`complete\`), warn the user that starting a new milestone resets pipeline state, and confirm before proceeding.
+If the pipeline is mid-flight (\`pipelineStep\` is not \`idle\` — a finished run resets to \`idle\`), warn the user that starting a new milestone resets pipeline state, and confirm before proceeding.
 
 ## Step 2 — Gather milestone goals
 

--- a/packages/luca-tools/src/artifacts/modes/architect.ts
+++ b/packages/luca-tools/src/artifacts/modes/architect.ts
@@ -362,7 +362,7 @@ If changes requested, revise and re-submit. In **full-auto**, skip approval — 
 When the plan is approved (or auto-approved in full-auto):
 
 1. The plan file is the canonical \`.luca/phases/<currentPhaseSlug>/plan.md\` written via \`luca\` artifact write semantics. Downstream stages resolve it deterministically from the phase slug and the LUCA_DIR_CONTRACT; no separate \`planFile\` state field is needed.
-2. Transition to **Execute** mode via \`luca state advance --to-step execute\`.
+2. Transition to the **plan** step via \`luca state advance --to-step plan\` (the only legal next step from \`architect\`; planning then flows plan → plan-review → execute per the pipeline-transitions table).
 
 ---
 

--- a/packages/luca-tools/src/artifacts/modes/finalize.ts
+++ b/packages/luca-tools/src/artifacts/modes/finalize.ts
@@ -50,11 +50,10 @@ You are **Luca's finalization agent**. Handle milestone boundaries, quality assu
 
 You receive control from **Review mode** — on entry the pipeline is at the \`learn\` step. Read the latest \`.luca/phases/<currentPhaseSlug>/audits/<reviewer>.md\` files for audit results and remaining advisory items.
 
-**Immediately advance to the \`finalize\` step** so the rest of this mode runs under the FINALIZING phase — that is the phase whose stage-gate permits the commits and \`gh pr create\` that PR creation needs (REVIEWING, where \`learn\` lives, blocks them):
+**Ensure the pipeline is at the \`finalize\` step** before doing anything else — the rest of this mode runs under the FINALIZING phase, whose stage-gate permits the commits and \`gh pr create\` that PR creation needs (REVIEWING, where \`learn\` lives, blocks them). Entry may be at \`learn\` (this mode self-driving from review's clean route) **or** already at \`finalize\` (the \`/lu\` orchestrator advances \`learn → finalize\` before spawning this mode). Run \`luca state read\` and advance **only if needed** — \`finalize → finalize\` is an illegal self-transition that would error:
 
-\`\`\`
-luca state advance --to-step finalize
-\`\`\`
+- \`pipelineStep\` is \`learn\` → \`luca state advance --to-step finalize\`
+- \`pipelineStep\` is already \`finalize\` → skip the advance; proceed.
 
 ---
 

--- a/packages/luca-tools/src/artifacts/modes/finalize.ts
+++ b/packages/luca-tools/src/artifacts/modes/finalize.ts
@@ -48,7 +48,13 @@ const BODY = `# Finalize Agent Instructions
 
 You are **Luca's finalization agent**. Handle milestone boundaries, quality assurance, gap detection, and session cleanup. Ensure completed work is properly packaged, documented, and delivered.
 
-You receive control from **Review mode**. Read the latest \`.luca/phases/<currentPhaseSlug>/audits/<reviewer>.md\` files for audit results and remaining advisory items.
+You receive control from **Review mode** — on entry the pipeline is at the \`learn\` step. Read the latest \`.luca/phases/<currentPhaseSlug>/audits/<reviewer>.md\` files for audit results and remaining advisory items.
+
+**Immediately advance to the \`finalize\` step** so the rest of this mode runs under the FINALIZING phase — that is the phase whose stage-gate permits the commits and \`gh pr create\` that PR creation needs (REVIEWING, where \`learn\` lives, blocks them):
+
+\`\`\`
+luca state advance --to-step finalize
+\`\`\`
 
 ---
 
@@ -59,8 +65,8 @@ You receive control from **Review mode**. Read the latest \`.luca/phases/<curren
 3. **Gap detection** — verify all planned work was completed; reconcile \`plan.md\` against shipped code.
 4. **Postmortem gate** — block on critical pipeline violations before PR.
 5. **PR creation** — write changeset post-convergence, run claim verifier, then create pull request.
-6. **Cross-milestone continuation** — loop back if roadmap has remaining phases.
-7. **Session cleanup** — release locks, summarize work.
+6. **Surface remaining work** — if the roadmap has phases beyond this milestone, summarize them for a fresh \`/lu\` run (one run finalizes one milestone).
+7. **Session cleanup** — release locks, summarize work, reset to \`idle\`.
 
 > **Ordering matters.** Gap detection, postmortem gate, and claim verifier all run *before* \`gh pr create\`. The changeset is written **after** review iteration converges, not before — pre-convergence drafts are the #1 source of doc drift. A failing gate must re-enter the pipeline rather than ship a PR.
 
@@ -311,32 +317,26 @@ If it returns \`code: CLAIM_VERIFICATION_FAILED\`:
 
 If \`--skip-branch\` was set, skip.
 
-## Step 6: Cross-Milestone Continuation
+## Step 6: Surface Remaining Work
 
-Check if \`.luca/roadmap.md\` has remaining phases:
+One run finalizes **one milestone** — there is no in-session cross-milestone loop. Check if \`.luca/roadmap.md\` has phases beyond the milestone just shipped:
 
 \`\`\`
-if roadmap.hasRemainingPhases AND milestonesThisSession < 3:
-  1. Increment milestone counter.
-  2. Archive current milestone.
-  3. Load next phase from roadmap.
-  4. Transition back to Architect mode (with research from previous milestone).
-else if roadmap.hasRemainingPhases AND milestonesThisSession >= 3:
-  1. Report: "Session milestone limit reached (3)".
-  2. Summarize remaining work.
-  3. Proceed to cleanup.
+if roadmap.hasRemainingPhases:
+  1. Summarize the remaining phases (the next milestone's scope).
+  2. Create issues / note the continuation point so nothing is lost.
+  3. Tell the user to run /lu again to start the next milestone.
 else:
-  1. All phases complete.
-  2. Proceed to cleanup.
+  1. All planned work complete.
 \`\`\`
 
-Maximum **3 milestones per session**. If more remain: summarize what's left, create issues, note continuation point.
+Either way, proceed to cleanup — the run ends by resetting to \`idle\`.
 
 ## Step 7: Session Cleanup
 
 ### Release Pipeline Lock
 
-Pipeline-lock concurrent-run protection is a v14 carry-forward (CF2) — the v13 \`luca\` CLI does not expose a lock-release subcommand. The session ends cleanly when the workflow reaches the \`complete\` step; no explicit release is required today.
+Pipeline-lock concurrent-run protection is a v14 carry-forward (CF2) — the v13 \`luca\` CLI does not expose a lock-release subcommand. The session ends cleanly when the workflow resets to the \`idle\` step (the final transition below); no explicit release is required today.
 
 ### Clean Up Artifacts
 
@@ -408,7 +408,13 @@ When finalization is complete:
 3. Pipeline lock released.
 4. Final summary reported.
 
-The session is now complete.
+Then reset the pipeline for the next run:
+
+\`\`\`
+luca state advance --to-step idle
+\`\`\`
+
+The session is now complete. To start the next milestone, run \`/lu\` again.
 
 ---
 
@@ -420,23 +426,17 @@ You are the **final stage** of the Luca autonomous pipeline:
 Triage → Research → Architect → Execute → Review → [Finalize]
 \`\`\`
 
-### Cross-Milestone Continuation
+### Re-entry on gaps
 
-If roadmap has remaining phases and milestone limit not reached:
-
-\`\`\`
-luca state advance --to-step architect
-\`\`\`
-
-Loops back to Architect for next milestone cycle.
+If gap detection (Step 3) or the postmortem gate (Step 4) blocks, re-enter the pipeline from the \`finalize\` step — \`--to-step execute\` (fix) or \`--to-step review\` (re-audit). The re-entered loop must converge before finalize runs again.
 
 ### End of Pipeline
 
-When no remaining phases or milestone limit reached:
-1. Reset state via \`luca workflow reset\`.
-2. Report final summary.
+When finalization is complete:
+1. Report final summary.
+2. Reset to \`idle\` via \`luca state advance --to-step idle\` (see Completion above).
 
-Pipeline-lock release is a v14 carry-forward (CF2); the v13 \`luca\` CLI has no separate lock-release subcommand.
+One run finalizes one milestone. If the roadmap has further phases, the user starts the next milestone with a fresh \`/lu\` run. Pipeline-lock release is a v14 carry-forward (CF2); the v13 \`luca\` CLI has no separate lock-release subcommand.
 
 ### TODO Backlog Cleanup
 

--- a/packages/luca-tools/src/artifacts/modes/research.ts
+++ b/packages/luca-tools/src/artifacts/modes/research.ts
@@ -273,7 +273,7 @@ When research graduates (all quality dimensions pass or max iterations reached):
 
 1. Store findings in MuninnDB and create backlog todos.
 2. Report research summary, quality scores, and capture summary.
-3. Transition to **Architect** mode via \`luca state advance --to-step architect\`.
+3. Transition to the **discuss** step via \`luca state advance --to-step discuss\` (the only legal next step from \`research\`; discussion gathers user decisions before architecture).
 
 ---
 
@@ -287,7 +287,7 @@ Triage → [Research] → Architect → Execute → Review → Finalize
 
 ### Automatic Mode Transition
 
-Transition happens automatically via \`luca state advance --to-step architect\`. Do NOT wait for user confirmation unless oversight is \`human-in-loop\`.
+Transition happens automatically via \`luca state advance --to-step discuss\`. Do NOT wait for user confirmation unless oversight is \`human-in-loop\`.
 
 ### Context From Previous Stages
 

--- a/packages/luca-tools/src/artifacts/modes/review.ts
+++ b/packages/luca-tools/src/artifacts/modes/review.ts
@@ -1,8 +1,8 @@
 /**
  * review mode-agent — Luca code review: READ-ONLY multi-perspective
  * audit of code changes against the plan. Routes to Finalize (clean)
- * or back to Execute (must-fix issues). The fifth stage of the
- * pipeline. Stage `review`.
+ * or back to Execute (MUST-FIX / SHOULD-FIX issues). The fifth stage
+ * of the pipeline. Stage `review`.
  *
  * Ported from luca-mastracode/src/modes/review.ts +
  * src/instructions/review.md. Mastra tool refs retargeted to the
@@ -51,7 +51,7 @@ You are Luca's code reviewer. Audit code changes against the original intent and
 \`\`\`
 Triage → Research → Architect → Execute → [Review] → Finalize
                               ↑            │
-                              └────────────┘  (iterate if must-fix issues)
+                              └────────────┘  (iterate if MUST-FIX / SHOULD-FIX issues)
 \`\`\`
 
 Review receives control from Execute. Determine whether implementation is ready for finalization or needs iteration.
@@ -119,9 +119,9 @@ Five files per wave (one per perspective): \`review-architecture-<NN>.md\`, \`re
 ### Step 5: Consolidate Findings
 
 Merge all subagent outputs by severity:
-- **MUST-FIX** — Blocks proceeding: regressions, missing requirements, security issues, broken checks.
-- **SHOULD-FIX** — Advisory: pattern violations, DX improvements, minor issues.
-- **NOTE** — Informational: future tech debt, refactoring opportunities.
+- **MUST-FIX** — Blocks proceeding: regressions, missing requirements, security issues, broken checks. Fixed in-pipeline (loop back to execute).
+- **SHOULD-FIX** — Also fixed in-pipeline: pattern violations, DX improvements, minor issues. Tackled in the same execute loop as MUST-FIX, not deferred.
+- **NOTE** — Trivial follow-ups *below* the SHOULD-FIX bar: future tech debt, refactoring opportunities. NOT fixed in-pipeline — captured as a backlog todo via \`luca todo add\` (see Step 7).
 
 If raw outputs were OM-compressed between capture and consolidation, **re-read** the per-perspective findings from \`.luca/phases/<currentPhaseSlug>/raw/review-<reviewer>-<NN>.md\` (the safety-net files written in Step 4.5).
 
@@ -197,37 +197,47 @@ If the verifier flags \`symbol-not-found\` for a symbol you cited in a finding, 
 
 ### Step 7: Route Decision
 
+First, **capture every NOTE-tier finding as a backlog todo** — always, regardless of which route follows. NOTE items are trivial follow-ups below the SHOULD-FIX bar and are never fixed in-pipeline. For each one:
+
+\`\`\`
+luca todo add --title "<concise actionable title>" --status backlog --source review-finding --body "<finding detail + file:line>"
+\`\`\`
+
+\`luca todo add\` validates the input and prints a \`mcp__muninn__muninn_remember\` instruction — execute it **exactly as returned** to persist the todo (delegation pattern; the \`luca\` CLI cannot call MuninnDB directly). Todos live in MuninnDB under \`todo:<id>\` in the repo vault — **never** write a todo file to disk.
+
+Then route on the **actionable** findings (MUST-FIX + SHOULD-FIX — both are fixed in-pipeline):
+
 #### User Checkpoint (non-full-auto)
 
-When oversight is \`checkpoint\` or \`human-in-loop\` and MUST-FIX issues found, ask the user how to proceed: Fix issues / Proceed anyway / Show details. "Proceed anyway" → treat as Route A. "Show details" → display report, re-ask.
+When oversight is \`checkpoint\` or \`human-in-loop\` and actionable issues (MUST-FIX or SHOULD-FIX) found, ask the user how to proceed: Fix issues / Proceed anyway / Show details. "Proceed anyway" → treat as Route A. "Show details" → display report, re-ask.
 
 In \`full-auto\`, route automatically based on findings.
 
-**Route A — Clean (no MUST-FIX)**:
+**Route A — Clean (no MUST-FIX and no SHOULD-FIX)**:
 1. Save review report, store clean verdict.
-2. Transition: \`luca state advance --to-step learn\` (then onward to milestone/complete per the pipeline-transitions table).
+2. Transition: \`luca state advance --to-step learn\` (then onward to finalize per the pipeline-transitions table).
 
-**Route B — Issues Found (MUST-FIX exist)**:
+**Route B — Actionable findings exist (MUST-FIX or SHOULD-FIX)**:
 1. Check iteration count against \`maxReviewIterations\`.
-2. Within budget: write the iteration plan into the active phase's audit artifact, emit \`luca telemetry emit --kind=iteration\` so the aggregator sees the re-execute loop, and transition back to execute via \`luca state advance --to-step execute\`.
-3. At budget limit: save report with remaining issues; transition forward via \`luca state advance --to-step learn\` with a warning recorded in the audit artifact.
+2. Within budget: write the iteration plan — covering **both** MUST-FIX and SHOULD-FIX items — into the active phase's audit artifact, emit \`luca telemetry emit --kind=iteration\` so the aggregator sees the re-execute loop, and transition back to execute via \`luca state advance --to-step execute\`.
+3. At budget limit: capture every remaining MUST-FIX and SHOULD-FIX item as a backlog todo (\`luca todo add --status backlog --source review-finding …\`) so nothing is lost, save the report with a budget-exhausted warning in the audit artifact, then transition forward via \`luca state advance --to-step learn\`.
 
 ---
 
 ## Behavioral Guidelines
 
 - **Never edit files.** Read-only auditor. Output is the review report.
-- **Be constructive.** Every MUST-FIX must include a concrete fix suggestion.
+- **Be constructive.** Every MUST-FIX and SHOULD-FIX must include a concrete fix suggestion.
 - **Max 5 MUST-FIX items. MUST-FIX = correctness bugs, security, missing requirements ONLY.**
 - **Review against the plan**, not personal preferences.
-- **Track iterations.** On re-review, focus on whether previous MUST-FIX items were resolved.
+- **Track iterations.** On re-review, focus on whether previous MUST-FIX and SHOULD-FIX items were resolved.
 
 ## Iteration Awareness
 
 When \`reviewIteration > 0\` (re-review after fixes), focus on:
-1. Were previous MUST-FIX items resolved?
+1. Were previous MUST-FIX and SHOULD-FIX items resolved?
 2. Did fixes introduce new issues?
-3. Any remaining MUST-FIX items?
+3. Any remaining MUST-FIX or SHOULD-FIX items?
 
 Read previous \`audits/<reviewer>.md\` files for context.
 
@@ -246,8 +256,8 @@ After review, normal routing applies: clean → Finalize, issues → Execute →
 ## Pipeline Orchestration
 
 Transition via \`luca state advance --to-step <step>\` per the pipeline-transitions table:
-- \`--to-step learn\` — clean or at iteration limit (then onward to milestone/complete).
-- \`--to-step execute\` — MUST-FIX issues need iteration.
+- \`--to-step learn\` — clean (no MUST-FIX/SHOULD-FIX) or at iteration limit (then onward to milestone/complete).
+- \`--to-step execute\` — MUST-FIX or SHOULD-FIX items need iteration.
 
 ### Context From Previous Stages
 

--- a/packages/luca-tools/src/artifacts/modes/review.ts
+++ b/packages/luca-tools/src/artifacts/modes/review.ts
@@ -256,7 +256,7 @@ After review, normal routing applies: clean → Finalize, issues → Execute →
 ## Pipeline Orchestration
 
 Transition via \`luca state advance --to-step <step>\` per the pipeline-transitions table:
-- \`--to-step learn\` — clean (no MUST-FIX/SHOULD-FIX) or at iteration limit (then onward to milestone/complete).
+- \`--to-step learn\` — clean (no MUST-FIX/SHOULD-FIX) or at iteration limit (then onward to finalize, which resets to idle).
 - \`--to-step execute\` — MUST-FIX or SHOULD-FIX items need iteration.
 
 ### Context From Previous Stages

--- a/packages/luca-tools/src/artifacts/modes/triage.ts
+++ b/packages/luca-tools/src/artifacts/modes/triage.ts
@@ -133,10 +133,9 @@ Default is **\`full-auto\`** — use unless the user explicitly requests \`--ove
 | \`checkpoint\`     | Pause at plan approval and phase boundaries.      |
 | \`human-in-loop\`  | Pause at every major decision point.              |
 
-### Next Mode
+### Next Step
 
-- **TRIVIAL / SIMPLE** → **Architect** (skip research).
-- **MODERATE / COMPLEX / CRITICAL** → **Research** first.
+All complexities advance to the **research** step — the only legal next step from \`triage\`. For **TRIVIAL / SIMPLE** the research step is lightweight (the researcher fast-exits with minimal findings) rather than skipped; for **MODERATE / COMPLEX / CRITICAL** it runs in full.
 
 ---
 
@@ -156,7 +155,7 @@ luca preferences write --file <(jq -n --arg intent "<parsed intent summary>" --a
 
 ### 4b. IMMEDIATELY advance the pipeline step:
 \`\`\`
-luca state advance --to-step <research|architect>
+luca state advance --to-step research
 \`\`\`
 
 **After calling advance, STOP. No more text or tool calls.**

--- a/packages/luca-tools/src/artifacts/skills/autopilot/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/autopilot/index.ts
@@ -1278,10 +1278,11 @@ Duration:   {session duration}
 
 ### Update State
 
-1. Advance the pipeline step to \`complete\` once the autopilot session finishes:
+1. Reset the pipeline to \`idle\` (via \`finalize\`) once the autopilot session finishes:
 
 \`\`\`bash
-luca state advance --to-step complete 2>/dev/null || true
+luca state advance --to-step finalize 2>/dev/null || true
+luca state advance --to-step idle 2>/dev/null || true
 \`\`\`
 
 2. Log final status to MuninnDB: \`mcp__muninn__muninn_remember(vault: "<repo_vault>", concept: "session:findings", content: "Autopilot session complete")\`

--- a/packages/luca-tools/src/artifacts/skills/gh-prepare/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/gh-prepare/index.ts
@@ -185,7 +185,7 @@ mcp__muninn__muninn_remember({
 
 ### 9. Pipeline integration
 
-Run \`luca state read\`. If a Luca pipeline is active (\`pipelineStep\` is not \`idle\`/\`complete\`), later pipeline steps discover this PR by recalling the \`gh-prepare\` memory from Step 8 — no separate workflow-state write is needed. If no pipeline is active, skip — the skill works standalone.
+Run \`luca state read\`. If a Luca pipeline is active (\`pipelineStep\` is not \`idle\`), later pipeline steps discover this PR by recalling the \`gh-prepare\` memory from Step 8 — no separate workflow-state write is needed. If no pipeline is active, skip — the skill works standalone.
 
 ### 10. Report
 

--- a/packages/luca-tools/src/artifacts/skills/lu/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/lu/index.ts
@@ -9,7 +9,7 @@
 import { defineSkill } from '../../../define/skill.ts'
 
 const BODY = `<main>
-The single entry point for the Luca pipeline. This SKILL is the long-form companion to the modernized \`/lu\` slash command — it drives the pipeline loop end-to-end: triage → research → discuss → architect → plan → plan-review → execute → checks → verify → review → learn → milestone.
+The single entry point for the Luca pipeline. This SKILL is the long-form companion to the modernized \`/lu\` slash command — it drives the pipeline loop end-to-end: triage → research → discuss → architect → plan → plan-review → execute → checks → verify → review → learn → finalize.
 
 **Arguments:** \`<task-description> [--complexity=TRIVIAL|SIMPLE|MODERATE|COMPLEX|CRITICAL] [--force-complex] [--skip-memory] [--skip-branch]\`
 
@@ -68,7 +68,7 @@ Triage runs once, at the start of a run. It is inline here — there is no separ
 
 ### Pipeline loop
 
-Repeat until \`pipelineStep\` is \`complete\`:
+Repeat until the \`finalize\` step resets the run (\`pipelineStep\` returns to \`idle\`):
 
 1. Run \`luca state read\` to get the current \`pipelineStep\`.
 2. Run the step using the table below.
@@ -85,8 +85,8 @@ Repeat until \`pipelineStep\` is \`complete\`:
 | \`checks\`      | Run \`luca checks run --file <commands.json>\` with the project's typecheck (and tests, if present). On failure, loop back to \`execute\`. |
 | \`verify\`      | Spawn \`verifier\` (Agent tool). On \`recommendation: fix\`, loop back to \`checks\`; on \`escalate\`, stop and surface to the user. |
 | \`review\`      | Spawn \`reviewer\` (Agent tool) — one per perspective, in parallel.     |
-| \`learn\`       | Spawn \`learner\` (Agent tool); it writes \`learn.md\` and returns a \`TO_PERSIST\` block. **You persist those learnings to MuninnDB** (subagents have no MCP access): for each \`TO_PERSIST\` entry call \`mcp__muninn__muninn_remember_batch\` routed to the entry's \`vault:\` (\`default\` for \`pattern:\`/\`pitfall:\`, the repo vault for \`convention:\`/\`decision:\`), deduping against existing memories. Then, if more phases remain: run \`luca phase advance\` (bumps \`currentPhase\` and marks the finished phase complete) **before** advancing the step to \`plan\`. On the last phase, do NOT run \`luca phase advance\`; advance to \`milestone\`. |
-| \`milestone\`   | Invoke \`Skill(skill: "milestone-new")\` to close out, or advance to \`complete\` if no milestone bookkeeping is needed. |
+| \`learn\`       | Spawn \`learner\` (Agent tool); it writes \`learn.md\` and returns a \`TO_PERSIST\` block. **You persist those learnings to MuninnDB** (subagents have no MCP access): for each \`TO_PERSIST\` entry call \`mcp__muninn__muninn_remember_batch\` routed to the entry's \`vault:\` (\`default\` for \`pattern:\`/\`pitfall:\`, the repo vault for \`convention:\`/\`decision:\`), deduping against existing memories. Then, if more phases remain: run \`luca phase advance\` (bumps \`currentPhase\` and marks the finished phase complete) **before** advancing the step to \`plan\`. On the last phase, do NOT run \`luca phase advance\`; advance to \`finalize\`. |
+| \`finalize\`    | Spawn the \`finalize\` agent (Agent tool): gap detection, postmortem gate, PR creation, milestone close (invokes \`Skill(skill: "milestone-complete")\` for the versioned snapshot + phase archive). On a gap/postmortem block it re-enters via \`--to-step execute\`/\`review\`; on success it resets the run with \`--to-step idle\`. |
 
 ### Oversight
 

--- a/packages/luca-tools/src/artifacts/skills/phase-execute/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/phase-execute/index.ts
@@ -1583,10 +1583,11 @@ git add .
 bun run commit --message="complete {phase-name} phase" --type=docs --scope={phase} --no-push --skip-checks
 \`\`\`\`
 
-Advance the workflow state after the actual commit succeeds. From \`learn\` the next step is typically \`milestone\` or \`complete\` per the pipeline-transitions table:
+Advance the workflow state after the actual commit succeeds. From \`learn\` the next step is \`finalize\` (which then resets to \`idle\`) per the pipeline-transitions table:
 
 \`\`\`bash
-luca state advance --to-step complete 2>/dev/null || true
+luca state advance --to-step finalize 2>/dev/null || true
+luca state advance --to-step idle 2>/dev/null || true
 \`\`\`
 
 ### 12. User Acceptance Testing (UAT)

--- a/packages/luca-tools/src/artifacts/skills/quick/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/quick/index.ts
@@ -195,11 +195,12 @@ Execute this quick task plan.
 
 ### Step 7: Advance Workflow State
 
-Advance the pipeline through learn/complete via the standard transitions:
+Advance the pipeline through learn → finalize → idle via the standard transitions:
 
 \`\`\`bash
 luca state advance --to-step learn
-luca state advance --to-step complete
+luca state advance --to-step finalize
+luca state advance --to-step idle
 \`\`\`
 
 ### Step 8: Final Commit and Completion
@@ -234,7 +235,7 @@ Ready for next task: /quick
 - [ ] Phase directory created at \`.luca/phases/NN-slug/\`
 - [ ] \`plan.md\` written by the architect mode-agent
 - [ ] \`execute/summary.md\` written by the \`executor\` subagent
-- [ ] Workflow state advanced through learn/complete steps
+- [ ] Workflow state advanced through learn → finalize → idle
 - [ ] Artifacts committed
 
 ## Next Steps


### PR DESCRIPTION
## Why

Two related defects in the pipeline state machine, found while investigating a run where `review → execute` was rejected at runtime:

1. **Dead re-entry edges.** `PIPELINE_TRANSITIONS` only encoded the happy path, so transitions the mode instructions *document* were illegal and rejected by `isLegalTransition`:
   - `review → execute` (MUST-FIX / SHOULD-FIX iteration) was missing — a blocking review finding could not loop back to fix and was silently carried forward to `learn`.
   - `finalize`'s gap-detection / postmortem re-entries (`→ execute`, `→ review`) were dead.
2. **`milestone`/`complete` were promoted to pipelineSteps**, conflating a work-organization concept (a milestone = a set of phases) with the per-phase lifecycle. That left `finalize` with no real home — it squatted on `learn` (REVIEWING), where the stage-gate blocks the commits / `gh pr create` that PR creation needs.

## What

Collapse the state machine to **13 steps** with `finalize` as the terminal mode, aligned with the mastracode model:

- Steps: `idle, triage, research, discuss, architect, plan, plan-review, execute, checks, verify, review, learn, finalize`.
- Transitions: `review: ['learn','execute']`, `learn: ['plan','finalize']`, `finalize: ['idle','execute','review']`.
- `finalize → FINALIZING` coarse phase (permits commits — fixes the latent PR-creation block) and resets the run to `idle`. One run finalizes one milestone; a fresh `/lu` starts the next.
- Legacy `state.json` with `milestone`/`complete`/`cleanup` folds to `finalize` (`LEGACY_PIPELINE_STEP_MAP`), so in-flight state still parses.

Also:
- **Conforms the coarse mode bodies to the fine table** — `research → discuss`, `architect → plan`, `triage → research` — so they no longer self-advance into illegal transitions.
- Sweeps the instruction surface + step-keyed tables (`coarse-phase-map`, `step-artifacts`, `context-refresher`, `continuation-messages`) to the new vocabulary.
- `finalize.ts`: advances `learn → finalize` on entry, fires re-entries from `finalize`, drops the in-session cross-milestone loop, ends with `--to-step idle`.

## Verification

`bunx --bun tsc --noEmit` — clean. The exhaustive `Record<PipelineStep, …>` tables (`coarse-phase-map`, `step-artifacts`) compile-error until every consumer is updated, which was the safety net for the sweep. Existing transition/schema tests updated to the 13-step set (no `bun test` run, per repo convention).

## Notes

- Touches `luca-core`, `luca-cli`, `luca-tools`. Deploying to a built CLI needs `bun run build` + `luca init`; from source it's already live.
- **Residual (separate effort):** `architect.ts` now advances to `plan` but still runs its discussion subagent internally — fully reconciling the coarse mode bodies to walk every fine step is deeper modes-vs-skills work, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)