### PR TITLE
fix(luca-core): canonicalize vault config to muninn.vault

### DIFF
--- a/.changeset/fix-vault-config-canonical-location.md
+++ b/.changeset/fix-vault-config-canonical-location.md
@@ -1,0 +1,12 @@
+---
+"@alecsibilia/luca": patch
+---
+
+Reconcile where the repo vault name lives in `.luca/config.json`: the canonical location is `muninn.vault`.
+
+`luca init`'s project skeleton wrote a **top-level** `vault: null` key, while `luca vault:init` writes `muninn.vault` — so a fully set-up project ended up with both a dead top-level `vault: null` and the real `muninn.vault`. The top-level key was never primary (`resolveRepoVault` only reads it as a legacy fallback), so it was dead weight that misled anyone reading the config.
+
+- **Writer fix:** the `init` skeleton now writes `muninn: { vault: null }` (the canonical, self-documenting placeholder) instead of a top-level `vault: null`. `luca vault:init` fills it in later by merging into `muninn`.
+- **Migration:** a new `luca doctor` project-scope check ("Vault config location") flags an existing top-level `vault` key and, under `luca doctor --fix`, normalizes it — folding a non-empty top-level value into `muninn.vault` when `muninn.vault` is unset, then removing the stale top-level key (all other config keys preserved).
+
+`resolveRepoVault` keeps its legacy top-level `vault` fallback for back-compat, but nothing writes there anymore.

