### PR TITLE
fix(stage-gate): classify viewer-open launchers as read-only

### DIFF
--- a/.changeset/fix-stage-gate-allows-viewer-open.md
+++ b/.changeset/fix-stage-gate-allows-viewer-open.md
@@ -1,0 +1,23 @@
+---
+"@alecsibilia/luca": patch
+---
+
+Stage-gate: classify desktop viewer-open launchers (`open`, `xdg-open`,
+`start`) as read-only so they're allowed in gated pipeline steps.
+
+Follow-up to the ephemeral-scratch fix. Writing a preview to
+`.luca/tmp/previews/<name>.html` now works mid-pipeline, but the natural
+next step — opening it in a browser — still failed:
+
+```
+The browser-open is blocked by the Luca stage-gate (we're parked at
+learn, which disallows shell side-effects)
+```
+
+`open <path>` hands a file (or URL) to the OS default handler for display;
+it mutates no files and no repo/pipeline state, so it belongs in the
+read-only command set alongside `cat`/`ls` — not the unknown-command →
+`bash-mutate` fallback that the matrix blocks in REVIEWING/FINALIZING.
+
+A skill can now render AND open its page without the `!` shell escape.
+Git-mutating and file-writing commands remain phase-gated.

--- a/packages/luca-cli/src/hook/helpers/classify-bash-command.test.ts
+++ b/packages/luca-cli/src/hook/helpers/classify-bash-command.test.ts
@@ -25,6 +25,11 @@ describe('classifyBashCommand — read-only', () => {
         'bunx --bun tsc --noEmit',
         'playwright-cli open http://localhost:3000/demo',
         'playwright-cli screenshot --filename=.playwright-cli/uat.png',
+        // Desktop viewer-open launchers — display a file, never mutate it.
+        'open .luca/tmp/previews/phase3-direction-1.html',
+        'open "/Users/alec/repo/.luca/tmp/previews/decision.html"',
+        'xdg-open /tmp/decision.html',
+        'start decision.html',
     ])('%s → bash-readonly', (cmd) => {
         const r = classifyBashCommand(cmd)
         expect(r.category).toBe('bash-readonly')

--- a/packages/luca-cli/src/hook/helpers/classify-bash-command.ts
+++ b/packages/luca-cli/src/hook/helpers/classify-bash-command.ts
@@ -65,6 +65,17 @@ const READONLY_COMMANDS = new Set([
     'paste',
     'fold',
     'join',
+    // Desktop "open with the default handler" launchers. These hand a path
+    // (or URL) to the OS to display in a viewer/browser — they do NOT mutate
+    // files or repo/pipeline state, so they are benign for the file-mutation
+    // policy this classifier enforces. Without them, a skill that renders a
+    // preview and opens it (e.g. decision-visualizer's
+    // `open .luca/tmp/previews/<name>.html`) fell through to the
+    // unknown-command → bash-mutate path and got blocked in gated phases
+    // (REVIEWING/learn), even though the HTML write itself is allowed.
+    'open', // macOS
+    'xdg-open', // Linux
+    'start', // Windows (cmd builtin)
     // NOTE: `playwright-cli` is NOT in this set — it has a dedicated
     // clause (step 4c in classifySubcommand) that extracts `--filename`
     // output paths and enforces the `.playwright-cli/` artifact dir.

--- a/packages/luca-cli/src/hook/helpers/handle-stage-gate-hook.test.ts
+++ b/packages/luca-cli/src/hook/helpers/handle-stage-gate-hook.test.ts
@@ -283,6 +283,19 @@ describe('handleStageGateHook — ephemeral scratch (gated step)', () => {
         expect(r.decision).toBe('allow')
     })
 
+    test('allows opening the rendered preview in a browser during learn', async () => {
+        // `open`/`xdg-open` launch a viewer — no file/repo mutation — so the
+        // skill can render AND open its page without the `!` shell escape.
+        for (const command of [
+            'open .luca/tmp/previews/phase3-direction-1.html',
+            'xdg-open /tmp/decision.html',
+        ]) {
+            const r = await handleStageGateHook({ stdin: bashStdin(command), cwd })
+            expect(r.exitCode).toBe(0)
+            expect(r.decision).toBe('allow')
+        }
+    })
+
     test('still blocks Write to a project HTML file during learn', async () => {
         const r = await handleStageGateHook({
             stdin: writeStdin('src/pages/decision.html'),


### PR DESCRIPTION
## Problem

Follow-up to #303 (ephemeral-scratch). Writing a preview to `.luca/tmp/previews/<name>.html` now works mid-pipeline, but the natural next step — opening it in a browser — was still blocked:

```
The browser-open is blocked by the Luca stage-gate (we're parked at learn,
which disallows shell side-effects)
```

**Root cause:** `open`/`xdg-open`/`start` weren't in `READONLY_COMMANDS`, so they hit the unknown-command → `bash-mutate` fallback, which `REVIEWING`/`FINALIZING` disallow.

## Fix

Classify the desktop "open with default handler" launchers as **read-only**. `open <path>` hands a file/URL to the OS for display — it mutates no files and no repo/pipeline state — so it belongs alongside `cat`/`ls`, not the mutate fallback.

A skill can now render **and** open its page without the `!` shell escape.

### Scope / safety
- Only the three viewer launchers move to read-only (`open`, `xdg-open`, `start`).
- Git-mutating commands, file-writing commands (`tee`, redirects), and `xargs`/`eval` stay exactly as gated/denied as before.

## Verification
- `bunx --bun tsc --noEmit` → clean.
- New tests (green): bash classifier `open`/`xdg-open`/`start` → `bash-readonly`; hook end-to-end `open .luca/tmp/previews/…` allowed at the `learn` step.
- Suites: bash classifier + stage-gate hook = 118 pass.

## Notes
- Changeset: `patch` → next `13.0.0-alpha.*` (four packages in lockstep).
- After merge + release, reinstall the global `luca` (or `bun run release:local`) for the deployed `luca hook stage-gate` to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)