### PR TITLE
fix(stage-gate): allow inert ephemeral scratch writes in any pipeline step

### DIFF
--- a/.changeset/fix-stage-gate-allows-ephemeral-scratch.md
+++ b/.changeset/fix-stage-gate-allows-ephemeral-scratch.md
@@ -1,0 +1,34 @@
+---
+"@alecsibilia/luca": patch
+---
+
+Stage-gate: allow inert ephemeral scratch writes in any pipeline step.
+
+The stage-gate hook classified every `Write` as either a `.luca/` artifact
+or project `code`, so a skill writing an out-of-band preview (e.g.
+`decision-visualizer`'s self-contained HTML page) was blocked as
+`code-write` whenever the pipeline was parked at a gated step:
+
+```
+stage-gate BLOCK: Write (category=code-write) is not allowed in
+phase=REVIEWING (pipelineStep=learn)
+```
+
+Worse, macOS `mktemp` returns a path under `/var/folders/…`, which the
+`/var` system-dir rule hard-denied in *every* phase.
+
+This adds a first-class `ephemeral` write class for writes that touch
+neither the repo tree nor pipeline state, allowed in any `pipelineStep`
+(the phase/tool matrix is bypassed for this class):
+
+- **OS temp dirs** — the universal `/tmp` and `/private/tmp`, plus the
+  platform temp root supplied via `os.tmpdir()` / `$TMPDIR`, so macOS
+  `/var/folders/…/T` is recognised *before* the `/var` denial.
+- **`.luca/tmp/previews/<name>.<ext>`** — a sanctioned, gitignored in-repo
+  preview location (new `tmp.preview` contract kind) so previews render
+  mid-pipeline and persist for the session.
+
+Security floor preserved: the legacy `/tmp/luca-*` collision denial is
+checked first; non-temp `/var` paths, `.git/`, `~/.claude/`, `~/.luca/`,
+and system dirs stay denied; and only the structured `Write`/`Edit` tools
+get the bypass — Bash mutations remain phase-gated.

--- a/packages/luca-cli/src/hook/helpers/handle-stage-gate-hook.test.ts
+++ b/packages/luca-cli/src/hook/helpers/handle-stage-gate-hook.test.ts
@@ -234,6 +234,73 @@ describe('handleStageGateHook — REVIEWING', () => {
     })
 })
 