--- a/packages/luca-cli/src/init/helpers/write-project-skeleton.ts
+++ b/packages/luca-cli/src/init/helpers/write-project-skeleton.ts
@@ -60,8 +60,12 @@ export async function writeProjectSkeleton(
             JSON.stringify(
                 {
                     lucaVersion: LUCA_VERSION,
-                    vault: null,
                     oversight: 'full-auto',
+                    // Canonical vault location is `muninn.vault` (see
+                    // resolveRepoVault + the vault-routing rule). `luca
+                    // vault:init` fills this in later; the placeholder makes the
+                    // canonical home discoverable in a fresh config.
+                    muninn: { vault: null },
                 },
                 null,
                 2

--- a/packages/luca-cli/src/utils/doctor/checks/vault-config-location.ts
+++ b/packages/luca-cli/src/utils/doctor/checks/vault-config-location.ts
@@ -1,0 +1,142 @@
+/**
+ * Doctor check: `.luca/config.json` stores the vault in the wrong place.
+ *
+ * The canonical vault location is `muninn.vault` (see `resolveRepoVault` and the
+ * vault-routing rule). An earlier `luca init` skeleton wrote a TOP-LEVEL `vault`
+ * key instead, so projects initialized before the fix carry a stale top-level
+ * `vault` (usually `null`) alongside the real `muninn.vault` that `luca
+ * vault:init` writes. The top-level key is never primary — `resolveRepoVault`
+ * only consults it as a legacy fallback — so it is dead weight that misleads
+ * anyone reading the config.
+ *
+ * Project-scoped (reads `<cwd>/.luca/config.json`). Warning-only with an
+ * auto-`fix()` that folds a non-empty top-level `vault` into `muninn.vault`
+ * (only when `muninn.vault` is unset) and removes the top-level key, preserving
+ * every other config key.
+ */
+import { existsSync } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import type { CheckResult, DoctorCheck, DoctorFixResult } from '../types'
+
+const CHECK_NAME = 'Vault config location'
+
+function configPath(): string {
+    return join(process.cwd(), '.luca', 'config.json')
+}
+
+async function readConfig(): Promise<Record<string, unknown> | null> {
+    const p = configPath()
+    if (!existsSync(p)) return null
+    try {
+        const raw = JSON.parse(await readFile(p, 'utf-8')) as unknown
+        return raw && typeof raw === 'object' && !Array.isArray(raw)
+            ? (raw as Record<string, unknown>)
+            : null
+    } catch {
+        return null
+    }
+}
+
+/** Read `muninn.vault` as a non-empty string, or undefined. */
+function muninnVaultOf(config: Record<string, unknown>): string | undefined {
+    const muninn = config.muninn
+    if (muninn && typeof muninn === 'object' && !Array.isArray(muninn)) {
+        const v = (muninn as Record<string, unknown>).vault
+        if (typeof v === 'string' && v.length > 0) return v
+    }
+    return undefined
+}
+
+export const vaultConfigLocationCheck: DoctorCheck = {
+    name: CHECK_NAME,
+    scope: 'project',
+
+    async run(): Promise<CheckResult> {
+        const pass = (message: string): CheckResult => ({
+            name: CHECK_NAME,
+            status: 'pass',
+            message,
+            fixCommand: null,
+            details: null,
+        })
+
+        const config = await readConfig()
+        if (config === null) {
+            return pass('no .luca/config.json to check')
+        }
+        if (!('vault' in config)) {
+            return pass('vault stored at canonical muninn.vault')
+        }
+
+        // A stale top-level `vault` key is present.
+        const topLevel = config.vault
+        const muninnVault = muninnVaultOf(config)
+        const wouldFold =
+            typeof topLevel === 'string' &&
+            topLevel.length > 0 &&
+            muninnVault === undefined
+
+        const detail = wouldFold
+            ? `It carries "${topLevel}" and muninn.vault is unset — \`--fix\` `
+              + `folds it into muninn.vault, then removes the top-level key.`
+            : `\`--fix\` removes it (muninn.vault is the source of truth).`
+
+        return {
+            name: CHECK_NAME,
+            status: 'warning',
+            message:
+                'config.json has a top-level `vault` key (canonical location is `muninn.vault`)',
+            fixCommand: 'luca doctor --fix',
+            details: [
+                `.luca/config.json stores a top-level \`vault\` key. The `
+                    + `canonical location is \`muninn.vault\`; the top-level key `
+                    + `is only read as a legacy fallback.`,
+                detail,
+            ].join('\n  '),
+        }
+    },
+
+    async fix(): Promise<DoctorFixResult> {
+        const config = await readConfig()
+        if (config === null || !('vault' in config)) {
+            return { applied: [], errors: [] }
+        }
+        try {
+            const topLevel = config.vault
+            const muninnVault = muninnVaultOf(config)
+            const next: Record<string, unknown> = { ...config }
+            const applied: string[] = []
+
+            if (
+                typeof topLevel === 'string' &&
+                topLevel.length > 0 &&
+                muninnVault === undefined
+            ) {
+                const existingMuninn =
+                    config.muninn &&
+                    typeof config.muninn === 'object' &&
+                    !Array.isArray(config.muninn)
+                        ? (config.muninn as Record<string, unknown>)
+                        : {}
+                next.muninn = { ...existingMuninn, vault: topLevel }
+                applied.push(`Folded top-level vault "${topLevel}" → muninn.vault`)
+            }
+
+            delete next.vault
+            applied.push('Removed stale top-level `vault` key from .luca/config.json')
+
+            await writeFile(configPath(), JSON.stringify(next, null, 2) + '\n')
+            return { applied, errors: [] }
+        } catch (err) {
+            return {
+                applied: [],
+                errors: [
+                    `Failed to normalize .luca/config.json vault location: `
+                        + `${(err as Error).message}`,
+                ],
+            }
+        }
+    },
+}

--- a/packages/luca-cli/src/utils/doctor/checks/vault-config-location.ts
+++ b/packages/luca-cli/src/utils/doctor/checks/vault-config-location.ts
@@ -39,12 +39,20 @@ async function readConfig(): Promise<Record<string, unknown> | null> {
     }
 }
 
-/** Read `muninn.vault` as a non-empty string, or undefined. */
+/** Return the trimmed string if non-empty after trimming, else undefined. */
+function nonEmptyTrimmed(v: unknown): string | undefined {
+    if (typeof v === 'string') {
+        const trimmed = v.trim()
+        if (trimmed.length > 0) return trimmed
+    }
+    return undefined
+}
+
+/** Read `muninn.vault` as a non-empty (trimmed) string, or undefined. */
 function muninnVaultOf(config: Record<string, unknown>): string | undefined {
     const muninn = config.muninn
     if (muninn && typeof muninn === 'object' && !Array.isArray(muninn)) {
-        const v = (muninn as Record<string, unknown>).vault
-        if (typeof v === 'string' && v.length > 0) return v
+        return nonEmptyTrimmed((muninn as Record<string, unknown>).vault)
     }
     return undefined
 }
@@ -67,16 +75,13 @@ export const vaultConfigLocationCheck: DoctorCheck = {
             return pass('no .luca/config.json to check')
         }
         if (!('vault' in config)) {
-            return pass('vault stored at canonical muninn.vault')
+            return pass('no legacy top-level vault key present')
         }
 
         // A stale top-level `vault` key is present.
-        const topLevel = config.vault
+        const topLevel = nonEmptyTrimmed(config.vault)
         const muninnVault = muninnVaultOf(config)
-        const wouldFold =
-            typeof topLevel === 'string' &&
-            topLevel.length > 0 &&
-            muninnVault === undefined
+        const wouldFold = topLevel !== undefined && muninnVault === undefined
 
         const detail = wouldFold
             ? `It carries "${topLevel}" and muninn.vault is unset — \`--fix\` `
@@ -104,16 +109,12 @@ export const vaultConfigLocationCheck: DoctorCheck = {
             return { applied: [], errors: [] }
         }
         try {
-            const topLevel = config.vault
+            const topLevel = nonEmptyTrimmed(config.vault)
             const muninnVault = muninnVaultOf(config)
             const next: Record<string, unknown> = { ...config }
             const applied: string[] = []
 
-            if (
-                typeof topLevel === 'string' &&
-                topLevel.length > 0 &&
-                muninnVault === undefined
-            ) {
+            if (topLevel !== undefined && muninnVault === undefined) {
                 const existingMuninn =
                     config.muninn &&
                     typeof config.muninn === 'object' &&

--- a/packages/luca-cli/src/utils/doctor/run-doctor.ts
+++ b/packages/luca-cli/src/utils/doctor/run-doctor.ts
@@ -39,6 +39,9 @@ export async function executeDoctor(
     const { configVersionSkewCheck } = await import(
         './checks/config-version-skew'
     )
+    const { vaultConfigLocationCheck } = await import(
+        './checks/vault-config-location'
+    )
 
     const allChecks: DoctorCheck[] = [
         // Prerequisites
@@ -52,6 +55,7 @@ export async function executeDoctor(
         // Project (cwd-dependent)
         strayLocalInstallCheck,
         configVersionSkewCheck,
+        vaultConfigLocationCheck,
     ]
 
     // Filter by scope if provided


### PR DESCRIPTION
## Why

The repo vault name was being stored in **two different places**: `luca init`'s skeleton wrote a top-level `vault: null`, while `luca vault:init` writes `muninn.vault`. A fully set-up project therefore ended up with both — a dead top-level `vault: null` *and* the real `muninn.vault`. The canonical location is `muninn.vault` (it's what `resolveRepoVault` reads first, what `vault:init` writes, and what the `vault-routing`/`vault-guard` rules specify); the top-level key was never primary and only survived as a legacy reader fallback, so it was dead weight that misled anyone reading the config.

## What

**1. Writer fix** — `write-project-skeleton.ts` now writes the canonical shape:
```jsonc
{ "lucaVersion": "...", "oversight": "full-auto", "muninn": { "vault": null } }
```
instead of a top-level `vault: null`. `luca vault:init` fills it in later by merging into `muninn`.

**2. Migration** — a new `luca doctor` project-scope check **"Vault config location"** flags an existing top-level `vault` key and, under `luca doctor --fix`, normalizes it:
- folds a non-empty top-level value into `muninn.vault` **only when `muninn.vault` is unset**,
- removes the stale top-level key,
- preserves every other config key.

`resolveRepoVault` keeps its legacy top-level fallback for back-compat, but nothing writes there anymore.

## Verification

- `bunx --bun tsc --noEmit` — clean.
- Empirically exercised `run()`/`fix()` across four config shapes (throwaway harness, not committed):
  - fresh canonical (`muninn.vault`) → **pass**, untouched
  - dead top-level `null` + real `muninn.vault` → drops the dead key, keeps the real one
  - legacy top-level value, `muninn` unset → folds value into `muninn.vault`
  - both set → `muninn.vault` wins, top-level dropped
- Changeset included (`patch`, fixed group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)