### PR TITLE
feat(repo): antigravity support

### DIFF
--- a/.changeset/feat-antigravity-support.md
+++ b/.changeset/feat-antigravity-support.md
@@ -1,0 +1,11 @@
+---
+"@alecsibilia/luca": patch
+"@alecsibilia/luca-cli": patch
+---
+
+feat(repo): add Antigravity CLI support
+
+- `luca init` now natively configures Antigravity CLI alongside Claude Code.
+- Adds `~/.gemini/antigravity-cli/skills` and `agents` provisioning.
+- Registers the stage-gate hook for Antigravity's `PreToolUse` event in `hooks.json`.
+- Automates MuninnDB MCP server registration in Antigravity's `settings.json`.

--- a/packages/luca-cli/src/commands/init.ts
+++ b/packages/luca-cli/src/commands/init.ts
@@ -42,10 +42,12 @@ import * as p from '@clack/prompts'
 import { defineCommand, runMain } from 'citty'
 
 import {
+    defaultAntigravityHome,
     defaultClaudeHome,
     installHooks,
     installSkills,
     installStatusline,
+    wireAntigravityHooks,
     wireClaudeHooks,
     writeProjectSkeleton,
 } from '../init'
@@ -198,18 +200,21 @@ export const initCommand = defineCommand({
             p.log.info('Step 3/5: MuninnDB (skipped)')
         }
 
-        // ── Step 4: Global Claude integration ────────────────────────────────
+        // ── Step 4: Global Agent integration ────────────────────────────────
         const claudeHome = defaultClaudeHome()
-        let claudeSetupRan = false
+        const agyHome = defaultAntigravityHome()
+        let agentSetupRan = false
         if (!args['skip-claude']) {
-            p.log.step('Step 4/5: Claude integration (~/.claude/)')
+            p.log.step('Step 4/5: Agent integration (~/.claude/ + ~/.gemini/antigravity-cli/)')
             await installSkills({ log: (msg) => p.log.info(msg) })
             await wireClaudeHooks({ log: (msg) => p.log.info(msg) })
+            await wireAntigravityHooks({ log: (msg) => p.log.info(msg) })
+            await wireAntigravityMcp({ log: (msg) => p.log.info(msg) })
             await installStatusline({ log: (msg) => p.log.info(msg) })
-            claudeSetupRan = true
-            p.log.success(`Claude skills, stage-gate hook, and statusline installed to ${claudeHome}`)
+            agentSetupRan = true
+            p.log.success('Claude and Antigravity skills, stage-gate hook, and MCP settings installed')
         } else {
-            p.log.info('Step 4/5: Claude integration (skipped)')
+            p.log.info('Step 4/5: Agent integration (skipped)')
         }
 
         // ── Step 5: Per-project skeleton ─────────────────────────────────────
@@ -266,8 +271,9 @@ export const initCommand = defineCommand({
         readout.push('Directories:')
         readout.push(`  ${homePaths.root}/`)
         readout.push(`  ${homePaths.bin}/`)
-        if (claudeSetupRan) {
+        if (agentSetupRan) {
             readout.push(`  ${claudeHome}/  (Claude skills, agents, hook — global)`)
+            readout.push(`  ${agyHome}/  (Antigravity skills, agents, hook — global)`)
         }
         if (projectSetupRan) {
             readout.push(`  ${process.cwd()}/.luca/  (per-project planning)`)

--- a/packages/luca-cli/src/hook/helpers/handle-stage-gate-hook.ts
+++ b/packages/luca-cli/src/hook/helpers/handle-stage-gate-hook.ts
@@ -166,14 +166,17 @@ export async function handleStageGateHook(
     if (
         toolName === 'Edit' ||
         toolName === 'Write' ||
-        toolName === 'NotebookEdit'
+        toolName === 'NotebookEdit' ||
+        toolName === 'replace' ||
+        toolName === 'write_file'
     ) {
-        const targetPath = (toolInput as { file_path?: string } | undefined)
-            ?.file_path
+        const targetPath = (
+            toolInput as { file_path?: string; path?: string } | undefined
+        )?.file_path ?? (toolInput as { file_path?: string; path?: string } | undefined)?.path
         if (!targetPath) {
             // Can't classify without a target. Allow conservatively —
-            // shouldn't happen in real Claude Code invocations.
-            log(`stage-gate: ${toolName} without file_path — allowing`)
+            // shouldn't happen in real Claude Code/Antigravity invocations.
+            log(`stage-gate: ${toolName} without file_path/path — allowing`)
             return { exitCode: 0, toolName, toolInput, decision: 'allow' }
         }
         // Claude Code passes an ABSOLUTE file_path, but the .luca/ contract
@@ -219,7 +222,11 @@ export async function handleStageGateHook(
             // pc.class === 'code' — normal project file. Matrix decides.
             category = pathClassToToolCategory(pc.class)
         }
-    } else if (toolName === 'Bash') {
+    } else if (
+        toolName === 'Bash' ||
+        toolName === 'run_shell_command' ||
+        toolName === 'run_command'
+    ) {
         const command =
             (toolInput as { command?: string } | undefined)?.command ?? ''
         const bashResult = classifyBashCommand(command)

--- a/packages/luca-cli/src/init/helpers/install-skills.ts
+++ b/packages/luca-cli/src/init/helpers/install-skills.ts
@@ -48,11 +48,22 @@ export function defaultClaudeHome(): string {
     return join(homedir(), '.claude')
 }
 
+/** The default global Antigravity config directory: `~/.gemini/antigravity-cli`. */
+export function defaultAntigravityHome(): string {
+    return join(homedir(), '.gemini', 'antigravity-cli')
+}
+
 /**
- * Copy bundled luca skills into the *global* Claude config directory:
+ * Copy bundled luca skills into the *global* config directories:
+ *
+ * For Claude Code:
  *   - `<artifacts>/.claude/commands/*.md`       → ~/.claude/commands/
  *   - `<artifacts>/.claude/agents/*.md`         → ~/.claude/agents/
  *   - `<artifacts>/skills/<name>/SKILL.md`      → ~/.claude/skills/
+ *
+ * For Antigravity CLI:
+ *   - `<artifacts>/skills/<name>/SKILL.md`      → ~/.gemini/antigravity-cli/skills/
+ *   - `<artifacts>/.claude/agents/*.md`         → ~/.gemini/antigravity-cli/agents/
  *
  * Installing globally — rather than per-repo — means one luca CLI version
  * owns a single canonical skill set across every project. Repos stay
@@ -77,6 +88,8 @@ export function defaultClaudeHome(): string {
 export async function installSkills(opts: InstallSkillsOptions): Promise<void> {
     const log = opts.log ?? (() => {})
     const claudeHome = opts.claudeHome ?? defaultClaudeHome()
+    const agyHome = defaultAntigravityHome()
+
     const resolved = resolveBundledArtifacts({
         claudeArtifactsRoot: opts.claudeArtifactsRoot,
         skillsRoot: opts.skillsRoot,
@@ -98,23 +111,40 @@ export async function installSkills(opts: InstallSkillsOptions): Promise<void> {
         return
     }
 
+    // Install to Claude Code
     await copyDir({
         from: join(claudeArtifactsRoot, 'commands'),
         to: join(claudeHome, 'commands'),
         log,
-        label: 'command',
+        label: 'Claude command',
     })
 
     await copyDir({
         from: join(claudeArtifactsRoot, 'agents'),
         to: join(claudeHome, 'agents'),
         log,
-        label: 'agent',
+        label: 'Claude agent',
     })
 
     await copySkillTree({
         from: skillsRoot,
         to: join(claudeHome, 'skills'),
+        log,
+    })
+
+    // Install to Antigravity CLI (if the directory exists or we want to support it)
+    // We don't check for existence of agyHome here to allow 'luca init' to set it up
+    // even if agy hasn't been run yet, but typically agy creates it.
+    await copyDir({
+        from: join(claudeArtifactsRoot, 'agents'),
+        to: join(agyHome, 'agents'),
+        log,
+        label: 'Antigravity agent',
+    })
+
+    await copySkillTree({
+        from: skillsRoot,
+        to: join(agyHome, 'skills'),
         log,
     })
 }

--- a/packages/luca-cli/src/init/helpers/wire-claude-hooks.ts
+++ b/packages/luca-cli/src/init/helpers/wire-claude-hooks.ts
@@ -2,20 +2,23 @@ import { existsSync } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
-import { defaultClaudeHome } from './install-skills.ts'
+import { defaultAntigravityHome, defaultClaudeHome } from './install-skills.ts'
 
 export interface WireClaudeHooksOptions {
-    /** Global Claude config directory. Defaults to `~/.claude`. */
+    /** Global config directory. Defaults to `~/.claude` for Claude or `~/.gemini/antigravity-cli` for Antigravity. */
+    home?: string
+    /** Alias for home, kept for compatibility with older callers. */
     claudeHome?: string
     log?: (msg: string) => void
 }
 
 // Matcher per decision:luca-stage-gate-hook-scope-2026-05-19 (D2): hook fires
 // on every tool that can mutate the filesystem.
-const STAGE_GATE_MATCHER = 'Edit|Write|NotebookEdit|Bash'
+const CLAUDE_STAGE_GATE_MATCHER = 'Edit|Write|NotebookEdit|Bash'
+const AGY_STAGE_GATE_MATCHER = 'replace|write_file|run_shell_command|run_command'
 
 /**
- * Command registered in `~/.claude/settings.json`. The luca CLI is on PATH
+ * Command registered in the agent's global settings. The luca CLI is on PATH
  * (installed globally), so the hook needs no wrapper script — it delegates
  * straight to `luca hook stage-gate`, which reads the project's
  * `.luca/state.json` relative to the cwd at invocation time. In a non-luca
@@ -44,6 +47,27 @@ interface ClaudeSettings {
     [k: string]: unknown
 }
 
+interface AntigravitySettings {
+    hooks?: AntigravityHooks
+    mcpServers?: Record<
+        string,
+        {
+            command: string
+            args: string[]
+            env?: Record<string, string>
+        }
+    >
+    [k: string]: unknown
+}
+
+interface AntigravityHooks {
+    [hookName: string]: {
+        enabled?: boolean
+        PreToolUse?: PreToolUseEntry[]
+        [k: string]: unknown
+    }
+}
+
 /**
  * Register the luca stage-gate hook in the *global* Claude settings
  * (`~/.claude/settings.json`). Merges the PreToolUse entry into any
@@ -54,10 +78,10 @@ interface ClaudeSettings {
  * per-repo. Idempotent — re-running won't duplicate the entry.
  */
 export async function wireClaudeHooks(
-    opts: WireClaudeHooksOptions
+    opts: WireClaudeHooksOptions = {}
 ): Promise<void> {
     const log = opts.log ?? (() => {})
-    const claudeHome = opts.claudeHome ?? defaultClaudeHome()
+    const claudeHome = opts.home ?? opts.claudeHome ?? defaultClaudeHome()
     const settingsPath = join(claudeHome, 'settings.json')
 
     await mkdir(claudeHome, { recursive: true })
@@ -71,6 +95,56 @@ export async function wireClaudeHooks(
         : {}
 
     const next = mergeStageGateRegistration(existing)
+
+    await writeFile(settingsPath, JSON.stringify(next, null, 2) + '\n')
+    log(`  write: ${settingsPath}`)
+}
+
+/**
+ * Register the luca stage-gate hook in the *global* Antigravity hooks
+ * (`~/.gemini/antigravity-cli/hooks.json`).
+ */
+export async function wireAntigravityHooks(
+    opts: WireClaudeHooksOptions = {}
+): Promise<void> {
+    const log = opts.log ?? (() => {})
+    const agyHome = opts.home ?? defaultAntigravityHome()
+    const hooksPath = join(agyHome, 'hooks.json')
+
+    await mkdir(agyHome, { recursive: true })
+
+    const existing = existsSync(hooksPath)
+        ? ((JSON.parse(
+              await readFile(hooksPath, 'utf-8')
+          ) as AntigravityHooks) ?? {})
+        : {}
+
+    const next = mergeAntigravityHookRegistration(existing)
+
+    await writeFile(hooksPath, JSON.stringify(next, null, 2) + '\n')
+    log(`  write: ${hooksPath}`)
+}
+
+/**
+ * Register the MuninnDB MCP server in the *global* Antigravity settings
+ * (`~/.gemini/antigravity-cli/settings.json`).
+ */
+export async function wireAntigravityMcp(
+    opts: WireClaudeHooksOptions = {}
+): Promise<void> {
+    const log = opts.log ?? (() => {})
+    const agyHome = opts.home ?? defaultAntigravityHome()
+    const settingsPath = join(agyHome, 'settings.json')
+
+    await mkdir(agyHome, { recursive: true })
+
+    const existing = existsSync(settingsPath)
+        ? ((JSON.parse(
+              await readFile(settingsPath, 'utf-8')
+          ) as AntigravitySettings) ?? {})
+        : {}
+
+    const next = mergeAntigravityMcpRegistration(existing)
 
     await writeFile(settingsPath, JSON.stringify(next, null, 2) + '\n')
     log(`  write: ${settingsPath}`)
@@ -102,7 +176,7 @@ export function mergeStageGateRegistration(
     }
 
     preToolUse.push({
-        matcher: STAGE_GATE_MATCHER,
+        matcher: CLAUDE_STAGE_GATE_MATCHER,
         hooks: [
             {
                 type: 'command',
@@ -113,5 +187,66 @@ export function mergeStageGateRegistration(
     })
 
     next.hooks.PreToolUse = preToolUse
+    return next
+}
+
+/**
+ * Merge the stage-gate PreToolUse registration into an existing
+ * AntigravityHooks object.
+ */
+export function mergeAntigravityHookRegistration(
+    hooks: AntigravityHooks
+): AntigravityHooks {
+    const next: AntigravityHooks = { ...hooks }
+
+    // Idempotency: check if 'luca-stage-gate' already exists
+    if (next['luca-stage-gate']) {
+        return next
+    }
+
+    next['luca-stage-gate'] = {
+        enabled: true,
+        PreToolUse: [
+            {
+                matcher: AGY_STAGE_GATE_MATCHER,
+                hooks: [
+                    {
+                        type: 'command',
+                        command: STAGE_GATE_COMMAND,
+                        timeout: 30,
+                    },
+                ],
+            },
+        ],
+    }
+
+    return next
+}
+
+/**
+ * Merge the MuninnDB MCP registration into an existing AntigravitySettings object.
+ */
+export function mergeAntigravityMcpRegistration(
+    settings: AntigravitySettings
+): AntigravitySettings {
+    const next: AntigravitySettings = { ...settings }
+    next.mcpServers = { ...(settings.mcpServers ?? {}) }
+
+    // Idempotency: check if 'muninn' already exists
+    if (next.mcpServers.muninn) {
+        return next
+    }
+
+    // Note: This uses the standard SSE transport for MuninnDB.
+    // The API key is usually picked up from the environment or vault.
+    next.mcpServers.muninn = {
+        command: 'npx',
+        args: [
+            '-y',
+            '@modelcontextprotocol/server-sse',
+            'http://localhost:8750/mcp',
+        ],
+    }
+
     return next
 }

--- a/packages/luca-cli/src/init/index.ts
+++ b/packages/luca-cli/src/init/index.ts
@@ -7,7 +7,11 @@ export type { WriteProjectSkeletonOptions } from './helpers/write-project-skelet
 
 export {
     wireClaudeHooks,
+    wireAntigravityHooks,
+    wireAntigravityMcp,
     mergeStageGateRegistration,
+    mergeAntigravityHookRegistration,
+    mergeAntigravityMcpRegistration,
 } from './helpers/wire-claude-hooks.ts'
 export type { WireClaudeHooksOptions } from './helpers/wire-claude-hooks.ts'
 


### PR DESCRIPTION
Extracts the Antigravity CLI integration from the PAI learnings branch into a standalone release. This adds native support for `agy` initialization, stage-gate hooks, and MuninnDB MCP registration.