### PR TITLE
fix(tools): statusline 1M context windows + /lu classify scope signals

### DIFF
--- a/.changeset/fix-lu-classify-scope-signals.md
+++ b/.changeset/fix-lu-classify-scope-signals.md
@@ -1,0 +1,7 @@
+---
+"@alecsibilia/luca": patch
+---
+
+/lu Triage: pass scope signals to `luca classify` and treat the heuristic as a floor.
+
+The Triage step called `luca classify --task ... --json` with no scope signals, starving the heuristic (estimatedFileCount=0, no domains/concerns) so it scored on description keywords alone and systematically under-rated work — deep single-file design/tuning tasks scored TRIVIAL. The orchestrator instructions now pass `--files/--domains/--concerns/--breaking` and frame the heuristic baseline as a floor, not a ceiling: take the higher of heuristic vs judgment, and always re-judge a TRIVIAL result. Instruction-wording change only; no heuristic code or keyword list changed.

--- a/.changeset/fix-statusline-1m-context-window.md
+++ b/.changeset/fix-statusline-1m-context-window.md
@@ -1,0 +1,9 @@
+---
+"@alecsibilia/luca": patch
+---
+
+Statusline: recognize native 1M context windows.
+
+The context-usage segment inferred the window size from a legacy `[1m]` model-id suffix and defaulted everything else to 200k, so current-generation models with native 1M windows (Fable/Mythos 5, Opus 4.6/4.7/4.8, Sonnet 4.6, Sonnet 5) rendered as `###/200k` and pegged the bar at 100% far too early.
+
+`contextLimit` now checks a known-1M model-id list alongside the `[1m]` suffix. Unrecognized ids (e.g. Haiku 4.5) still fall back to the conservative 200k so the bar over-warns rather than under-warns. Re-run `luca init` (or copy the rebuilt bundle) to refresh the installed `~/.claude/luca-statusline.ts`.