+// Regression: a presentational skill (e.g. decision-visualizer) writes an
+// inert ephemeral HTML preview while the pipeline is parked at a gated step.
+// Such writes touch neither the repo nor pipeline state and must be allowed
+// in any pipelineStep — the previous behaviour blocked them as 'code-write'.
+describe('handleStageGateHook — ephemeral scratch (gated step)', () => {
+    let cwd: string
+    beforeEach(async () => {
+        // `learn` lives in REVIEWING — the exact step from the bug report.
+        cwd = await makeProjectAtStep('learn')
+    })
+    afterEach(async () => {
+        await rm(cwd, { recursive: true, force: true })
+    })
+
+    function writeStdin(filePath: string): string {
+        return JSON.stringify({
+            tool_name: 'Write',
+            tool_input: { file_path: filePath },
+        })
+    }
+
+    test('allows Write to an OS-temp HTML preview during learn', async () => {
+        const r = await handleStageGateHook({
+            stdin: writeStdin('/tmp/ramora-p4-cycle4-decision.html'),
+            cwd,
+        })
+        expect(r.exitCode).toBe(0)
+        expect(r.decision).toBe('allow')
+    })
+
+    test('allows Write to the platform tmpdir via tmpdirs', async () => {
+        const r = await handleStageGateHook({
+            stdin: writeStdin('/var/folders/ab/cd/T/xyz/decision.html'),
+            cwd,
+            tmpdirs: ['/var/folders/ab/cd/T'],
+        })
+        expect(r.exitCode).toBe(0)
+        expect(r.decision).toBe('allow')
+    })
+
+    test('allows Write to .luca/tmp/previews/<name> during learn', async () => {
+        const r = await handleStageGateHook({
+            stdin: writeStdin('.luca/tmp/previews/auth-decision.html'),
+            cwd,
+        })
+        expect(r.exitCode).toBe(0)
+        expect(r.decision).toBe('allow')
+    })
+
+    test('still blocks Write to a project HTML file during learn', async () => {
+        const r = await handleStageGateHook({
+            stdin: writeStdin('src/pages/decision.html'),
+            cwd,
+        })
+        expect(r.exitCode).toBe(2)
+    })
+
+    test('still denies the legacy /tmp/luca-* payload during learn', async () => {
+        const r = await handleStageGateHook({
+            stdin: writeStdin('/tmp/luca-checks-07.json'),
+            cwd,
+            tmpdirs: ['/tmp'],
+        })
+        expect(r.exitCode).toBe(2)
+    })
+})
+
 describe('handleStageGateHook — FINALIZING', () => {
     let cwd: string
     beforeEach(async () => {

--- a/packages/luca-cli/src/hook/helpers/handle-stage-gate-hook.ts
+++ b/packages/luca-cli/src/hook/helpers/handle-stage-gate-hook.ts
@@ -16,6 +16,8 @@ import {
     type ToolCategory,
     type WritePathClass,
 } from '@alecsibilia/luca-core'
+import { tmpdir } from 'node:os'
+
 import { parse } from 'shell-quote'
 
 import {
@@ -35,6 +37,11 @@ export interface HandleStageGateHookOptions {
     /** User home directory (for detecting absolute paths under ~/.claude/
      *  or ~/.luca/). Defaults to process.env.HOME. */
     homedir?: string
+    /** Absolute OS-temp-dir prefixes treated as ephemeral scratch (allowed
+     *  in any pipelineStep). Defaults to [`$TMPDIR`, `os.tmpdir()`]; tests
+     *  pass an explicit dir. The universal `/tmp` and `/private/tmp` roots
+     *  are always recognised regardless of this value. */
+    tmpdirs?: string[]
 }
 
 export interface HandleStageGateHookResult {
@@ -101,6 +108,9 @@ export async function handleStageGateHook(
 
     const cwd = opts.cwd ?? process.cwd()
     const homedir = opts.homedir ?? process.env.HOME
+    const tmpdirs = opts.tmpdirs ?? [process.env.TMPDIR, tmpdir()].filter(
+        (d): d is string => Boolean(d)
+    )
 
     const state = await loadCurrentState({ cwd })
 
@@ -186,9 +196,19 @@ export async function handleStageGateHook(
         // yield `../../.luca/…` and wrongly fail the gate). Denied checks
         // still run on the absolute original inside classifyWritePath.
         const relTarget = toLucaRelative(targetPath, cwd)
-        const pc = classifyWritePath(targetPath, { homedir, cwd })
+        const pc = classifyWritePath(targetPath, { homedir, cwd, tmpdirs })
         if (pc.class === 'denied') {
             pathBlockReason = `${toolName} to '${targetPath}' is always denied: ${pc.reason ?? 'forbidden path'}`
+        } else if (pc.class === 'ephemeral') {
+            // Inert ephemeral scratch (OS-temp file or .luca/tmp/previews/<name>):
+            // a browser preview / screenshot / generated HTML that touches
+            // neither the repo nor pipeline state. Allowed in ANY pipelineStep
+            // — bypass the phase/tool matrix entirely (the always-denied path
+            // rules above have already run).
+            log(
+                `stage-gate: ${toolName} to '${targetPath}' is ephemeral scratch — allowing`
+            )
+            return { exitCode: 0, toolName, toolInput, decision: 'allow' }
         } else if (
             pc.class === 'planning-general' ||
             pc.class === 'planning-audit'
@@ -236,7 +256,7 @@ export async function handleStageGateHook(
             }`
         } else {
             for (const target of bashResult.targetPaths) {
-                const pc = classifyWritePath(target, { homedir })
+                const pc = classifyWritePath(target, { homedir, tmpdirs })
                 if (pc.class === 'denied') {
                     pathBlockReason = `Bash writes to denied path '${target}': ${
                         pc.reason ?? 'forbidden path'
@@ -502,6 +522,10 @@ function pathClassToToolCategory(c: WritePathClass): ToolCategory {
             return 'planning-write-general'
         case 'planning-audit':
             return 'planning-write-audit'
+        case 'ephemeral':
+            // Caller short-circuits 'ephemeral' to allow before this is
+            // called — it has no phase/tool-matrix category.
+            throw new Error('pathClassToToolCategory called with ephemeral')
         case 'denied':
             // Caller has already handled 'denied' before this is called.
             throw new Error('pathClassToToolCategory called with denied')

--- a/packages/luca-core/src/luca-dir/configs.ts
+++ b/packages/luca-core/src/luca-dir/configs.ts
@@ -140,13 +140,13 @@ export const LUCA_DIR_CONTRACT = {
         tmp: {
             path: 'tmp/',
             description:
-                'Ephemeral, repo-scoped CLI-handoff payloads (LLM orchestrator → `luca` CLI via --file). Gitignored; NOT pipeline artifacts. Flat .json files only.',
-            pattern: '<kebab-name>.json',
+                'Ephemeral, repo-scoped scratch. Gitignored; NOT pipeline artifacts; writable in any pipelineStep. Two shapes: flat <kebab-name>.json CLI-handoff payloads (LLM orchestrator → `luca` CLI via --file), and previews/<name>.<ext> browser previews (e.g. a decision-visualizer page).',
+            pattern: '<kebab-name>.json | previews/<name>.<ext>',
         },
     },
     rules: [
-        'No notes/, drafts/, or other ad-hoc directories — if not in the allowlist, it does not exist. (tmp/ IS sanctioned, but only for flat <kebab-name>.json CLI-handoff payloads.)',
-        'tmp/ holds ONLY ephemeral <kebab-name>.json handoff files (repo-scoped scratch for `luca <cmd> --file`); it is gitignored and writable in any pipelineStep. Never put pipeline artifacts there.',
+        'No notes/, drafts/, or other ad-hoc directories — if not in the allowlist, it does not exist. (tmp/ IS sanctioned, but only for flat <kebab-name>.json CLI-handoff payloads and previews/<name>.<ext> browser previews.)',
+        'tmp/ holds ONLY ephemeral <kebab-name>.json handoff files and previews/<name>.<ext> browser previews; it is gitignored and writable in any pipelineStep. Never put pipeline artifacts there.',
         'Phase slugs are <NN>-<kebab-case> with zero-padded NN derived from roadmap order — NOT LLM-named.',
         'Audit filenames are fixed by reviewer name (kebab-case) — NOT LLM-named.',
         'Wave files are NN.md (zero-padded) — NOT LLM-named.',

--- a/packages/luca-core/src/luca-dir/constants.ts
+++ b/packages/luca-core/src/luca-dir/constants.ts
@@ -37,6 +37,14 @@ export const RUN_ID_RE = /^[A-Za-z0-9_-]+$/
 // are NOT pipeline artifacts. Examples: "roadmap.json", "pr-findings.json"
 export const TMP_FILE_RE = /^[a-z][a-z0-9-]*\.json$/
 
+// tmp/previews/ scratch file: a kebab-case basename with any single
+// extension. These are ephemeral, repo-scoped, gitignored browser previews
+// (e.g. a decision-visualizer page) — NOT pipeline artifacts and NOT
+// CLI-handoff payloads. Allowed in ANY pipelineStep because they touch
+// neither the repo nor pipeline state. Examples: "auth-decision.html",
+// "ws-reconnect-tradeoffs.html".
+export const TMP_PREVIEW_FILE_RE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.[a-z0-9]+$/i
+
 // ---------------------------------------------------------------------------
 // Directory + file path constants
 // ---------------------------------------------------------------------------

--- a/packages/luca-core/src/luca-dir/helpers/classify-write-path.test.ts
+++ b/packages/luca-core/src/luca-dir/helpers/classify-write-path.test.ts
@@ -105,9 +105,9 @@ describe('classifyWritePath — always-denied paths', () => {
         }
     })
 
-    test('does not deny non-luca /tmp scratch files', () => {
-        expect(classifyWritePath('/tmp/scratch.json').class).toBe('code')
-        expect(classifyWritePath('/tmp/some-script.sh').class).toBe('code')
+    test('classifies non-luca /tmp scratch files as ephemeral (not denied)', () => {
+        expect(classifyWritePath('/tmp/scratch.json').class).toBe('ephemeral')
+        expect(classifyWritePath('/tmp/some-script.sh').class).toBe('ephemeral')
     })
 
     test('denies absolute paths under the user home .claude/ or .luca/', () => {
@@ -122,6 +122,70 @@ describe('classifyWritePath — always-denied paths', () => {
                 homedir,
             }).class
         ).toBe('denied')
+    })
+})
+
+describe('classifyWritePath — ephemeral OS-temp + preview scratch', () => {
+    test('classifies universal /tmp and /private/tmp writes as ephemeral', () => {
+        expect(classifyWritePath('/tmp/decision.html').class).toBe('ephemeral')
+        expect(
+            classifyWritePath('/private/tmp/ramora-p4-decision.html').class
+        ).toBe('ephemeral')
+    })
+
+    test('classifies platform tmpdir (macOS /var/folders) as ephemeral via tmpdirs opt', () => {
+        const tmpdirs = ['/var/folders/ab/cd1234/T']
+        expect(
+            classifyWritePath('/var/folders/ab/cd1234/T/abc/decision.html', {
+                tmpdirs,
+            }).class
+        ).toBe('ephemeral')
+        // A custom $TMPDIR-style root also passed via tmpdirs.
+        expect(
+            classifyWritePath('/Users/alec/.cache/tmp/x.html', {
+                tmpdirs: ['/Users/alec/.cache/tmp'],
+            }).class
+        ).toBe('ephemeral')
+    })
+
+    test('platform /var/folders temp is NOT denied by the /var system-dir rule', () => {
+        // Without the tmpdirs opt it falls back to the /var denial — but the
+        // hook always supplies os.tmpdir(), so the real path is exercised above.
+        const r = classifyWritePath('/var/folders/ab/cd/T/x.html', {
+            tmpdirs: ['/var/folders/ab/cd/T'],
+        })
+        expect(r.class).not.toBe('denied')
+    })
+
+    test('legacy /tmp/luca-* payloads stay denied even though they live under /tmp', () => {
+        // The collision denial is checked before the ephemeral allow.
+        const r = classifyWritePath('/tmp/luca-checks-07.json', {
+            tmpdirs: ['/tmp'],
+        })
+        expect(r.class).toBe('denied')
+        expect(r.reason).toContain('.luca/tmp/')
+    })
+
+    test('non-temp /var paths remain denied', () => {
+        expect(classifyWritePath('/var/log/system.log').class).toBe('denied')
+    })
+
+    test('classifies .luca/tmp/previews/<name> as ephemeral', () => {
+        expect(
+            classifyWritePath('.luca/tmp/previews/auth-decision.html').class
+        ).toBe('ephemeral')
+        expect(
+            classifyWritePath(
+                '/repo/.luca/tmp/previews/ws-reconnect.html',
+                { cwd: '/repo' }
+            ).class
+        ).toBe('ephemeral')
+    })
+
+    test('flat .luca/tmp/<name>.json handoffs remain planning-general (unchanged)', () => {
+        expect(classifyWritePath('.luca/tmp/roadmap.json').class).toBe(
+            'planning-general'
+        )
     })
 })
 

--- a/packages/luca-core/src/luca-dir/helpers/classify-write-path.ts
+++ b/packages/luca-core/src/luca-dir/helpers/classify-write-path.ts
@@ -1,11 +1,21 @@
 import { isAbsolute, relative } from 'node:path'
 
-import { PHASE_SLUG_RE, REVIEWER_NAME_RE, TMP_FILE_RE } from '../constants.ts'
+import {
+    PHASE_SLUG_RE,
+    REVIEWER_NAME_RE,
+    TMP_FILE_RE,
+    TMP_PREVIEW_FILE_RE,
+} from '../constants.ts'
 
 export type WritePathClass =
     | 'code'
     | 'planning-general'
     | 'planning-audit'
+    // Inert ephemeral scratch — an OS-temp-dir file or a sanctioned in-repo
+    // preview (`.luca/tmp/previews/<name>`). Touches neither the repo nor
+    // pipeline state, so the stage-gate allows it in ANY pipelineStep
+    // (the matrix is bypassed for this class — see the hook).
+    | 'ephemeral'
     | 'denied'
 
 export interface ClassifyResult {
@@ -26,6 +36,15 @@ export interface ClassifyOptions {
      * blocks it. The always-denied checks still run on the original path.
      */
     cwd?: string
+    /**
+     * Absolute OS-temp-dir prefixes to treat as ephemeral scratch (in
+     * addition to the universal `/tmp` and `/private/tmp`). Callers pass
+     * `os.tmpdir()` / `$TMPDIR` so platform-specific temp roots are covered
+     * — notably macOS's per-user `/var/folders/…/T`, which would otherwise be
+     * hard-denied by the `/var` system-dir rule. A write under any of these
+     * (that is not a legacy `/tmp/luca-*` payload) classifies as `ephemeral`.
+     */
+    tmpdirs?: string[]
 }
 
 // Patterns matched against the leading directory segments of a path.
@@ -44,6 +63,35 @@ const HOME_DENIED_SUBDIRS = ['.claude', '.luca']
 // macOS's physical location for `/tmp` (a symlink), so both spellings
 // are covered.
 const SHARED_TMP_LUCA_PATTERN = /^\/(private\/)?tmp\/luca-/
+
+// Universal POSIX temp roots, always treated as ephemeral scratch (`/tmp`
+// is a symlink to `/private/tmp` on macOS, so both spellings are covered).
+// Platform-specific roots (macOS `/var/folders/…/T`, a custom `$TMPDIR`)
+// arrive via ClassifyOptions.tmpdirs.
+const BUILTIN_TMP_PREFIXES = ['/tmp/', '/private/tmp/']
+
+/**
+ * Is `path` a write into a genuine OS temp directory? Such writes are inert
+ * scratch (browser previews, screenshots, generated HTML) — they touch
+ * neither the repo tree nor `.luca/` pipeline state — so they are allowed in
+ * any pipelineStep. The caller-supplied `tmpdirs` extend the universal
+ * `/tmp` roots with the platform temp dir (`os.tmpdir()` / `$TMPDIR`).
+ *
+ * The legacy `/tmp/luca-*` collision denial is checked BEFORE this in
+ * `classifyWritePath`, so a luca-namespaced handoff payload stays denied
+ * even though it lives under `/tmp`.
+ */
+function isEphemeralOsTemp(path: string, tmpdirs: readonly string[]): boolean {
+    const p = path.replace(/\\/g, '/')
+    if (!p.startsWith('/')) return false
+    const prefixes = [...BUILTIN_TMP_PREFIXES]
+    for (const dir of tmpdirs) {
+        if (!dir) continue
+        const norm = dir.replace(/\\/g, '/').replace(/\/+$/, '')
+        if (norm.startsWith('/')) prefixes.push(`${norm}/`)
+    }
+    return prefixes.some((prefix) => p.startsWith(prefix))
+}
 
 // Audit file pattern: .luca/phases/<NN-slug>/audits/<reviewer>.md
 //
@@ -128,12 +176,15 @@ export function toLucaRelative(path: string, cwd?: string): string {
  *   - 'code': normal project file (src/, packages/, package.json, …)
  *   - 'planning-general': .luca/ artifact other than an audit file
  *   - 'planning-audit': .luca/phases/<slug>/audits/<reviewer>.md
+ *   - 'ephemeral': inert OS-temp scratch or `.luca/tmp/previews/<name>`
+ *                  (browser previews, screenshots) — allowed in any phase
  *   - 'denied': must never be written regardless of phase
  *               (.git/, ~/.claude/, ~/.luca/, /etc/, /usr/, /var/, /System/,
  *               /bin/, /sbin/, and legacy shared-tmp /tmp/luca-* payloads)
  *
  * Pass `homedir` to detect absolute paths under the user home that
- * resolve to denied subdirectories.
+ * resolve to denied subdirectories. Pass `tmpdirs` (`os.tmpdir()`/`$TMPDIR`)
+ * so the platform temp root is recognised as ephemeral.
  */
 export function classifyWritePath(
     path: string,
@@ -147,15 +198,10 @@ export function classifyWritePath(
         }
     }
 
-    // 2. Always-denied: system dirs
-    if (SYSTEM_DIR_PATTERN.test(path)) {
-        return {
-            class: 'denied',
-            reason: 'writes under system directories (/etc, /usr, /var, /System, /bin, /sbin) are never allowed',
-        }
-    }
-
-    // 3. Always-denied: legacy shared-tmp luca handoff payloads
+    // 2. Always-denied: legacy shared-tmp luca handoff payloads. Checked
+    //    BEFORE the ephemeral OS-temp allow (step 3) so a luca-namespaced
+    //    payload under /tmp stays denied — it must be repo-scoped to avoid
+    //    cross-repo collisions.
     if (SHARED_TMP_LUCA_PATTERN.test(path)) {
         return {
             class: 'denied',
@@ -165,7 +211,23 @@ export function classifyWritePath(
         }
     }
 
-    // 4. Always-denied: user-home tooling dirs
+    // 3. Ephemeral OS-temp scratch. Runs BEFORE the system-dir denial (step
+    //    4) because macOS's per-user temp root lives under /var/folders,
+    //    which the /var rule would otherwise hard-deny. Inert scratch —
+    //    allowed in any pipelineStep.
+    if (isEphemeralOsTemp(path, opts.tmpdirs ?? [])) {
+        return { class: 'ephemeral' }
+    }
+
+    // 4. Always-denied: system dirs
+    if (SYSTEM_DIR_PATTERN.test(path)) {
+        return {
+            class: 'denied',
+            reason: 'writes under system directories (/etc, /usr, /var, /System, /bin, /sbin) are never allowed',
+        }
+    }
+
+    // 5. Always-denied: user-home tooling dirs
     for (const subdir of HOME_DENIED_SUBDIRS) {
         if (path.startsWith(`~/${subdir}/`) || path === `~/${subdir}`) {
             return {
@@ -184,18 +246,26 @@ export function classifyWritePath(
         }
     }
 
-    // 5. .luca/ artifacts. Normalize to the contract-relative form first —
+    // 6. .luca/ artifacts. Normalize to the contract-relative form first —
     //    the contract (and AUDIT_PATH_PATTERN) is relative, but callers pass
     //    absolute file paths. `toLucaRelative` is robust to `cwd` not being
     //    the repo root (see its docstring).
     const rel = toLucaRelative(path, opts.cwd)
     if (rel.startsWith('.luca/') || rel === '.luca') {
+        // Sanctioned in-repo preview scratch: `.luca/tmp/previews/<name>`.
+        // Ephemeral, gitignored browser previews — not a pipeline artifact,
+        // so allowed in any pipelineStep (intercepted before the generic
+        // planning-general fallthrough below).
+        const preview = rel.match(/^\.luca\/tmp\/previews\/([^/]+)$/)
+        if (preview && TMP_PREVIEW_FILE_RE.test(preview[1]!)) {
+            return { class: 'ephemeral' }
+        }
         if (AUDIT_PATH_PATTERN.test(rel)) {
             return { class: 'planning-audit' }
         }
         return { class: 'planning-general' }
     }
 
-    // 6. Default: code
+    // 7. Default: code
     return { class: 'code' }
 }

--- a/packages/luca-core/src/luca-dir/helpers/is-valid-luca-path.test.ts
+++ b/packages/luca-core/src/luca-dir/helpers/is-valid-luca-path.test.ts
@@ -134,6 +134,30 @@ describe('isValidLucaPath — archive', () => {
     })
 })
 
+describe('isValidLucaPath — tmp scratch', () => {
+    test('accepts flat <kebab-name>.json handoff payloads', () => {
+        const r = isValidLucaPath('.luca/tmp/roadmap.json')
+        expect(r.valid).toBe(true)
+        if (r.valid) expect(r.kind).toBe('tmp.handoff')
+    })
+
+    test('accepts previews/<name>.<ext> browser previews', () => {
+        const r = isValidLucaPath('.luca/tmp/previews/auth-decision.html')
+        expect(r.valid).toBe(true)
+        if (r.valid) expect(r.kind).toBe('tmp.preview')
+    })
+
+    test('rejects a non-json flat tmp file', () => {
+        expect(isValidLucaPath('.luca/tmp/scratch.txt').valid).toBe(false)
+    })
+
+    test('rejects a preview nested deeper than one level', () => {
+        expect(
+            isValidLucaPath('.luca/tmp/previews/sub/x.html').valid
+        ).toBe(false)
+    })
+})
+
 describe('isValidLucaPath — top-level errors', () => {
     test('rejects paths not starting with .luca/', () => {
         expect(isValidLucaPath('src/foo.ts').valid).toBe(false)

--- a/packages/luca-core/src/luca-dir/helpers/is-valid-luca-path.ts
+++ b/packages/luca-core/src/luca-dir/helpers/is-valid-luca-path.ts
@@ -6,6 +6,7 @@ import {
     RUN_ID_RE,
     SEMVER_TAG_RE,
     TMP_FILE_RE,
+    TMP_PREVIEW_FILE_RE,
     WAVE_FILE_RE,
 } from '../constants.ts'
 import type { LucaArtifactKind } from '../schemas.ts'
@@ -82,18 +83,32 @@ export function isValidLucaPath(relPath: string): ValidationResult {
 }
 
 /**
- * Validate `.luca/tmp/<name>.json` — the sanctioned, repo-scoped scratch
- * area for ephemeral CLI-handoff payloads (LLM orchestrator → `luca` CLI
- * via `--file`). Flat (no subdirectories), `.json` only, kebab-case basename.
- * These files are gitignored and are NOT pipeline artifacts; they exist so
- * a large payload (e.g. `roadmap create`'s phases array) never has to ride
- * a shared global `/tmp` path that collides across repos.
+ * Validate `.luca/tmp/` — the sanctioned, repo-scoped scratch area. Two
+ * shapes are legal, both gitignored and NOT pipeline artifacts:
+ *
+ *   - `tmp/<kebab-name>.json` — ephemeral CLI-handoff payloads (LLM
+ *     orchestrator → `luca` CLI via `--file`). Flat, `.json` only. They
+ *     exist so a large payload (e.g. `roadmap create`'s phases array) never
+ *     has to ride a shared global `/tmp` path that collides across repos.
+ *   - `tmp/previews/<name>.<ext>` — ephemeral browser previews (e.g. a
+ *     decision-visualizer page). Any extension; one level deep.
  */
 function validateTmpSubtree(parts: string[]): ValidationResult {
+    // tmp/previews/<name>.<ext>
+    if (parts.length === 2 && parts[0] === 'previews') {
+        if (TMP_PREVIEW_FILE_RE.test(parts[1]!)) {
+            return { valid: true, kind: 'tmp.preview' }
+        }
+        return {
+            valid: false,
+            error: 'tmp/previews/ contains <kebab-name>.<ext> preview files only',
+        }
+    }
+    // tmp/<kebab-name>.json
     if (parts.length !== 1 || !TMP_FILE_RE.test(parts[0]!)) {
         return {
             valid: false,
-            error: 'tmp/ contains <kebab-name>.json handoff files only (flat, no subdirectories)',
+            error: 'tmp/ contains <kebab-name>.json handoff files or previews/<name>.<ext> only',
         }
     }
     return { valid: true, kind: 'tmp.handoff' }

--- a/packages/luca-core/src/luca-dir/schemas.ts
+++ b/packages/luca-core/src/luca-dir/schemas.ts
@@ -47,6 +47,9 @@ export const LucaArtifactKind = z.enum([
     // Ephemeral CLI-handoff scratch (.luca/tmp/<name>.json) — repo-scoped,
     // gitignored, not a pipeline artifact.
     'tmp.handoff',
+    // Ephemeral browser preview (.luca/tmp/previews/<name>) — repo-scoped,
+    // gitignored, not a pipeline artifact. Allowed in any pipelineStep.
+    'tmp.preview',
 ])
 export type LucaArtifactKind = z.infer<typeof LucaArtifactKind>
 


### PR DESCRIPTION
## Problem

The `decision-visualizer` skill (and any presentational skill that writes an out-of-band HTML preview) was blocked by the global stage-gate hook when the Luca pipeline was parked at a gated step:

```
PreToolUse:Write hook error: [luca hook stage-gate]: stage-gate BLOCK:
Write (category=code-write) is not allowed in phase=REVIEWING (pipelineStep=learn)
```

**Root cause:** `classifyWritePath` only understood two kinds of write — a `.luca/` artifact or project `code`. A temp HTML file fell through to `code` → `code-write`, which `REVIEWING`/`PLANNING`/`FINALIZING` disallow. Worse, the skill's own `$(mktemp -d)` path on macOS resolves under `/var/folders/…`, which the `/var` system-dir rule **hard-denied in every phase**.

## Fix

Introduce a first-class **`ephemeral`** write class for writes that touch neither the repo tree nor pipeline state. The phase/tool matrix is bypassed for this class, so it's allowed in any `pipelineStep`. Two sanctioned locations:

- **OS temp dirs** — universal `/tmp` · `/private/tmp`, plus the platform temp root supplied via `os.tmpdir()` / `$TMPDIR` (passed through a new `tmpdirs` option), so macOS `/var/folders/…/T` is recognised **before** the `/var` denial.
- **`.luca/tmp/previews/<name>.<ext>`** — a gitignored in-repo preview dir (new `tmp.preview` contract kind) so previews render mid-pipeline and persist for the session.

### Security floor preserved
- Legacy `/tmp/luca-*` collision denial is checked **first** → still denied.
- Non-temp `/var` (e.g. `/var/log`), `.git/`, `~/.claude/`, `~/.luca/`, system dirs → still denied.
- Only the structured `Write`/`Edit` tools get the bypass — **Bash mutations remain phase-gated**.

## Changes
- `luca-core`: `classify-write-path.ts` (new `ephemeral` class + OS-temp/preview detection + `tmpdirs` opt), `constants.ts` (`TMP_PREVIEW_FILE_RE`), `configs.ts` (contract doc), `is-valid-luca-path.ts` (`tmp/previews/` → `tmp.preview`), `schemas.ts` (new kind).
- `luca-cli`: `handle-stage-gate-hook.ts` wires `tmpdirs` and short-circuits `ephemeral` to allow.

## Verification
- `bunx --bun tsc --noEmit` → clean (pipeline gate).
- New tests (all green): classifier ephemeral/preview/regression cases; validator `tmp.preview` cases; **hook end-to-end repro at `learn` step** (allows OS-temp + `/var/folders` via `tmpdirs` + `.luca/tmp/previews/`, still blocks project HTML, still denies `/tmp/luca-*`).
- Suites: luca-dir 107 pass, stage-gate hook 33 pass.

## Notes
- Changeset: `patch` → cuts the next `13.0.0-alpha.*` (four packages bump in lockstep).
- The global `decision-visualizer` SKILL.md (lives in `~/.claude/skills/`, outside this repo) was also updated to write via the `Write` tool and prefer `.luca/tmp/previews/` in Luca repos — not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)