--- a/packages/luca-tools/src/artifacts/skills/lu/index.ts
+++ b/packages/luca-tools/src/artifacts/skills/lu/index.ts
@@ -70,7 +70,15 @@ Triage runs once, at the start of a run. It is inline here — there is no separ
 
 1. **Classify complexity.** Read the request. Pick one of \`TRIVIAL | SIMPLE | MODERATE | COMPLEX | CRITICAL\` based on file count, scope, and risk. There is no CLI command to persist complexity — record it in your reasoning and pass it to every subagent you spawn (pass it to any subagent whose behavior varies by complexity). If \`--complexity=<level>\` or \`--force-complex\` was passed, use that directly.
 
-   **Override telemetry.** Once the final complexity level is chosen, compare it against the deterministic heuristic baseline from \`luca classify --task "<request>" --json\` (the \`--task\` flag is REQUIRED — read its \`.complexity\` field). On a MISMATCH between the heuristic level and your final level, emit one override record:
+   **Heuristic baseline (floor, not ceiling).** Compute the deterministic baseline with \`luca classify\`, passing the scope signals you already extracted while reading the request — NOT just \`--task\`. A \`--task\`-only call starves the heuristic (it scores \`estimatedFileCount=0\`, no domains, no concerns) and collapses to description-keyword matching, which systematically under-scores work. Supply every signal you can estimate:
+   \`\`\`
+   luca classify --task "<request>" --files <estimated-file-count> --domains "<comma-list>" --concerns "<comma-list>" [--breaking] --json
+   \`\`\`
+   (\`--task\` is REQUIRED; \`--files\`/\`--domains\`/\`--concerns\`/\`--breaking\` are optional — pass each one you can estimate. Read the \`.complexity\` field.)
+
+   This baseline is a **FLOOR, never a ceiling.** Breadth signals (files, domains) cannot measure design/iteration depth — a deep single-file design, tuning, or balancing task is genuinely hard yet touches one file. Your own judgment is authoritative: take the HIGHER of the heuristic level and your read, and never demote below your judgment to match the heuristic. **In particular, never trust a \`TRIVIAL\` heuristic result on its face — re-judge it before accepting**, because a breadth-only score under-rates deep single-file work.
+
+   **Override telemetry.** On a MISMATCH between the heuristic level and your final level, emit one override record:
    \`\`\`
    luca telemetry emit --kind classifier.override --run-id <runId> --meta '{"classifier":"complexity","from":"<heuristic-level>","to":"<final-level>","source":"<taxonomy>"}'
    \`\`\`

--- a/packages/luca-tools/src/statusline/handler.ts
+++ b/packages/luca-tools/src/statusline/handler.ts
@@ -35,7 +35,9 @@
  * occupancy. Only the transcript tail (256 KiB) is read so the handler
  * stays cheap on long sessions (statusLine fires on every TUI update,
  * debounced to ~300ms). The window size is inferred from the model id:
- * a `[1m]` suffix means a 1M-token window, anything else 200k.
+ * current-generation models (Fable/Mythos 5, Opus 4.6+, Sonnet 4.6+)
+ * have native 1M windows, a `[1m]` suffix marks the 1M beta on older
+ * models, and anything unrecognized (e.g. Haiku) falls back to 200k.
  *
  * Failure philosophy: a statusline must never break the session. Every
  * data source is best-effort — on any parse/spawn/read error the segment
@@ -192,9 +194,26 @@ async function readContextTokens(
     return null
 }
 
+/**
+ * Model-id substrings with a native 1M-token context window. Everything
+ * in the current lineup except Haiku is 1M; unrecognized ids fall back
+ * to the conservative 200k so the bar over-warns rather than under-warns.
+ */
+const ONE_MILLION_MODEL_IDS = [
+    'fable',
+    'mythos',
+    'opus-4-6',
+    'opus-4-7',
+    'opus-4-8',
+    'sonnet-4-6',
+    'sonnet-5',
+]
+
 /** Context-window size inferred from the model id. */
 function contextLimit(modelId: string | undefined): number {
-    return modelId !== undefined && modelId.includes('[1m]')
+    if (modelId === undefined) return 200_000
+    if (modelId.includes('[1m]')) return 1_000_000
+    return ONE_MILLION_MODEL_IDS.some((id) => modelId.includes(id))
         ? 1_000_000
         : 200_000
 }


### PR DESCRIPTION
Two `luca-tools` fixes, each with its own patch changeset (`@alecsibilia/luca` fixed group).

## 1. Statusline: recognize native 1M context windows

### What

The statusline's context-usage segment now renders current-generation models against their native 1M-token window. Previously `contextLimit()` only granted 1M when the model id contained the legacy `[1m]` suffix, so Fable/Mythos 5, Opus 4.6/4.7/4.8, Sonnet 4.6, and Sonnet 5 all displayed `###/200k` and pegged the usage bar at 100% far too early.

### How

- Added a `ONE_MILLION_MODEL_IDS` substring list (`fable`, `mythos`, `opus-4-6/7/8`, `sonnet-4-6`, `sonnet-5`) checked in `contextLimit()` alongside the existing `[1m]` suffix check (`packages/luca-tools/src/statusline/handler.ts`).
- Unrecognized ids still fall back to 200k, so the bar over-warns rather than under-warns on unknown/future models.
- Installed statuslines pick up the fix on the next `luca init`.

### Test Plan

Manual verification — piped fake statusline payloads through the rebuilt bundle:

- `claude-fable-5` → `250k/1M` at 25%
- `claude-opus-4-8` → `250k/1M`
- `claude-sonnet-4-5[1m]` → `250k/1M` (suffix path still works)
- `claude-sonnet-4-5` → `250k/200k` (older Sonnet correctly stays 200k)
- `claude-haiku-4-5-20251001` → `250k/200k`

## 2. /lu Triage: pass scope signals to `luca classify` + heuristic as floor

### What

The /lu Triage step called `luca classify --task ... --json` with no scope signals, starving the heuristic (estimatedFileCount=0, no domains/concerns) so it scored on description keywords alone and systematically under-rated work — deep single-file design/tuning tasks scored TRIVIAL.

### How

The orchestrator instructions (`packages/luca-tools/src/artifacts/skills/lu/index.ts`) now pass `--files/--domains/--concerns/--breaking` and frame the heuristic baseline as a floor, not a ceiling: take the higher of heuristic vs judgment, and always re-judge a TRIVIAL result. Instruction-wording change only; no heuristic code or keyword list changed.

---

`bunx --bun tsc --noEmit` passes; `bun run build` bundles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)